### PR TITLE
fix: potential deadlock in pex module tests

### DIFF
--- a/internal/p2p/pex/reactor_test.go
+++ b/internal/p2p/pex/reactor_test.go
@@ -708,6 +708,9 @@ func (r *reactorTestSuite) connectPeers(ctx context.Context, t *testing.T, sourc
 	added, err = n2.PeerManager.Add(sourceAddress)
 	require.NoError(t, err)
 	require.True(t, added)
+
+	n1.PeerManager.Unsubscribe(sourceSub)
+	n2.PeerManager.Unsubscribe(targetSub)
 }
 
 func (r *reactorTestSuite) checkNodePair(t *testing.T, first, second int) (types.NodeID, types.NodeID) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The tests in `pex` module are flaky, i.e. `TestReactorConnectFullNetwork`

```
go test ./internal/p2p/pex -test.run TestReactorConnectFullNetwork -race -test.v -test.count 10
=== RUN   TestReactorConnectFullNetwork
    reactor_test.go:65: started ef59301921b33674348cc04ef4e63f8159bdb234
    reactor_test.go:65: started 395bc84197103724210f39587cb11a597c631696
    reactor_test.go:65: started 47c54b7311f120d81702f23b399761985df35fa4
    reactor_test.go:65: started 436ed2bf9bac168ca7f403c5f78c66e7fabc94d3
--- PASS: TestReactorConnectFullNetwork (2.02s)
=== RUN   TestReactorConnectFullNetwork
    reactor_test.go:65: started 21ac0dd98f38a817e15389961511803c164dfbb1
    reactor_test.go:65: started afaff974a583bcb46237ff53a1fc9d8f423b33d4
    reactor_test.go:65: started 37f264190bb20b4fb67c923f07f0818256262a87
    reactor_test.go:65: started d8e026d4a59747158fb3d03e1dbbc90f42943a49
POTENTIAL DEADLOCK:
Previous place where the lock was grabbed
goroutine 1663 lock 0xc0000ef778
../peermanager.go:851 p2p.(*PeerManager).Ready { m.mtx.Lock() } <<<<<
../peermanager.go:850 p2p.(*PeerManager).Ready { func (m *PeerManager) Ready(ctx context.Context, peerID types.NodeID, channels ChannelIDSet) { }
../router.go:722 p2p.(*Router).routePeer {  }

Have been trying to lock it again for more than 30s
goroutine 1267 lock 0xc0000ef778
../peermanager.go:581 p2p.(*PeerManager).TryDialNext { m.mtx.Lock() } <<<<<
../peermanager.go:580 p2p.(*PeerManager).TryDialNext { func (m *PeerManager) TryDialNext() NodeAddress { }
../peermanager.go:558 p2p.(*PeerManager).DialNext { for counter := uint32(0); ; counter++ { }
../router.go:557 p2p.(*Router).dialPeers { for { }

```

## What was done?
<!--- Describe your changes in detail -->
Added ability to remove a subscription from the list through `PeerManager.Unsubscribe`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit / E2E tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
