### PR TITLE
refactor: use llmq.Validate function to validate llmq type

### DIFF
--- a/dash/core/client.go
+++ b/dash/core/client.go
@@ -164,7 +164,7 @@ func (rpcClient *RPCClient) QuorumSign(
 	messageHash bytes.HexBytes,
 	quorumHash crypto.QuorumHash,
 ) (*btcjson.QuorumSignResult, error) {
-	if err := ValidateQuorumType(quorumType); err != nil {
+	if err := quorumType.Validate(); err != nil {
 		return nil, err
 	}
 	quorumSignResultWithBool, err := rpcClient.endpoint.QuorumSign(
@@ -198,7 +198,7 @@ func (rpcClient *RPCClient) QuorumVerify(
 	signature bytes.HexBytes,
 	quorumHash crypto.QuorumHash,
 ) (bool, error) {
-	if err := ValidateQuorumType(quorumType); err != nil {
+	if err := quorumType.Validate(); err != nil {
 		return false, err
 	}
 	resp, err := rpcClient.endpoint.QuorumVerify(
@@ -219,14 +219,4 @@ func (rpcClient *RPCClient) QuorumVerify(
 	)
 	return resp, err
 
-}
-
-// ValidateQuorumType checks if quorum type is valid.
-// TODO: move to dashevo/dashd-go
-func ValidateQuorumType(t btcjson.LLMQType) error {
-	if (t >= 1 && t <= 5) || (t >= 100 && t <= 105) {
-		return nil
-	}
-
-	return fmt.Errorf("unsupported quorum type %d", t)
 }

--- a/dash/core/mock.go
+++ b/dash/core/mock.go
@@ -146,7 +146,7 @@ func (mc *MockClient) QuorumSign(
 	messageHash tmbytes.HexBytes,
 	quorumHash crypto.QuorumHash,
 ) (*btcjson.QuorumSignResult, error) {
-	if err := ValidateQuorumType(quorumType); err != nil {
+	if err := quorumType.Validate(); err != nil {
 		return nil, err
 	}
 	if !mc.canSign {
@@ -187,7 +187,7 @@ func (mc *MockClient) QuorumVerify(
 	signature tmbytes.HexBytes,
 	quorumHash crypto.QuorumHash,
 ) (bool, error) {
-	if err := ValidateQuorumType(quorumType); err != nil {
+	if err := quorumType.Validate(); err != nil {
 		return false, err
 	}
 	signID := crypto.SignID(

--- a/internal/consensus/replayer.go
+++ b/internal/consensus/replayer.go
@@ -8,7 +8,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/merkle"
-	"github.com/tendermint/tendermint/dash/core"
 	"github.com/tendermint/tendermint/internal/eventbus"
 	sm "github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/libs/log"
@@ -338,7 +337,7 @@ func (r *BlockReplayer) execInitChain(ctx context.Context, rs *replayState, stat
 	}
 
 	quorumType := state.Validators.QuorumType
-	if core.ValidateQuorumType(quorumType) != nil {
+	if quorumType.Validate() != nil {
 		r.logger.Debug("state quorum type: %w", err)
 		quorumType = r.genDoc.QuorumType
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -212,7 +212,7 @@ func makeNode(
 			}
 		} else {
 			llmqType := genDoc.QuorumType
-			if err := core.ValidateQuorumType(llmqType); err != nil {
+			if err := llmqType.Validate(); err != nil {
 				return nil, fmt.Errorf("invalid genesis quorum type %d: %w", llmqType, err)
 			}
 			// This is used for light client verification only

--- a/privval/dash_core_signer_client.go
+++ b/privval/dash_core_signer_client.go
@@ -48,7 +48,7 @@ var _ DashPrivValidator = (*DashCoreSignerClient)(nil)
 func NewDashCoreSignerClient(
 	client dashcore.Client, defaultQuorumType btcjson.LLMQType,
 ) (*DashCoreSignerClient, error) {
-	if err := dashcore.ValidateQuorumType(defaultQuorumType); err != nil {
+	if err := defaultQuorumType.Validate(); err != nil {
 		return nil, err
 	}
 	return &DashCoreSignerClient{dashCoreRPCClient: client, defaultQuorumType: defaultQuorumType}, nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To avoid to maintain 2 validation functions, need to replace custom implementation on using native LLMQType.Validate method

## What was done?
<!--- Describe your changes in detail -->
Replaced custom function `ValidateQuorumType` on to call `LLMQType.Validate()` method

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
