### PR TITLE
feat(Docker): env var ABCI changes abci option in config.toml

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -94,6 +94,7 @@ COPY --from=compile /src/tenderdash/build/tenderdash /src/tenderdash/build/abcid
 # config.json and genesis.json. Additionally, you can override
 # CMD to add parameters to `tenderdash node`.
 ENV PROXY_APP=kvstore MONIKER=dockernode CHAIN_ID=dockerchain
+ENV ABCI
 
 COPY ./DOCKER/docker-entrypoint.sh /usr/local/bin/
 

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -93,8 +93,7 @@ COPY --from=compile /src/tenderdash/build/tenderdash /src/tenderdash/build/abcid
 # You can overwrite these before the first run to influence
 # config.json and genesis.json. Additionally, you can override
 # CMD to add parameters to `tenderdash node`.
-ENV PROXY_APP=kvstore MONIKER=dockernode CHAIN_ID=dockerchain
-ENV ABCI
+ENV PROXY_APP=kvstore MONIKER=dockernode CHAIN_ID=dockerchain ABCI=""
 
 COPY ./DOCKER/docker-entrypoint.sh /usr/local/bin/
 

--- a/DOCKER/docker-entrypoint.sh
+++ b/DOCKER/docker-entrypoint.sh
@@ -15,8 +15,14 @@ if [ ! -d "$TMHOME/config" ]; then
 		-e 's/^prometheus\s*=.*/prometheus = true/' \
 		"$TMHOME/config/config.toml"
 
+	if [ -n "$ABCI" ]; then
+		sed -i \
+			-e "s/^abci\s*=.*/abci = \"$ABCI\"/" \
+			"$TMHOME/config/config.toml"
+	fi
+
 	jq ".chain_id = \"$CHAIN_ID\" | .consensus_params.block.time_iota_ms = \"500\"" \
-		"$TMHOME/config/genesis.json" > "$TMHOME/config/genesis.json.new"
+		"$TMHOME/config/genesis.json" >"$TMHOME/config/genesis.json.new"
 	mv "$TMHOME/config/genesis.json.new" "$TMHOME/config/genesis.json"
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

To test gRPC, we need to be able to provide `abci` config option using Docker env variable


## What was done?

Added support for `ABCI` env var in Docker. If set, it will replace `abci` option in config.toml.


## How Has This Been Tested?

Tested in https://github.com/dashpay/rs-tenderdash-abci/pull/50 GHA, "grpc" test.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
