### PR TITLE
backport: fix(types): nil voteset panics in rest handler (#609)

### DIFF
--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -572,6 +572,9 @@ func (voteSet *VoteSet) String() string {
 //
 // See Vote#String.
 func (voteSet *VoteSet) StringIndented(indent string) string {
+	if voteSet == nil {
+		return nilVoteSetString
+	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
 
@@ -599,6 +602,9 @@ func (voteSet *VoteSet) StringIndented(indent string) string {
 // Marshal the VoteSet to JSON. Same as String(), just in JSON,
 // and without the height/round/signedMsgType (since its already included in the votes).
 func (voteSet *VoteSet) MarshalJSON() ([]byte, error) {
+	if voteSet == nil {
+		return nil, nil
+	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
 	return json.Marshal(VoteSetJSON{
@@ -621,6 +627,9 @@ type VoteSetJSON struct {
 // the fraction of power that has voted like:
 // "BA{29:xx__x__x_x___x__x_______xxx__} 856/1304 = 0.66"
 func (voteSet *VoteSet) BitArrayString() string {
+	if voteSet == nil {
+		return nilVoteSetString
+	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
 	return voteSet.bitArrayString()
@@ -634,6 +643,9 @@ func (voteSet *VoteSet) bitArrayString() string {
 
 // Returns a list of votes compressed to more readable strings.
 func (voteSet *VoteSet) VoteStrings() []string {
+	if voteSet == nil {
+		return []string{}
+	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
 	return voteSet.voteStrings()

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"math"
 	"sort"
 	"strconv"
@@ -546,6 +547,24 @@ func TestVoteSet_LLMQType_50_60(t *testing.T) {
 			assert.True(t, anyMaj, "'any' majority expected")
 		})
 	}
+}
+
+func TestVoteSet_json_marshal_nil(t *testing.T) {
+	var vset *VoteSet
+	jsonBytes, err := json.Marshal(vset)
+	assert.Equal(t, "null", string(jsonBytes))
+	assert.Nil(t, err)
+}
+
+func TestVoteSet_strings_nil(t *testing.T) {
+	var vset *VoteSet
+	assert.Equal(t, nilVoteSetString, vset.String())
+	assert.Equal(t, nilVoteSetString, vset.BitArrayString())
+	assert.Equal(t, nilVoteSetString, vset.String())
+	assert.Equal(t, nilVoteSetString, vset.StringIndented(" "))
+	assert.Equal(t, nilVoteSetString, vset.StringShort())
+	assert.Zero(t, vset.Type())
+	assert.Empty(t, vset.VoteStrings())
 }
 
 func castVote(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Backport of #609  to v0.11


## What was done?

Cherry-pick f042f25b484198ae24507482417326aad31738e6

## How Has This Been Tested?

github workflow

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
