### PR TITLE
fix(docker): downgrade alpine to 3.15

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -1,5 +1,5 @@
 # stage 1 Generate Tenderdash Binary
-FROM golang:1.18-alpine AS builder
+FROM golang:1.18-alpine3.15 AS builder
 
 RUN apk update && \
     apk upgrade && \
@@ -15,7 +15,7 @@ RUN make build_abcidump
 
 
 # stage 2
-FROM alpine:3.9
+FROM alpine:3.15
 LABEL maintainer="developers@dash.org"
 
 # Tenderdash will be looking for the genesis file in /tenderdash/config/genesis.json


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented


Alpine 3.16 uses GCC 11, which is not compatible with our BLS library.

## What was done?

Use Alpine 3.15 to build docker image

## How Has This Been Tested?

Built image locally.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
