### PR TITLE
fix: seeds should try to reconnect to another seed when they get disconnected from the whole network

### DIFF
--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -671,6 +671,14 @@ func (r *Reactor) crawlPeersRoutine() {
 		select {
 		case <-ticker.C:
 			r.attemptDisconnects()
+
+			// If we got disconnected from the whole network, we reconnect to seeds
+			out, in, dial := r.Switch.NumPeers()
+			if out+in+dial < 1 {
+				r.Logger.Info("All peers disconnected, dialing seeds")
+				r.dialSeeds()
+			}
+
 			r.crawlPeers(r.book.GetSelection())
 			r.cleanupCrawlPeerInfos()
 		case <-r.Quit():


### PR DESCRIPTION
## Issue being fixed or feature implemented

If the seed is disconnected from the network, it can get "orphaned" with 0 connections.
This can be reproduced when if you start e2e dashcore network on a fast machine.

## What was done?

Added logic that will dial seeds when the seed (or crawler) node is not connected nor dialing to any node.

## How Has This Been Tested?

Test e2e dashcore network locally before and after.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
