### PR TITLE
fix: panic verifying evidence due to missing pubkey

### DIFF
--- a/internal/evidence/verify.go
+++ b/internal/evidence/verify.go
@@ -98,6 +98,9 @@ func VerifyDuplicateVote(e *types.DuplicateVoteEvidence, chainID string, valSet 
 	}
 	proTxHash := val.ProTxHash
 	pubKey := val.PubKey
+	if pubKey == nil {
+		return fmt.Errorf("we don't have a public key of validator %X at height %d", proTxHash, e.Height())
+	}
 
 	// H/R/S must be the same
 	if e.VoteA.Height != e.VoteB.Height ||


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

```
{"level":"error","module":"evidence","err":"panic in processing message: runtime error: invalid memory address or nil pointer dereference","stack":"goroutine 139 [running]:\nruntime/debug.Stack()\n\truntime/debug/stack.go:24 +0x64\ngithub.com/tendermint/tendermint/internal/evidence.(*Reactor).handleMessage.func1()\n\tgithub.com/tendermint/tendermint/internal/evidence/reactor.go:143 +0x90\npanic({0x1072d00, 0x1d915a0})\n\truntime/panic.go:884 +0x20c\ngithub.com/tendermint/tendermint/internal/evidence.VerifyDuplicateVote(0x40093e9d80, {0x4001ebcc70, 0xf}, 0x400941fa40)\n\tgithub.com/tendermint/tendermint/internal/evidence/verify.go:137 +0x5b8\ngithub.com/tendermint/tendermint/internal/evidence.(*Pool).verify(0x4000154240, {0x15cd698, 0x4001ef4210}, {0x15d3378, 0x40093e9d80})\n\tgithub.com/tendermint/tendermint/internal/evidence/verify.go:67 +0x314\ngithub.com/tendermint/tendermint/internal/evidence.(*Pool).AddEvidence(0x4000154240, {0x15cd698, 0x4001ef4210}, {0x15d3378?, 0x40093e9d80})\n\tgithub.com/tendermint/tendermint/internal/evidence/pool.go:163 +0x258\ngithub.com/tendermint/tendermint/internal/evidence.(*Reactor).handleEvidenceMessage(0x4001970180, {0x15cd698, 0x4001ef4210}, 0x40093bde00)\n\tgithub.com/tendermint/tendermint/internal/evidence/reactor.go:117 +0x1d8\ngithub.com/tendermint/tendermint/internal/evidence.(*Reactor).handleMessage(0x4000423ea0?, {0x15cd698?, 0x4001ef4210?}, 0x4000145598?)\n\tgithub.com/tendermint/tendermint/internal/evidence/reactor.go:152 +0x70\ngithub.com/tendermint/tendermint/internal/evidence.(*Reactor).processEvidenceCh(0x4001970180, {0x15cd698, 0x4001ef4210}, {0x15cec80, 0x40003dee10})\n\tgithub.com/tendermint/tendermint/internal/evidence/reactor.go:166 +0x78\ncreated by github.com/tendermint/tendermint/internal/evidence.(*Reactor).OnStart\n\tgithub.com/tendermint/tendermint/internal/evidence/reactor.go:91 +0x140\n","time":"2023-09-13T14:46:51.971559126Z","message":"recovering from processing message panic"}
```

## What was done?

Added check as a workaround; proper solution would be to not process evidence on non-validators (similar to votes).


## How Has This Been Tested?

Run unit tests

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
