### PR TITLE
build(docker): add abcidump to release image

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.19-alpine3.15 AS builder
 
 RUN apk update && \
     apk upgrade && \
-    apk add bash git gmp-dev sudo cmake build-base
+    apk --no-cache add bash git gmp-dev sudo cmake build-base libpcap-dev
 
 WORKDIR /src/tenderdash
 
@@ -27,6 +27,8 @@ RUN rm -r third_party && mv third_party.bak third_party
 ARG TENDERMINT_BUILD_OPTIONS=tenderdash
 RUN make build-linux
 
+RUN make build_abcidump
+
 # stage 2
 FROM alpine:3.15
 LABEL maintainer="developers@dash.org"
@@ -45,7 +47,7 @@ ENV TMHOME /tenderdash
 # could execute bash commands.
 RUN apk update && \
     apk upgrade && \
-    apk --no-cache add curl jq bash gmp libstdc++ && \
+    apk --no-cache add curl jq bash gmp libstdc++ libpcap && \
     addgroup tmuser && \
     adduser -S -G tmuser tmuser -h "$TMHOME"
 
@@ -60,6 +62,7 @@ EXPOSE 26656 26657 26660
 STOPSIGNAL SIGTERM
 
 COPY --from=builder /src/tenderdash/build/tenderdash /usr/bin/tenderdash
+COPY --from=builder /src/tenderdash/build/abcidump /usr/bin/abcidump
 
 # You can overwrite these before the first run to influence
 # config.json and genesis.json. Additionally, you can override


### PR DESCRIPTION
## Issue being fixed or feature implemented

abcidump is a tool that can be used to debug communication between Tenderdash and ABCI client (Drive).
Injecting it into the docker image is quite complex, so we decided to include it in the image.


## What was done?
<!--- Describe your changes in detail -->

Install libpcap inside the docker image
Build and install abcidump to /usr/bin/abcidump

## How Has This Been Tested?

Built locally with 

```
docker buildx build -f DOCKER/Dockerfile --build-arg TENDERMINT_BUILD_OPTIONS=deadlock --tag tenderdash:test .
```

Built with Github pipeline: https://github.com/dashpay/tenderdash/actions/runs/4013973095 

Tested with: 

```
docker run -ti --entrypoint /usr/bin/abcidump tenderdash:test help
docker run -ti --entrypoint /usr/bin/abcidump dashpay/tenderdash:build-abci --help
```

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
