### PR TITLE
build: manual docker image build platform selection

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           context: .
           file: ./DOCKER/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event.inputs.platforms }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,15 @@ on:
         type: string
         description: "Docker tag"
         required: false
+
+      platforms:
+        type: choice
+        description: "Image architecture to build"
+        default: "linux/amd64,linux/arm64"
+        options:
+          - "linux/amd64,linux/arm64"
+          - "linux/amd64"
+          - "linux/arm64"
   release:
     types:
       - published
@@ -79,7 +88,7 @@ jobs:
         with:
           context: .
           file: ./DOCKER/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event.inputs.platforms }}
           target: base
           push: false
           cache-from: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Build time of docker images for arm takes long time, effectively slowing development.

## What was done?

Added option to select platforms to use when starting Docker job manually

## How Has This Been Tested?

Built Docker image:

* amd: https://github.com/dashpay/tenderdash/actions/runs/7294117823
* amd and arm: 

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
