### PR TITLE
fix(types): nil voteset panics in rest handler

### DIFF
--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -573,6 +573,9 @@ func (voteSet *VoteSet) String() string {
 //
 // See Vote#String.
 func (voteSet *VoteSet) StringIndented(indent string) string {
+	if voteSet == nil {
+		return nilVoteSetString
+	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
 
@@ -600,6 +603,9 @@ func (voteSet *VoteSet) StringIndented(indent string) string {
 // Marshal the VoteSet to JSON. Same as String(), just in JSON,
 // and without the height/round/signedMsgType (since its already included in the votes).
 func (voteSet *VoteSet) MarshalJSON() ([]byte, error) {
+	if voteSet == nil {
+		return nil, nil
+	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
 	return json.Marshal(VoteSetJSON{
@@ -622,6 +628,9 @@ type VoteSetJSON struct {
 // the fraction of power that has voted like:
 // "BA{29:xx__x__x_x___x__x_______xxx__} 856/1304 = 0.66"
 func (voteSet *VoteSet) BitArrayString() string {
+	if voteSet == nil {
+		return nilVoteSetString
+	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
 	return voteSet.bitArrayString()
@@ -635,6 +644,9 @@ func (voteSet *VoteSet) bitArrayString() string {
 
 // Returns a list of votes compressed to more readable strings.
 func (voteSet *VoteSet) VoteStrings() []string {
+	if voteSet == nil {
+		return []string{}
+	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
 	return voteSet.voteStrings()

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"math"
 	"sort"
 	"strconv"
@@ -546,6 +547,24 @@ func TestVoteSet_LLMQType_50_60(t *testing.T) {
 			assert.True(t, anyMaj, "'any' majority expected")
 		})
 	}
+}
+
+func TestVoteSet_json_marshal_nil(t *testing.T) {
+	var vset *VoteSet
+	jsonBytes, err := json.Marshal(vset)
+	assert.Equal(t, "null", string(jsonBytes))
+	assert.Nil(t, err)
+}
+
+func TestVoteSet_strings_nil(t *testing.T) {
+	var vset *VoteSet
+	assert.Equal(t, nilVoteSetString, vset.String())
+	assert.Equal(t, nilVoteSetString, vset.BitArrayString())
+	assert.Equal(t, nilVoteSetString, vset.String())
+	assert.Equal(t, nilVoteSetString, vset.StringIndented(" "))
+	assert.Equal(t, nilVoteSetString, vset.StringShort())
+	assert.Zero(t, vset.Type())
+	assert.Empty(t, vset.VoteStrings())
 }
 
 func castVote(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

In some conditions, accessing REST endpoint like `dump_consensus_state` causes panic due to access to NIL VoteSet to obtain lock.

Example:
``
curl 127.0.0.1:36657/dump_consensus_state
runtime error: invalid memory address or nil pointer dereference
``

## What was done?

Check nil VoteSet before accessing the lock.


## How Has This Been Tested?

Added unit tests


## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
