### PR TITLE
fix(e2e): invalid initial height in e2e vote extensions test

### DIFF
--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -141,7 +141,7 @@ func (app *Application) Info(_ context.Context, req *abci.RequestInfo) (*abci.Re
 	}, nil
 }
 
-// Info implements ABCI.
+// InitChain implements ABCI.
 func (app *Application) InitChain(_ context.Context, req *abci.RequestInitChain) (*abci.ResponseInitChain, error) {
 	app.mu.Lock()
 	defer app.mu.Unlock()
@@ -441,7 +441,11 @@ func (app *Application) ProcessProposal(_ context.Context, req *abci.RequestProc
 func (app *Application) ExtendVote(_ context.Context, req *abci.RequestExtendVote) (*abci.ResponseExtendVote, error) {
 	// We ignore any requests for vote extensions that don't match our expected
 	// next height.
-	if req.Height != int64(app.state.Height)+1 {
+	currentHeight := app.state.Height
+	if currentHeight == 0 {
+		currentHeight = app.state.initialHeight
+	}
+	if req.Height != int64(currentHeight)+1 {
 		app.logger.Error(
 			"got unexpected height in ExtendVote request",
 			"expectedHeight", app.state.Height+1,


### PR DESCRIPTION
## Issue being fixed or feature implemented

e2e dashcore test fails due to invalid handling of height 0

## What was done?

Fixed bug in e2e test app vote extensions handling.

## How Has This Been Tested?

e2e dashcore, rotate + github pipelines

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
