### PR TITLE
build(github): save e2e failure logs as artifact

### DIFF
--- a/test/e2e/node/main.go
+++ b/test/e2e/node/main.go
@@ -58,9 +58,6 @@ func init() {
 
 // main is the binary entrypoint.
 func main() {
-	// FIXME: just to test e2e
-	time.AfterFunc(time.Second*30, func() { os.Exit(1) })
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Emitting e2e logs on failure takes forever. 

## What was done?

E2E logs are saved to a file and then uploaded as a github actions artifact.


## How Has This Been Tested?

Run the workflow that fails, example: https://github.com/dashpay/tenderdash/actions/runs/3515130343

## Breaking Changes
n/a

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
