### PR TITLE
fix(release): release script tries to use non-existing file

### DIFF
--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -232,8 +232,8 @@ function createRelease() {
 
     gh release create \
         --draft \
-        --notes-file "${REPO_DIR}/build/CHANGELOG_CURRENT.md" \
         --title "v${NEW_PACKAGE_VERSION}" \
+        --generate-notes \
         $gh_args \
         "v${NEW_PACKAGE_VERSION}"
 }
@@ -242,6 +242,9 @@ function deleteRelease() {
     if [[ "$(gh release view --json isDraft --jq .isDraft "v${NEW_PACKAGE_VERSION}")" == "true" ]]; then
         gh release delete "v${NEW_PACKAGE_VERSION}"
     fi
+
+    git tag --delete "v${NEW_PACKAGE_VERSION}" || true
+    git push --delete origin "v${NEW_PACKAGE_VERSION}" || true
 }
 
 function getReleaseUrl() {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Release script tried to read non-existing Changelog file to include it on github release page.

## What was done?

Replaced with option to generate changelog automatically.
Also improved release cleanup code to remove tags.

## How Has This Been Tested?

During release ov v0.8.0-dev.5

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
