### PR TITLE
fix(build): docker tag is invalid for empty input.tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,7 +60,7 @@ jobs:
           images: dashpay/tenderdash
           tags: |
             type=semver,pattern={{version}},value=${{ github.event.inputs.tag }}
-            type=raw,priority=650,value=${{ github.event.inputs.tag }}
+            type=raw,priority=650,value=${{ github.event.inputs.tag }},enable=${{ github.event.inputs.tag != '' }}
             type=ref,event=branch
             type=ref,event=pr
             type=match,pattern=v(\d+),group=1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Docker build fails due to invalid docker image tag generated: 

https://github.com/dashpay/tenderdash/actions/runs/4144431646

ERROR: invalid tag "dashpay/tenderdash:-dev": invalid reference format

## What was done?

added `enable=` to respective line.

## How Has This Been Tested?

Started Docker action manually, with and without tag, and verified the output.

**With input tag:**

```
Processing tags input
  type=semver,pattern={{version}},value=test,enable=true,priority=900
  type=match,pattern=v(\d+),group=1,value=,enable=true,priority=800
  type=match,pattern=v(\d+.\d+),group=1,value=,enable=true,priority=800
  type=match,pattern=v(\d+.\d+.\d+),group=1,value=,enable=true,priority=800
  type=match,pattern=v(.*),group=1,suffix=,enable=false,value=,priority=800
  type=raw,priority=650,value=test,enable=true
  type=ref,event=branch,enable=true,priority=600
  type=ref,event=pr,prefix=pr-,enable=true,priority=600
Docker tags
  dashpay/tenderdash:test
  dashpay/tenderdash:fix-docker-tag
```

**without input tag:**

```

Processing tags input
  type=semver,pattern={{version}},value=,enable=true,priority=900
  type=match,pattern=v(\d+),group=1,value=,enable=true,priority=800
  type=match,pattern=v(\d+.\d+),group=1,value=,enable=true,priority=800
  type=match,pattern=v(\d+.\d+.\d+),group=1,value=,enable=true,priority=800
  type=match,pattern=v(.*),group=1,suffix=,enable=false,value=,priority=800
  type=raw,priority=650,value=,enable=false
  type=ref,event=branch,enable=true,priority=600
  type=ref,event=pr,prefix=pr-,enable=true,priority=600


Docker tags
  dashpay/tenderdash:fix-docker-tag
```


## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
