### PR TITLE
fix(consensus): PrepareProposal should not be called during replay

### DIFF
--- a/internal/consensus/state_controller.go
+++ b/internal/consensus/state_controller.go
@@ -87,6 +87,7 @@ func NewController(cs *State, wal *wrapWAL, statsQueue *chanQueue[msgInfo], prop
 			scheduler:       cs.roundScheduler,
 			eventPublisher:  cs.eventPublisher,
 			proposalCreator: propler,
+			replayMode:      cs.replayMode,
 		},
 		AddProposalBlockPartType: &AddProposalBlockPartAction{
 			logger:         cs.logger,

--- a/internal/consensus/state_enter_propose.go
+++ b/internal/consensus/state_enter_propose.go
@@ -31,6 +31,7 @@ type EnterProposeAction struct {
 	scheduler       *roundScheduler
 	eventPublisher  *EventPublisher
 	proposalCreator cstypes.ProposalCreator
+	replayMode      bool
 }
 
 func (c *EnterProposeAction) Execute(ctx context.Context, stateEvent StateEvent) error {
@@ -93,6 +94,12 @@ func (c *EnterProposeAction) Execute(ctx context.Context, stateEvent StateEvent)
 			"node_proTxHash", proTxHash.String())
 		return nil
 	}
+	// In replay mode, we don't propose blocks.
+	if c.replayMode {
+		logger.Debug("enter propose step; our turn to propose but in replay mode, not proposing")
+		return nil
+	}
+
 	logger.Debug("propose step; our turn to propose",
 		"proposer_proTxHash", proTxHash.ShortString(),
 	)

--- a/internal/consensus/types/round_state.go
+++ b/internal/consensus/types/round_state.go
@@ -97,7 +97,7 @@ type RoundState struct {
 	// Last known round with POL for non-nil valid block.
 	ValidRound         int32        `json:"valid_round"`
 	ValidBlock         *types.Block `json:"valid_block"`      // Last known block of POL mentioned above.
-	ValidBlockRecvTime time.Time    `json:"valid_block_time"` // Receive time of ast known block of POL mentioned above.
+	ValidBlockRecvTime time.Time    `json:"valid_block_time"` // Receive time of last known block of POL mentioned above.
 
 	// Last known block parts of POL mentioned above.
 	ValidBlockParts           *types.PartSet      `json:"valid_block_parts"`


### PR DESCRIPTION
## Issue being fixed or feature implemented

When replaying WAL on proposer, Tenderdash calls RequestPrepareProposal and creates new proposal, to drop it soon and use the one from replay process.

This can affect multiple mechanisms, including block locking.

## What was done?

Skip creating proposal in replay mode.

## How Has This Been Tested?

Unit tests, e2e tests passed

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
