### PR TITLE
fix(docker): replace tenderdash init single with tenderdash init validator

### DIFF
--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -2,27 +2,13 @@
 
 ## Supported tags and respective `Dockerfile` links
 
-DockerHub tags for official releases are [here](https://hub.docker.com/r/tendermint/tendermint/tags/). The "latest" tag will always point to the highest version number.
+DockerHub tags for official releases are [here](https://hub.docker.com/r/dashpay/tenderdash/tags). The "latest" tag will always point to the highest version number.
 
-Official releases can be found [here](https://github.com/tendermint/tendermint/releases).
+Official releases can be found [here](https://github.com/dashpay/tenderdash/releases).
 
-The Dockerfile for tendermint is not expected to change in the near future. The master file used for all builds can be found [here](https://raw.githubusercontent.com/tendermint/tendermint/master/DOCKER/Dockerfile).
+The Dockerfile used for all builds can be found [here](https://github.com/dashpay/tenderdash/blob/master/DOCKER/Dockerfile).
 
 Respective versioned files can be found at `https://raw.githubusercontent.com/tendermint/tendermint/vX.XX.XX/DOCKER/Dockerfile` (replace the Xs with the version number).
-
-## Quick reference
-
-- **Where to get help:** <https://tendermint.com/>
-- **Where to file issues:** <https://github.com/tendermint/tendermint/issues>
-- **Supported Docker versions:** [the latest release](https://github.com/moby/moby/releases) (down to 1.6 on a best-effort basis)
-
-## Tendermint
-
-Tendermint Core is Byzantine Fault Tolerant (BFT) middleware that takes a state transition machine, written in any programming language, and securely replicates it on many machines.
-
-For more background, see the [the docs](https://docs.tendermint.com/master/introduction/#quick-start).
-
-To get started developing applications, see the [application developers guide](https://docs.tendermint.com/master/introduction/quick-start.html).
 
 ## How to use this image
 
@@ -31,21 +17,10 @@ To get started developing applications, see the [application developers guide](h
 A quick example of a built-in app and Tendermint core in one container.
 
 ```sh
-docker run -it --rm -v "/tmp:/tendermint" dashpay/tenderdash init validator
-docker run -it --rm -v "/tmp:/tendermint" dashpay/tenderdash node --proxy_app=kvstore
+mkdir --mode=0777 -p /tmp/tenderdash
+docker run -it --rm -v "/tmp/tenderdash:/tenderdash" dashpay/tenderdash 
 ```
 
-## Local cluster
-
-To run a 4-node network, see the `Makefile` in the root of [the repo](https://github.com/tendermint/tendermint/blob/master/Makefile) and run:
-
-```sh
-make build-linux
-make build-docker-localnode
-make localnet-start
-```
-
-Note that this will build and use a different image than the ones provided here.
 
 ## License
 

--- a/DOCKER/docker-entrypoint.sh
+++ b/DOCKER/docker-entrypoint.sh
@@ -2,8 +2,8 @@
 set -e
 
 if [ ! -d "$TMHOME/config" ]; then
-	echo "Running tenderdash init single to create a single node (default) configuration for docker run."
-	tenderdash init single
+	echo "Running tenderdash init to create a single node (default) configuration for docker run."
+	tenderdash init validator
 
 	sed -i \
 		-e "s/^proxy-app\s*=.*/proxy-app = \"$PROXY_APP\"/" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Docker image calls `tenderdash init single` which was removed.

## What was done?

Use `tenderdash init validator` instead.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
