### PR TITLE
refactor(consensus): optimize initialize priv-validator

### DIFF
--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -178,7 +178,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 	lazyNodeState := states[1]
 
 	lazyNodeState.decideProposal = func(ctx context.Context, height int64, round int32) {
-		require.NotNil(t, lazyNodeState.privValidator)
+		require.False(t, lazyNodeState.privValidator.IsZero())
 
 		var commit *types.Commit
 		switch {
@@ -194,7 +194,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			return
 		}
 
-		if lazyNodeState.privValidator == nil {
+		if lazyNodeState.privValidator.IsZero() {
 			// If this node is a validator & proposer in the current round, it will
 			// miss the opportunity to create a block.
 			lazyNodeState.logger.Error("enterPropose", "err", ErrPrivValidatorNotSet)

--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -194,13 +194,12 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			return
 		}
 
-		if lazyNodeState.privValidatorProTxHash == nil {
+		if lazyNodeState.privValidator == nil {
 			// If this node is a validator & proposer in the current round, it will
 			// miss the opportunity to create a block.
-			lazyNodeState.logger.Error("enterPropose", "err", errProTxHashIsNotSet)
+			lazyNodeState.logger.Error("enterPropose", "err", ErrPrivValidatorNotSet)
 			return
 		}
-		proposerProTxHash := lazyNodeState.privValidatorProTxHash
 
 		block, uncommittedState, err := lazyNodeState.blockExec.CreateProposalBlock(
 			ctx,
@@ -208,7 +207,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			round,
 			lazyNodeState.state,
 			commit,
-			proposerProTxHash,
+			lazyNodeState.privValidator.ProTxHash,
 			0,
 		)
 		require.NoError(t, err)

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -226,7 +226,7 @@ func sortVValidatorStubsByPower(ctx context.Context, t *testing.T, vss []*valida
 // Functions for transitioning the consensus state
 
 func startTestRound(ctx context.Context, cs *State, height int64, round int32) {
-	ctx = dash.ContextWithProTxHash(ctx, cs.privValidatorProTxHash)
+	ctx = dash.ContextWithProTxHash(ctx, cs.privValidator.ProTxHash)
 	cs.enterNewRound(ctx, height, round)
 	cs.startRoutines(ctx, 0)
 }

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -1274,7 +1274,7 @@ func (r *Reactor) handleVoteMessage(ctx context.Context, envelope *p2p.Envelope,
 		r.state.peerMsgQueue <- msgInfo{cMsg, envelope.From, tmtime.Now()}
 	case *tmcons.Vote:
 		r.state.mtx.RLock()
-		isValidator := r.state.Validators.HasProTxHash(r.state.privValidatorProTxHash)
+		isValidator := r.state.Validators.HasProTxHash(r.state.privValidator.ProTxHash)
 		height, valSize, lastCommitSize := r.state.Height, r.state.Validators.Size(), r.state.LastPrecommits.Size()
 		r.state.mtx.RUnlock()
 

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -54,7 +54,7 @@ type reactorTestSuite struct {
 func (rts *reactorTestSuite) switchToConsensus(ctx context.Context) {
 	for nodeID, reactor := range rts.reactors {
 		state := reactor.state.GetState()
-		sCtx := dash.ContextWithProTxHash(ctx, rts.states[nodeID].privValidatorProTxHash)
+		sCtx := dash.ContextWithProTxHash(ctx, rts.states[nodeID].privValidator.ProTxHash)
 		reactor.SwitchToConsensus(sCtx, state, false)
 	}
 }
@@ -78,7 +78,7 @@ func setup(
 
 	privProTxHashes := make([]crypto.ProTxHash, len(states))
 	for i, state := range states {
-		privProTxHashes[i] = state.privValidatorProTxHash
+		privProTxHashes[i] = state.privValidator.ProTxHash
 	}
 	rts := &reactorTestSuite{
 		network:       p2ptest.MakeNetwork(ctx, t, p2ptest.NetworkOptions{NumNodes: numNodes, ProTxHashes: privProTxHashes}),
@@ -115,8 +115,8 @@ func setup(
 
 	for i := 0; i < numNodes; i++ {
 		state := states[i]
-		sCtx := dash.ContextWithProTxHash(ctx, states[i].privValidatorProTxHash)
-		node := rts.network.NodeByProTxHash(state.privValidatorProTxHash)
+		sCtx := dash.ContextWithProTxHash(ctx, states[i].privValidator.ProTxHash)
+		node := rts.network.NodeByProTxHash(state.privValidator.ProTxHash)
 		require.NotNil(t, node)
 		nodeID := node.NodeID
 		reactor := NewReactor(

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -345,7 +345,7 @@ func findValByProTxHash(ctx context.Context, t *testing.T, validatorStubs []*val
 
 func findStateByProTxHash(t *testing.T, css []*State, proTxHash crypto.ProTxHash) *State {
 	for _, consensusState := range css {
-		if proTxHash.Equal(consensusState.privValidatorProTxHash) {
+		if consensusState.privValidator.IsProTxHashEqual(proTxHash) {
 			return consensusState
 		}
 	}
@@ -549,7 +549,7 @@ func assertProposerState(ctx context.Context, t *testing.T, csProposer *State, v
 	csProposerPubKey, err := csProposer.privValidator.GetPubKey(ctx, quorumHash)
 	require.NoError(t, err)
 
-	assert.True(t, csProposer.privValidatorProTxHash.Equal(vsProposerProTxHash), "proTxHash match")
+	assert.True(t, csProposer.privValidator.IsProTxHashEqual(vsProposerProTxHash), "proTxHash match")
 
 	assert.Equal(t, vsProposerPubKey.Bytes(), csProposerPubKey.Bytes(), "pubkey match")
 

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/tendermint/tendermint/config"
-	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/dash"
 	cstypes "github.com/tendermint/tendermint/internal/consensus/types"
 	"github.com/tendermint/tendermint/internal/eventbus"
@@ -30,24 +29,21 @@ import (
 	tmos "github.com/tendermint/tendermint/libs/os"
 	"github.com/tendermint/tendermint/libs/service"
 	tmtime "github.com/tendermint/tendermint/libs/time"
-	"github.com/tendermint/tendermint/privval"
-	tmgrpc "github.com/tendermint/tendermint/privval/grpc"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/types"
 )
 
 // Consensus sentinel errors
 var (
-	ErrInvalidProposalNotSet      = errors.New("error invalid proposal not set")
-	ErrInvalidProposalForCommit   = errors.New("error invalid proposal for commit")
-	ErrUnableToVerifyProposal     = errors.New("error unable to verify proposal")
-	ErrInvalidProposalSignature   = errors.New("error invalid proposal signature")
-	ErrInvalidProposalCoreHeight  = errors.New("error invalid proposal core height")
-	ErrInvalidProposalPOLRound    = errors.New("error invalid proposal POL round")
-	ErrAddingVote                 = errors.New("error adding vote")
-	ErrSignatureFoundInPastBlocks = errors.New("found signature from the same key")
+	ErrInvalidProposalNotSet     = errors.New("error invalid proposal not set")
+	ErrInvalidProposalForCommit  = errors.New("error invalid proposal for commit")
+	ErrUnableToVerifyProposal    = errors.New("error unable to verify proposal")
+	ErrInvalidProposalSignature  = errors.New("error invalid proposal signature")
+	ErrInvalidProposalCoreHeight = errors.New("error invalid proposal core height")
+	ErrInvalidProposalPOLRound   = errors.New("error invalid proposal POL round")
+	ErrAddingVote                = errors.New("error adding vote")
 
-	errProTxHashIsNotSet = errors.New("protxhash is not set. Look for \"Can't get private validator protxhash\" errors")
+	ErrPrivValidatorNotSet = errors.New("priv-validator is not set")
 )
 
 var msgQueueSize = 1000
@@ -121,9 +117,8 @@ type State struct {
 	logger log.Logger
 
 	// config details
-	config            *config.ConsensusConfig
-	privValidator     types.PrivValidator // for signing votes
-	privValidatorType types.PrivValidatorType
+	config        *config.ConsensusConfig
+	privValidator *privValidator
 
 	// store blocks and commits
 	blockStore sm.BlockStore
@@ -145,10 +140,6 @@ type State struct {
 	mtx sync.RWMutex
 	cstypes.RoundState
 	state sm.State // State until height-1.
-
-	// privValidator proTxHash, memoized for the duration of one block
-	// to avoid extra requests to HSM
-	privValidatorProTxHash crypto.ProTxHash
 
 	// state changes may be triggered by: msgs from peers,
 	// msgs from ourself, or by timeouts
@@ -359,37 +350,15 @@ func (cs *State) GetValidatorSet() (int64, *types.ValidatorSet) {
 func (cs *State) SetPrivValidator(ctx context.Context, priv types.PrivValidator) {
 	cs.mtx.Lock()
 	defer cs.mtx.Unlock()
-
 	if priv == nil {
 		cs.logger.Error("attempting to set private validator to nil")
+		return
 	}
-
-	cs.privValidator = priv
-
-	if priv != nil {
-		switch t := priv.(type) {
-		case *privval.RetrySignerClient:
-			cs.privValidatorType = types.RetrySignerClient
-		case *privval.FilePV:
-			cs.privValidatorType = types.FileSignerClient
-		case *privval.SignerClient:
-			cs.privValidatorType = types.SignerSocketClient
-		case *tmgrpc.SignerClient:
-			cs.privValidatorType = types.SignerGRPCClient
-		case *types.MockPV:
-			cs.privValidatorType = types.MockSignerClient
-		case *types.ErroringMockPV:
-			cs.privValidatorType = types.ErrorMockSignerClient
-		case *privval.DashCoreSignerClient:
-			cs.privValidatorType = types.DashCoreRPCClient
-		default:
-			cs.logger.Error("unsupported priv validator type", "err",
-				fmt.Errorf("error privValidatorType %s", t))
-		}
-	}
-
-	if err := cs.updatePrivValidatorProTxHash(ctx); err != nil {
-		cs.logger.Error("failed to get private validator protxhash", "err", err)
+	cs.privValidator = &privValidator{PrivValidator: priv}
+	err := cs.privValidator.init(ctx)
+	if err != nil {
+		cs.logger.Error("failed to initialize private validator", "err", err)
+		return
 	}
 }
 
@@ -1397,13 +1366,7 @@ func (cs *State) enterPropose(ctx context.Context, height int64, round int32) {
 		return
 	}
 
-	if cs.privValidatorProTxHash == nil {
-		// If this node is a validator & proposer in the current round, it will
-		// miss the opportunity to create a block.
-		logger.Error(fmt.Sprintf("enterPropose: %v", errProTxHashIsNotSet))
-		return
-	}
-	proTxHash := cs.privValidatorProTxHash
+	proTxHash := cs.privValidator.ProTxHash
 
 	// if not a validator, we're done
 	if !cs.Validators.HasProTxHash(proTxHash) {
@@ -1429,8 +1392,7 @@ func (cs *State) enterPropose(ctx context.Context, height int64, round int32) {
 }
 
 func (cs *State) isProposer() bool {
-	proTxHash := cs.privValidatorProTxHash
-	return proTxHash != nil && bytes.Equal(cs.Validators.GetProposer().ProTxHash.Bytes(), proTxHash.Bytes())
+	return cs.privValidator.IsProTxHashEqual(cs.Validators.GetProposer().ProTxHash)
 }
 
 // checkValidBlock returns true if cs.ValidBlock is set and still valid (not expired)
@@ -1608,13 +1570,7 @@ func (cs *State) createProposalBlock(ctx context.Context, round int32) (*types.B
 		return nil, nil
 	}
 
-	if cs.privValidatorProTxHash == nil {
-		// If this node is a validator & proposer in the current round, it will
-		// miss the opportunity to create a block.
-		cs.logger.Error("propose step; empty priv validator pro tx hash", "err", errProTxHashIsNotSet)
-		return nil, nil
-	}
-	proposerProTxHash := cs.privValidatorProTxHash
+	proposerProTxHash := cs.privValidator.ProTxHash
 
 	ret, uncommittedState, err := cs.blockExec.CreateProposalBlock(ctx, cs.Height, round, cs.state, commit, proposerProTxHash, cs.proposedAppVersion)
 	if err != nil {
@@ -2423,11 +2379,6 @@ func (cs *State) applyCommit(ctx context.Context, commit *types.Commit, logger l
 	// NewHeightStep!
 	cs.updateToState(stateCopy, commit)
 
-	// Private validator might have changed it's key pair => refetch pubkey.
-	if err := cs.updatePrivValidatorProTxHash(ctx); err != nil {
-		logger.Error("failed to get private validator pubkey", "err", err)
-	}
-
 	// cs.StartTime is already set.
 	// Schedule Round0 to start soon.
 	cs.scheduleRound0(&cs.RoundState)
@@ -2446,18 +2397,6 @@ func (cs *State) RecordMetrics(height int64, block *types.Block) {
 		missingValidators      int
 		missingValidatorsPower int64
 	)
-	// height=0 -> MissingValidators and MissingValidatorsPower are both 0.
-	// Remember that the first LastPrecommits is intentionally empty, so it's not
-	// fair to increment missing validators number.
-	if height > cs.state.InitialHeight {
-
-		if cs.privValidator != nil {
-			if cs.privValidatorProTxHash == nil {
-				// Metrics won't be updated, but it's not critical.
-				cs.logger.Error(fmt.Sprintf("recordMetrics: %v", errProTxHashIsNotSet))
-			}
-		}
-	}
 	cs.metrics.MissingValidators.Set(float64(missingValidators))
 	cs.metrics.MissingValidatorsPower.Set(float64(missingValidatorsPower))
 
@@ -2762,11 +2701,11 @@ func (cs *State) tryAddVote(ctx context.Context, vote *types.Vote, peerID types.
 		// But if it's a conflicting sig, add it to the cs.evpool.
 		// If it's otherwise invalid, punish peer.
 		if voteErr, ok := err.(*types.ErrVoteConflictingVotes); ok {
-			if cs.privValidatorProTxHash == nil {
-				return false, errProTxHashIsNotSet
+			if cs.privValidator == nil {
+				return false, ErrPrivValidatorNotSet
 			}
 
-			if bytes.Equal(vote.ValidatorProTxHash, cs.privValidatorProTxHash) {
+			if cs.privValidator.IsProTxHashEqual(vote.ValidatorProTxHash) {
 				cs.logger.Error(
 					"found conflicting vote from ourselves; did you unsafe_reset a validator?",
 					"height", vote.Height,
@@ -2865,7 +2804,7 @@ func (cs *State) addVote(
 	// Verify VoteExtension if precommit and not nil
 	// https://github.com/tendermint/tendermint/issues/8487
 	if vote.Type == tmproto.PrecommitType && !vote.BlockID.IsNil() &&
-		!bytes.Equal(vote.ValidatorProTxHash, cs.privValidatorProTxHash) { // Skip the VerifyVoteExtension call if the vote was issued by this validator.
+		!cs.privValidator.IsProTxHashEqual(vote.ValidatorProTxHash) { // Skip the VerifyVoteExtension call if the vote was issued by this validator.
 
 		// The core fields of the vote message were already validated in the
 		// consensus reactor when the vote was received.
@@ -3031,10 +2970,10 @@ func (cs *State) signVote(
 		return nil, err
 	}
 
-	if cs.privValidatorProTxHash == nil {
-		return nil, errProTxHashIsNotSet
+	if cs.privValidator == nil {
+		return nil, ErrPrivValidatorNotSet
 	}
-	proTxHash := cs.privValidatorProTxHash
+	proTxHash := cs.privValidator.ProTxHash
 	valIdx, _ := cs.Validators.GetByProTxHash(proTxHash)
 
 	// Since the block has already been validated the block.lastAppHash must be the state.AppHash
@@ -3085,17 +3024,12 @@ func (cs *State) signAddVote(
 	blockID types.BlockID,
 ) *types.Vote {
 	if cs.privValidator == nil { // the node does not have a key
-		return nil
-	}
-
-	if cs.privValidatorProTxHash == nil {
-		// Vote won't be signed, but it's not critical.
-		cs.logger.Error("signAddVote", "err", errProTxHashIsNotSet)
+		cs.logger.Error("signAddVote", "err", ErrPrivValidatorNotSet)
 		return nil
 	}
 
 	// If the node not in the validator set, do nothing.
-	if !cs.Validators.HasProTxHash(cs.privValidatorProTxHash) {
+	if !cs.Validators.HasProTxHash(cs.privValidator.ProTxHash) {
 		cs.logger.Debug("do nothing, node is not a part of validator set")
 		return nil
 	}
@@ -3115,33 +3049,6 @@ func (cs *State) signAddVote(
 		"quorum_hash", cs.Validators.QuorumHash,
 		"took", time.Since(start).String())
 	return vote
-}
-
-// updatePrivValidatorPubKey get's the private validator public key and
-// memoizes it. This func returns an error if the private validator is not
-// responding or responds with an error.
-func (cs *State) updatePrivValidatorProTxHash(ctx context.Context) error {
-	if cs.privValidator == nil {
-		return nil
-	}
-
-	timeout := cs.voteTimeout(cs.Round)
-
-	// no GetPubKey retry beyond the proposal/voting in RetrySignerClient
-	if cs.Step >= cstypes.RoundStepPrecommit && cs.privValidatorType == types.RetrySignerClient {
-		timeout = 0
-	}
-
-	// set context timeout depending on the configuration and the State step,
-	// this helps in avoiding blocking of the remote signer connection.
-	ctxto, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	proTxHash, err := cs.privValidator.GetProTxHash(ctxto)
-	if err != nil {
-		return err
-	}
-	cs.privValidatorProTxHash = proTxHash
-	return nil
 }
 
 //---------------------------------------------------------
@@ -3267,4 +3174,19 @@ func proposerWaitTime(lt tmtime.Source, bt time.Time) time.Duration {
 		return bt.Sub(t)
 	}
 	return 0
+}
+
+type privValidator struct {
+	types.PrivValidator
+	ProTxHash types.ProTxHash
+}
+
+func (pv *privValidator) IsProTxHashEqual(proTxHash types.ProTxHash) bool {
+	return pv.ProTxHash.Equal(proTxHash)
+}
+
+func (pv *privValidator) init(ctx context.Context) error {
+	var err error
+	pv.ProTxHash, err = pv.GetProTxHash(ctx)
+	return err
 }

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -651,7 +651,7 @@ func TestStateLock_NoPOL(t *testing.T) {
 	cs2, _ := makeState(ctx, t, makeStateArgs{config: config, validators: 2})
 	// Since the quorum hash is also part of the sign ID we must make sure it's the same
 	cs2.state.Validators = cs1.state.Validators.Copy()
-	cs2.privValidator = &privValidator{PrivValidator: vs2}
+	cs2.privValidator = privValidator{PrivValidator: vs2}
 	cs2.privValidator.ProTxHash, err = vs2.PrivValidator.GetProTxHash(ctx)
 	require.NoError(t, err)
 

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -651,8 +651,8 @@ func TestStateLock_NoPOL(t *testing.T) {
 	cs2, _ := makeState(ctx, t, makeStateArgs{config: config, validators: 2})
 	// Since the quorum hash is also part of the sign ID we must make sure it's the same
 	cs2.state.Validators = cs1.state.Validators.Copy()
-	cs2.privValidator = vs2
-	cs2.privValidatorProTxHash, err = vs2.PrivValidator.GetProTxHash(ctx)
+	cs2.privValidator = &privValidator{PrivValidator: vs2}
+	cs2.privValidator.ProTxHash, err = vs2.PrivValidator.GetProTxHash(ctx)
 	require.NoError(t, err)
 
 	// before we time out into new round, set next proposal block


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some of the logic corresponding to the private-validator in `consensus.State` is redundant and cannot be used

## What was done?
<!--- Describe your changes in detail -->
This PR includes some changes of related to usage of private-validator in consensus.State.
1. Gather private-validator and its pro-tx-hash in one structure
2. Remove the field private-validator-type as a redundant
3. Remove redundant `updatePrivValidatorProTxHash` method, because pro-tx-hash can't be changed
4. Simplify `State.SetPrivValidator` method

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and E2E tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
