### PR TITLE
chore(types)!: rename genesis.json quorum fields

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -671,8 +671,8 @@ const testGenesisFmt = `{
       "pro_tx_hash": "51BF39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C45F"
     }
   ],
-  "quorum_hash": "28405D978AE15B97876411212E3ABD66515A285D901ACE06758DC1012030DA07",
-  "threshold_public_key": {
+  "validator_quorum_hash": "28405D978AE15B97876411212E3ABD66515A285D901ACE06758DC1012030DA07",
+  "validator_quorum_threshold_public_key": {
     "type": "tendermint/PubKeyBLS12381",
 	"value": "F5BjXeh0DppqaxX7a3LzoWr6CXPZcZeba6VHYdbiUCxQ23b00mFD8FRZpCz9Ug1E"
   },

--- a/docs/tendermint-core/using-tendermint.md
+++ b/docs/tendermint-core/using-tendermint.md
@@ -120,8 +120,8 @@ definition](https://github.com/tenderdash/tenderdash/blob/master/types/genesis.g
       "pro_tx_hash": "4F01160F58390DA57FE7FE1CCE4DDE452A448E90F4B560C0D788DCEEAD5B5E69"
     }
   ],
-  "quorum_hash": "444F39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C433",
-  "threshold_public_key": {
+  "validator_quorum_hash": "444F39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C433",
+  "validator_quorum_threshold_public_key": {
     "type": "tendermint/PubKeyBLS12381",
     "value": "F5BjXeh0DppqaxX7a3LzoWr6CXPZcZeba6VHYdbiUCxQ23b00mFD8FRZpCz9Ug1E"
   },

--- a/types/genesis.go
+++ b/types/genesis.go
@@ -80,9 +80,9 @@ type GenesisDoc struct {
 	// dash fields
 	InitialCoreChainLockedHeight uint32                 `json:"initial_core_chain_locked_height"`
 	InitialProposalCoreChainLock *tmproto.CoreChainLock `json:"initial_proposal_core_chain_lock"`
-	ThresholdPublicKey           crypto.PubKey          `json:"threshold_public_key"`
-	QuorumType                   btcjson.LLMQType       `json:"quorum_type"`
-	QuorumHash                   crypto.QuorumHash      `json:"quorum_hash"`
+	ThresholdPublicKey           crypto.PubKey          `json:"validator_quorum_threshold_public_key"`
+	QuorumType                   btcjson.LLMQType       `json:"validator_quorum_type"`
+	QuorumHash                   crypto.QuorumHash      `json:"validator_quorum_hash"`
 }
 
 type genesisDocJSON struct {
@@ -97,9 +97,15 @@ type genesisDocJSON struct {
 	// dash fields
 	InitialCoreChainLockedHeight uint32                 `json:"initial_core_chain_locked_height,omitempty"`
 	InitialProposalCoreChainLock *tmproto.CoreChainLock `json:"initial_proposal_core_chain_lock,omitempty"`
-	ThresholdPublicKey           json.RawMessage        `json:"threshold_public_key,omitempty"`
-	QuorumType                   btcjson.LLMQType       `json:"quorum_type,omitempty"`
-	QuorumHash                   crypto.QuorumHash      `json:"quorum_hash,omitempty"`
+	ThresholdPublicKey           json.RawMessage        `json:"validator_quorum_threshold_public_key,omitempty"`
+	QuorumType                   btcjson.LLMQType       `json:"validator_quorum_type,omitempty"`
+	QuorumHash                   crypto.QuorumHash      `json:"validator_quorum_hash,omitempty"`
+
+	// Deprecated fields, to be removed
+
+	DeprecatedThresholdPublicKey json.RawMessage   `json:"threshold_public_key,omitempty"`
+	DeprecatedQuorumType         btcjson.LLMQType  `json:"quorum_type,omitempty"`
+	DeprecatedQuorumHash         crypto.QuorumHash `json:"quorum_hash,omitempty"`
 }
 
 func (genDoc GenesisDoc) MarshalJSON() ([]byte, error) {
@@ -132,6 +138,17 @@ func (genDoc *GenesisDoc) UnmarshalJSON(data []byte) error {
 	if err := jsontypes.Unmarshal(g.ThresholdPublicKey, &genDoc.ThresholdPublicKey); err != nil {
 		return err
 	}
+
+	if len(g.DeprecatedQuorumHash) != 0 {
+		return fmt.Errorf("genesis.json: replace quorum_hash with validator_quorum_hash")
+	}
+	if g.DeprecatedQuorumType != 0 {
+		return fmt.Errorf("genesis.json: replace quorum_type with validator_quorum_type")
+	}
+	if len(g.DeprecatedThresholdPublicKey) != 0 {
+		return fmt.Errorf("genesis.json: replace threshold_public_key with validator_quorum_threshold_public_key")
+	}
+
 	genDoc.GenesisTime = g.GenesisTime
 	genDoc.ChainID = g.ChainID
 	genDoc.InitialHeight = g.InitialHeight

--- a/types/genesis_test.go
+++ b/types/genesis_test.go
@@ -44,7 +44,7 @@ func TestGenesisBad(t *testing.T) {
 		},
 		{ // missing pub_key type
 			[]byte(`{
-			"threshold_public_key": {
+			"validator_quorum_threshold_public_key": {
 				"type": "tendermint/PubKeyBLS12381",
 				"value": "F5BjXeh0DppqaxX7a3LzoWr6CXPZcZeba6VHYdbiUCxQ23b00mFD8FRZpCz9Ug1E"
 			},
@@ -67,7 +67,7 @@ func TestGenesisBad(t *testing.T) {
 			), "the threshold public key must be set if there are validators"},
 		{ // missing threshold_public_key key type
 			[]byte(`{
-				"threshold_public_key": {"value": "F5BjXeh0DppqaxX7a3LzoWr6CXPZcZeba6VHYdbiUCxQ23b00mFD8FRZpCz9Ug1E"},
+				"validator_quorum_threshold_public_key": {"value": "F5BjXeh0DppqaxX7a3LzoWr6CXPZcZeba6VHYdbiUCxQ23b00mFD8FRZpCz9Ug1E"},
 				"validators":[
 					{"pub_key":{"value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="},
 					"power":10,
@@ -97,8 +97,8 @@ func TestGenesisBad(t *testing.T) {
 		{ // missing pro_tx_hash
 			[]byte(`{
 				"chain_id":"mychain",
-				"threshold_public_key":{"type": "tendermint/PubKeyBLS12381","value":"F5BjXeh0DppqaxX7a3LzoWr6CXPZcZeba6VHYdbiUCxQ23b00mFD8FRZpCz9Ug1E"},
-				"quorum_hash":"43FF39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C4CC",
+				"validator_quorum_threshold_public_key":{"type": "tendermint/PubKeyBLS12381","value":"F5BjXeh0DppqaxX7a3LzoWr6CXPZcZeba6VHYdbiUCxQ23b00mFD8FRZpCz9Ug1E"},
+				"validator_quorum_hash":"43FF39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C4CC",
 				"validators":[{
 					"address": "A",
 					"pub_key":{"type":"tendermint/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="},
@@ -119,8 +119,10 @@ func TestGenesisBad(t *testing.T) {
 				"name":"",
 				"pro_tx_hash":"51BF39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C45F"
 			}],
-			"threshold_public_key":{"type": "tendermint/PubKeyBLS12381","value":"F5BjXeh0DppqaxX7a3LzoWr6CXPZcZeba6VHYdbiUCxQ23b00mFD8FRZpCz9Ug1E"}
-			}`), "the quorum hash must be base64-encoded and 32 bytes long"},
+			"validator_quorum_threshold_public_key":{
+				"type": "tendermint/PubKeyBLS12381",
+				"value":"F5BjXeh0DppqaxX7a3LzoWr6CXPZcZeba6VHYdbiUCxQ23b00mFD8FRZpCz9Ug1E"
+			}}`), "the quorum hash must be base64-encoded and 32 bytes long"},
 		{ // quorum_hash too short
 			[]byte(`{
 				"genesis_time": "0001-01-01T00:00:00Z",
@@ -134,8 +136,8 @@ func TestGenesisBad(t *testing.T) {
 					"name":"",
 					"pro_tx_hash":"51BF39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C45F"
 				}],
-				"threshold_public_key":{"type": "tendermint/PubKeyBLS12381","value":"F5BjXeh0DppqaxX7a3LzoWr6CXPZcZeba6VHYdbiUCxQ23b00mFD8FRZpCz9Ug1E"},
-				"quorum_hash": "MDEyMzQ1Njc4OTAxMjM0NTY3OA=="
+				"validator_quorum_threshold_public_key":{"type": "tendermint/PubKeyBLS12381","value":"F5BjXeh0DppqaxX7a3LzoWr6CXPZcZeba6VHYdbiUCxQ23b00mFD8FRZpCz9Ug1E"},
+				"validator_quorum_hash": "MDEyMzQ1Njc4OTAxMjM0NTY3OA=="
 				}`), "the quorum hash must be base64-encoded and 32 bytes long, is 19 byte"},
 		{ // validator power is not an int
 			jsonBlob: []byte(`{
@@ -147,8 +149,8 @@ func TestGenesisBad(t *testing.T) {
 				"pro_tx_hash":"51BF39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C45F",
 				"name":""
 			}],
-			"quorum_hash":"43FF39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C4CC",
-			"threshold_public_key": {
+			"validator_quorum_hash":"43FF39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C4CC",
+			"validator_quorum_threshold_public_key": {
 				"type": "tendermint/PubKeyBLS12381",
 				"value": "F5BjXeh0DppqaxX7a3LzoWr6CXPZcZeba6VHYdbiUCxQ23b00mFD8FRZpCz9Ug1E"
 			}}`,
@@ -203,11 +205,11 @@ func TestBasicGenesisDoc(t *testing.T) {
 				"name":"",
 				"pro_tx_hash":"51BF39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C45F"
 			}],
-			"threshold_public_key": {
+			"validator_quorum_threshold_public_key": {
 				"type": "tendermint/PubKeyBLS12381",
 				"value": "F5BjXeh0DppqaxX7a3LzoWr6CXPZcZeba6VHYdbiUCxQ23b00mFD8FRZpCz9Ug1E"
 			},
-			"quorum_hash":"43FF39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C4CC",
+			"validator_quorum_hash":"43FF39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C4CC",
 			"app_hash":"",
 			"app_state":{"account_owner": "Bob"},
 			"consensus_params": {


### PR DESCRIPTION
## Issue being fixed or feature implemented

To improve genesis JSON file and make it easier to understand, we rename some fields in genesis.json:

1. threshold_public_key -> validator_quorum_threshold_public_key
2. quorum_type -> validator_quorum_type
3. quorum_hash -> validator_quorum_hash

## What was done?

1. Renamed fields 
2. Old field names are marked as "deprecated" and error is returned when one of them is present.

## How Has This Been Tested?

Github pipelines

## Breaking Changes

Fields renamed:

* threshold_public_key -> validator_quorum_threshold_public_key
* quorum_type -> validator_quorum_type
* quorum_hash -> validator_quorum_hash

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
