### PR TITLE
fix(p2p): decrease log verbosity by logging send/recv logs on trace level

### DIFF
--- a/internal/p2p/conn/connection.go
+++ b/internal/p2p/conn/connection.go
@@ -279,7 +279,7 @@ func (c *MConnection) String() string {
 }
 
 func (c *MConnection) flush() {
-	c.logger.Debug("Flush", "conn", c)
+	c.logger.Trace("Flush", "conn", c)
 	err := c.bufConnWriter.Flush()
 	if err != nil {
 		c.logger.Debug("MConnection flush failed", "err", err)
@@ -310,7 +310,7 @@ func (c *MConnection) Send(chID ChannelID, msgBytes []byte) bool {
 		return false
 	}
 
-	c.logger.Debug("Send", "channel", chID, "conn", c, "msgBytes", msgBytes)
+	c.logger.Trace("Send", "channel", chID, "conn", c, "msgBytes", msgBytes)
 
 	// Send message to channel.
 	channel, ok := c.channelsIdx[chID]
@@ -563,7 +563,7 @@ FOR_LOOP:
 				break FOR_LOOP
 			}
 			if msgBytes != nil {
-				c.logger.Debug("Received bytes", "chID", channelID, "msgBytes", msgBytes)
+				c.logger.Trace("Received bytes", "chID", channelID, "msgBytes", msgBytes)
 				// NOTE: This means the reactor.Receive runs in the same thread as the p2p recv routine
 				c.onReceive(ctx, channelID, msgBytes)
 			}
@@ -733,7 +733,7 @@ func (ch *channel) writePacketMsgTo(w io.Writer) (n int, err error) {
 // complete, which is owned by the caller and will not be modified.
 // Not goroutine-safe
 func (ch *channel) recvPacketMsg(packet tmp2p.PacketMsg) ([]byte, error) {
-	ch.logger.Debug("Read PacketMsg", "conn", ch.conn, "packet", packet)
+	ch.logger.Trace("Read PacketMsg", "conn", ch.conn, "packet", packet)
 	var recvCap, recvReceived = ch.desc.RecvMessageCapacity, len(ch.recving) + len(packet.Data)
 	if recvCap < recvReceived {
 		return nil, fmt.Errorf("received message exceeds available capacity: %v < %v", recvCap, recvReceived)

--- a/libs/log/default.go
+++ b/libs/log/default.go
@@ -74,6 +74,10 @@ func (l defaultLogger) Debug(msg string, keyVals ...interface{}) {
 	l.Logger.Debug().Fields(getLogFields(keyVals...)).Msg(msg)
 }
 
+func (l defaultLogger) Trace(msg string, keyVals ...interface{}) {
+	l.Logger.Trace().Fields(getLogFields(keyVals...)).Msg(msg)
+}
+
 func (l defaultLogger) With(keyVals ...interface{}) Logger {
 	return &defaultLogger{Logger: l.Logger.With().Fields(getLogFields(keyVals...)).Logger()}
 }

--- a/libs/log/logger.go
+++ b/libs/log/logger.go
@@ -23,6 +23,7 @@ const (
 	LogFormatJSON string = "json"
 
 	// Supported loging levels
+	LogLevelTrace = "trace"
 	LogLevelDebug = "debug"
 	LogLevelInfo  = "info"
 	LogLevelWarn  = "warn"
@@ -31,6 +32,7 @@ const (
 
 // Logger defines a generic logging interface compatible with Tendermint.
 type Logger interface {
+	Trace(msg string, keyVals ...interface{})
 	Debug(msg string, keyVals ...interface{})
 	Info(msg string, keyVals ...interface{})
 	Error(msg string, keyVals ...interface{})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

In debug logs, all exchanged messages are logged, causing way too much logs to be generated.

This is hard to use during debugging, and hard to manage on a daily basis.

## What was done?
<!--- Describe your changes in detail -->

Moved these logs from level.Debug to level.Trace.

## How Has This Been Tested?

* Github workflow passed.
* Run e2e test locally with `log_level = "trace"` and  `log_level = "debug"` and compared the results

Result: 679 of 859 log lines got "TRACE" level, what means  DEBUG level logs will take ~ 20% of previous space.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
