### PR TITLE
build: fix docker platforms for releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    env:
+      PLATFORMS: ${{ github.event_name == 'release' && 'linux/amd64,linux/arm64' || github.event.inputs.platforms }}
     steps:
       - uses: actions/checkout@v4
 
@@ -88,7 +90,7 @@ jobs:
         with:
           context: .
           file: ./DOCKER/Dockerfile
-          platforms: ${{ github.event.inputs.platforms }}
+          platforms: ${{ env.PLATFORMS }}
           target: base
           push: false
           cache-from: |
@@ -104,7 +106,7 @@ jobs:
         with:
           context: .
           file: ./DOCKER/Dockerfile
-          platforms: ${{ github.event.inputs.platforms }}
+          platforms: ${{ env.PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Docker releases are only built for x86-64

## What was done?

Fixed to build for both x86-64 and arm

## How Has This Been Tested?

GHA for manual dispatch: https://github.com/dashpay/tenderdash/actions/runs/7741309780

For release, it needs to be merged first before we test.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
