### PR TITLE
refactor: replace peerID on proTxHash in peer-catchup-rounds map

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2863,7 +2863,7 @@ func (cs *State) addVote(
 	)
 
 	height := cs.Height
-	added, err = cs.Votes.AddVote(vote, peerID)
+	added, err = cs.Votes.AddVote(vote)
 	if !added {
 		if err != nil {
 			cs.logger.Error(

--- a/internal/consensus/types/height_vote_set_test.go
+++ b/internal/consensus/types/height_vote_set_test.go
@@ -31,31 +31,25 @@ func TestPeerCatchupRounds(t *testing.T) {
 	hvs := NewHeightVoteSet(chainID, 1, valSet)
 
 	vote999_0 := makeVoteHR(ctx, t, 1, 0, 999, privVals, chainID, valSet.QuorumType, valSet.QuorumHash, stateID)
-	added, err := hvs.AddVote(vote999_0, "peer1")
+	added, err := hvs.AddVote(vote999_0)
 	if !added || err != nil {
 		t.Error("Expected to successfully add vote from peer", added, err)
 	}
 
 	vote1000_0 := makeVoteHR(ctx, t, 1, 0, 1000, privVals, chainID, valSet.QuorumType, valSet.QuorumHash, stateID)
-	added, err = hvs.AddVote(vote1000_0, "peer1")
+	added, err = hvs.AddVote(vote1000_0)
 	if !added || err != nil {
 		t.Error("Expected to successfully add vote from peer", added, err)
 	}
 
 	vote1001_0 := makeVoteHR(ctx, t, 1, 0, 1001, privVals, chainID, valSet.QuorumType, valSet.QuorumHash, stateID)
-	added, err = hvs.AddVote(vote1001_0, "peer1")
+	added, err = hvs.AddVote(vote1001_0)
 	if err != ErrGotVoteFromUnwantedRound {
 		t.Errorf("expected GotVoteFromUnwantedRoundError, but got %v", err)
 	}
 	if added {
 		t.Error("Expected to *not* add vote from peer, too many catchup rounds.")
 	}
-
-	added, err = hvs.AddVote(vote1001_0, "peer2")
-	if !added || err != nil {
-		t.Error("Expected to successfully add vote from another peer")
-	}
-
 }
 
 func makeVoteHR(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`peerID` is used as a key in `HeightVoteSet.peerCatchupRounds` map
Since, vote has `validatorProTxHash` field, then we can use this value instead of peerID
This improvement allows us to remove second argument (peerID) from `HeightVoteSet.AddVote` method, and rely only on data in the vote

## What was done?
<!--- Describe your changes in detail -->
1. Use `Vote.ValidatorProTxHash` in a `HeightVoteSet.peerCatchupRounds` map
2. Remove `peerID` form `HeightVoteSet.AddVote`
3. Fix `TestPeerCatchupRounds ` test

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit / E2E tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
