### PR TITLE
fix(consensus): commits received during state sync are lost

### DIFF
--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -692,7 +692,7 @@ func (r *Reactor) logResult(err error, logger log.Logger, message string, keyval
 		logger.Debug(message+" error", append(keyvals, "error", err))
 		return false
 	}
-	logger.Debug(message+"success", keyvals...)
+	logger.Debug(message+" success", keyvals...)
 	return true
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

When a node is in state sync, it receives and ignores various messages.
One of these messages can be a commit.

Unfortunately, the sender marks this commit as delivered as soon as it sends it, and never retransmits it.
So, the commit gets lost, causing the consensus to hang.

## What was done?

We delay start of message consumption goroutines until we finish state sync.


## How Has This Been Tested?

Using e2e tests


## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
