### PR TITLE
build(deps): bump go to 1.22, alpine to 3.19, mockery to 2.41.0

### DIFF
--- a/.github/actions/bls/action.yml
+++ b/.github/actions/bls/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.21"
+        go-version: "1.22"
     - uses: actions/checkout@v2
       with:
         submodules: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - uses: actions/checkout@v4
 
@@ -31,7 +31,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          readonly MOCKERY=2.33.2  # N.B. no leading "v"
+          readonly MOCKERY=2.41.0  # N.B. no leading "v"
           curl -sL "https://github.com/vektra/mockery/releases/download/v${MOCKERY}/mockery_${MOCKERY}_Linux_x86_64.tar.gz" | tar -C /usr/local/bin -xzf -
           make mockery 2>/dev/null
 
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@v5.0.0
         with:
-          go-version: "^1.21"
+          go-version: "^1.22"
       - uses: technote-space/get-diff-action@v6
         with:
           PATTERNS: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v5.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: Build
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -4,8 +4,8 @@
 # * compile - builds final binaries
 # * image - creates final image of minimal size
 
-ARG ALIPNE_VERSION=3.17
-ARG GOLANG_VERSION=1.21
+ARG ALIPNE_VERSION=3.19
+ARG GOLANG_VERSION=1.22
 #################################
 # STAGE 1: install dependencies #
 #################################

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to notify you of vulnerabilities and fixes in Tendermint Core. You can subscribe
 
 | Requirement | Notes            |
 |-------------|------------------|
-| Go version  | Go1.21 or higher |
+| Go version  | Go1.22 or higher |
 
 ### Install
 

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -43,7 +43,7 @@ Verify that you have the latest version of Go installed:
 
 ```sh
 $ go version
-go version go1.21.x darwin/amd64
+go version go1.22.x darwin/amd64
 ```
 
 Note that the exact patch number may differ as Go releases come out.
@@ -596,7 +596,7 @@ This will populate the `go.mod` with a release number followed by a hash for Ten
 ```go
 module github.com/<username>/kvstore
 
-go 1.21
+go 1.22
 
 require (
  github.com/dgraph-io/badger/v3 v3.2103.2

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -454,7 +454,7 @@ This will populate the `go.mod` with a release number followed by a hash for Ten
 ```go
 module github.com/<username>/kvstore
 
-go 1.21
+go 1.22
 
 require (
  github.com/dgraph-io/badger/v3 v3.2103.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dashpay/tenderdash
 
-go 1.21
+go 1.22
 
 require (
 	github.com/BurntSushi/toml v1.3.2
@@ -52,7 +52,7 @@ require (
 	github.com/creachadair/taskgroup v0.3.2
 	github.com/go-pkgz/jrpc v0.2.0
 	github.com/google/go-cmp v0.6.0
-	github.com/vektra/mockery/v2 v2.33.2
+	github.com/vektra/mockery/v2 v2.41.0
 	gotest.tools v2.2.0+incompatible
 )
 
@@ -72,7 +72,7 @@ require (
 	github.com/butuzov/mirror v1.1.0 // indirect
 	github.com/catenacyber/perfsprint v0.2.0 // indirect
 	github.com/ccojocar/zxcvbn-go v1.0.1 // indirect
-	github.com/chigopher/pathlib v0.15.0 // indirect
+	github.com/chigopher/pathlib v0.19.1 // indirect
 	github.com/containerd/containerd v1.6.6 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
 	github.com/curioswitch/go-reassign v0.2.0 // indirect
@@ -90,6 +90,7 @@ require (
 	github.com/go-pkgz/expirable-cache v0.0.3 // indirect
 	github.com/go-pkgz/rest v1.5.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/jinzhu/copier v0.3.5 // indirect
 	github.com/kkHAIKE/contextcheck v1.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/charithe/durationcheck v0.0.10/go.mod h1:bCWXb7gYRysD1CU3C+u4ceO49LoG
 github.com/chavacava/garif v0.1.0 h1:2JHa3hbYf5D9dsgseMKAmc/MZ109otzgNFk5s87H9Pc=
 github.com/chavacava/garif v0.1.0/go.mod h1:XMyYCkEL58DF0oyW4qDjjnPWONs2HBqYKI+UIPD+Gww=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
-github.com/chigopher/pathlib v0.15.0 h1:1pg96WL3iC1/YyWV4UJSl3E0GBf4B+h5amBtsbAAieY=
-github.com/chigopher/pathlib v0.15.0/go.mod h1:3+YPPV21mU9vyw8Mjp+F33CyCfE6iOzinpiqBcccv7I=
+github.com/chigopher/pathlib v0.19.1 h1:RoLlUJc0CqBGwq239cilyhxPNLXTK+HXoASGyGznx5A=
+github.com/chigopher/pathlib v0.19.1/go.mod h1:tzC1dZLW8o33UQpWkNkhvPwL5n4yyFRFm/jL1YGWFvY=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -511,6 +511,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
+github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -888,8 +890,8 @@ github.com/ultraware/whitespace v0.0.5/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/uudashr/gocognit v1.1.2 h1:l6BAEKJqQH2UpKAPKdMfZf5kE4W/2xk8pfU1OVLvniI=
 github.com/uudashr/gocognit v1.1.2/go.mod h1:aAVdLURqcanke8h3vg35BC++eseDm66Z7KmchI5et4k=
-github.com/vektra/mockery/v2 v2.33.2 h1:znIUwQ3FxnA5jvPy8irYBoiIqMZhuOJhoPOJYNoTJqU=
-github.com/vektra/mockery/v2 v2.33.2/go.mod h1:9lREs4VEeQiUS3rizYQx1saxHu2JiIhThP0q9+fDegM=
+github.com/vektra/mockery/v2 v2.41.0 h1:miv6vazLja/sknB/Rv1ZyKzxOG24QJgIPNN1renwkrs=
+github.com/vektra/mockery/v2 v2.41.0/go.mod h1:XNTE9RIu3deGAGQRVjP1VZxGpQNm0YedZx4oDs3prr8=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/scripts/mockery_generate.sh
+++ b/scripts/mockery_generate.sh
@@ -6,7 +6,7 @@
 # runs the published Docker container. This legerdemain is so that the CI build
 # and a local build can work off the same script.
 #
-VERSION=v2.33.2
+VERSION=v2.41.0
 
 if ! mockery --version 2>/dev/null | grep $VERSION; then
   echo "Please install mockery $VERSION"

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,6 +1,6 @@
 ## Stage 1 and 2 is copied from /DOCKER/Dockerfile
-ARG ALIPNE_VERSION=3.17
-ARG GOLANG_VERSION=1.21
+ARG ALIPNE_VERSION=3.19
+ARG GOLANG_VERSION=1.22
 #################################
 # STAGE 1: install dependencies #
 #################################

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -1,7 +1,7 @@
 # fuzz
 
 Fuzzing for various packages in Tendermint using the fuzzing infrastructure included in
-Go 1.21.
+Go 1.22.
 
 Inputs:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Current version of Mockery fails to generate mocks for modern golang options.
New version of Mockery requires golang 1.22
There is no alpine 3.17 image for golang 1.22.

## What was done?

Updated go to 1.22, alpine to 3.19, mockery to 2.41.0

## How Has This Been Tested?

GHA


## Breaking Changes

None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
