### PR TITLE
test(consensus): skip broken PBTS tests

### DIFF
--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -400,6 +400,9 @@ func subscribeToVoter(ctx context.Context, t *testing.T, cs *State, proTxHash []
 	return ch
 }
 
+// TODO: used only in pbts_test.go, remove nolint:unused once pbts tests are un-skipped
+//
+//nolint:unused
 func subscribeToVoterBuffered(ctx context.Context, t *testing.T, cs *State, proTxHash []byte) <-chan tmpubsub.Message {
 	t.Helper()
 	votesSub, err := cs.eventBus.SubscribeWithArgs(ctx, tmpubsub.SubscribeArgs{

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -1,3 +1,6 @@
+// TODO: remove nolint:unused once PBTS test is un-skipped
+//
+//nolint:unused
 package consensus
 
 import (


### PR DESCRIPTION
## Issue being fixed or feature implemented

Proposer-based timestamp (PBTS) implementation is broken in current version of Tenderdash, resulting in flaky tests. 


## What was done?

Marked PBTS tests as skipped, to ensure they are not executed. These tests should be re-enabled/fixed once we fix PBTS.



## How Has This Been Tested?

Github pipelines should not break randomly on PBTS tests.

## Breaking Changes

None

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
