### PR TITLE
fix(state): don't increment proposer priority when processing InitChain response

### DIFF
--- a/internal/state/current_round_state.go
+++ b/internal/state/current_round_state.go
@@ -251,7 +251,12 @@ func (candidate *CurrentRoundState) populateValsetUpdates(ctx context.Context, u
 	if err != nil {
 		return fmt.Errorf("validator set updates: %w", err)
 	}
-	newValSet.IncrementProposerPriority(1)
+
+	if updateSource != initChain {
+		// we take validator sets as they arrive from initChain response
+		newValSet.IncrementProposerPriority(1)
+	}
+
 	candidate.NextValidators = newValSet
 
 	if updateSource != initChain && update != nil && len(update.ValidatorUpdates) > 0 {

--- a/test/e2e/tests/validator_test.go
+++ b/test/e2e/tests/validator_test.go
@@ -108,7 +108,10 @@ func TestValidator_Propose(t *testing.T) {
 		}
 
 		require.False(t, proposeCount == 0 && expectCount > 0,
-			"node did not propose any blocks (expected %v)", expectCount)
+			"node with proTxHash %s did not propose any blocks (expected %v)",
+			proTxHash.ShortString(),
+			expectCount,
+		)
 		if expectCount > 5 {
 			require.GreaterOrEqual(t, proposeCount, 3, "validator didn't propose even 3 blocks")
 		}
@@ -157,12 +160,12 @@ func newValidatorSchedule(testnet e2e.Testnet) *validatorSchedule {
 func (s *validatorSchedule) Increment(heights int64) error {
 	for i := int64(0); i < heights; i++ {
 		s.height++
-		if s.height > 2 {
-			// validator set updates are offset by 2, since they only take effect
-			// two blocks after they're returned.
-			if update, ok := s.updates[s.height-2]; ok {
-				if thresholdPublicKeyUpdate, ok := s.thresholdPublicKeyUpdates[s.height-2]; ok {
-					if quorumHashUpdate, ok := s.quorumHashUpdates[s.height-2]; ok {
+		if s.height > 1 {
+			// validator set updates are offset by 1, since they only take effect
+			// 1 block after they're returned.
+			if update, ok := s.updates[s.height-1]; ok {
+				if thresholdPublicKeyUpdate, ok := s.thresholdPublicKeyUpdates[s.height-1]; ok {
+					if quorumHashUpdate, ok := s.quorumHashUpdates[s.height-1]; ok {
 						if bytes.Equal(quorumHashUpdate, s.Set.QuorumHash) {
 							if err := s.Set.UpdateWithChangeSet(makeVals(update), thresholdPublicKeyUpdate, quorumHashUpdate); err != nil {
 								return err


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Priorities of validators retrieved from InitChain response are increased, causing incorrect node to be selected as proposer.

## What was done?

Priorities of validators from InitChain are no longer increased.

## How Has This Been Tested?

* unit tests
* e2e simple.yaml network test

## Breaking Changes

none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
