### PR TITLE
fix(evidence): send evidence only once

### DIFF
--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -359,7 +359,7 @@ func (r *Router) routeChannel(
 					r.metrics.RouterPeerQueueSend.Observe(time.Since(start).Seconds())
 
 				case <-q.closed():
-					r.logger.Debug("dropping message for unconnected peer", "peer", envelope.To, "channel", chID)
+					r.logger.Debug("dropping message on closed channel", "peer", envelope.To, "channel", chID)
 
 				case <-ctx.Done():
 					return


### PR DESCRIPTION
## Issue being fixed or feature implemented

Right now, evidence is sent to all peers, which is not necessary and can generate huge load during chain halt.

Reproduction scenario:

1. Stop majority of chain nodes (except one)
2. Remove WAL from stopped nodes
3. Break the code so that the chain will be halted
4. Start stopped nodes

As a result, these nodes will generate huge amount of evidence messages, which will be sent to all peers repeatedly. On big enough network, this will cause significant load.

## What was done?

We no longer repeatedly send evidence to all connected peers.

Instead:

1. When a peer connects, we send all evidence from the pool to it.
2. When new evidence arrives, we broadcast it to all peers.


## How Has This Been Tested?

TODO

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
