### PR TITLE
fix!: e2e tests are flaky due to slow app state processing

### DIFF
--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -3,9 +3,9 @@ package kvstore
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"path"
 	"strconv"
 	"time"
@@ -228,7 +228,12 @@ func newApplication(stateStore StoreFactory, opts ...OptFunc) (*Application, err
 	defer in.Close()
 
 	if err := app.LastCommittedState.Load(in); err != nil {
-		return nil, fmt.Errorf("load state: %w", err)
+		// EOF means we most likely don't have any state yet
+		if !errors.Is(err, io.EOF) {
+			return nil, fmt.Errorf("load state: %w", err)
+		} else {
+			app.logger.Debug("no state found, using initial state")
+		}
 	}
 
 	app.snapshots, err = NewSnapshotStore(path.Join(app.cfg.Dir, "snapshots"))
@@ -264,9 +269,9 @@ func (app *Application) InitChain(_ context.Context, req *abci.RequestInitChain)
 	}
 
 	// Overwrite state based on AppStateBytes
+	// Note this is not optimal from memory perspective; use chunked state sync instead
 	if len(req.AppStateBytes) > 0 {
-		err := json.Unmarshal(req.AppStateBytes, &app.LastCommittedState)
-		if err != nil {
+		if err := app.LastCommittedState.Load(bytes.NewBuffer(req.AppStateBytes)); err != nil {
 			return &abci.ResponseInitChain{}, err
 		}
 	}
@@ -530,14 +535,16 @@ func (app *Application) ApplySnapshotChunk(_ context.Context, req *abci.RequestA
 	}
 
 	if app.offerSnapshot.isFull() {
-		chunks := app.offerSnapshot.bytes()
-		err := json.Unmarshal(chunks, &app.LastCommittedState)
-		if err != nil {
+		// TODO: Refactor to use streaming
+		chunks := app.offerSnapshot.reader()
+		defer chunks.Close()
+
+		if err := app.LastCommittedState.Load(chunks); err != nil {
 			return &abci.ResponseApplySnapshotChunk{}, fmt.Errorf("cannot unmarshal state: %w", err)
 		}
+
 		app.logger.Info("restored state snapshot",
 			"height", app.LastCommittedState.GetHeight(),
-			"json", string(chunks),
 			"apphash", app.LastCommittedState.GetAppHash(),
 			"snapshot_height", app.offerSnapshot.snapshot.Height,
 			"snapshot_apphash", app.offerSnapshot.appHash,

--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -403,7 +403,8 @@ func (app *Application) FinalizeBlock(_ context.Context, req *abci.RequestFinali
 	appHash := tmbytes.HexBytes(req.Block.Header.AppHash)
 	roundState, ok := app.roundStates[roundKey(appHash, req.Height, req.Round)]
 	if !ok {
-		return &abci.ResponseFinalizeBlock{}, fmt.Errorf("state with apphash %s not found", appHash)
+		return &abci.ResponseFinalizeBlock{}, fmt.Errorf("state with apphash %s at height %d round %d not found",
+			appHash, req.Height, req.Round)
 	}
 	if roundState.GetHeight() != req.Height {
 		return &abci.ResponseFinalizeBlock{},

--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -536,7 +536,6 @@ func (app *Application) ApplySnapshotChunk(_ context.Context, req *abci.RequestA
 	}
 
 	if app.offerSnapshot.isFull() {
-		// TODO: Refactor to use streaming
 		chunks := app.offerSnapshot.reader()
 		defer chunks.Close()
 

--- a/abci/example/kvstore/kvstore_test.go
+++ b/abci/example/kvstore/kvstore_test.go
@@ -2,7 +2,6 @@ package kvstore
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"os"
 	"path"
@@ -138,9 +137,7 @@ func TestPersistentKVStoreKV(t *testing.T) {
 	data, err := os.ReadFile(path.Join(dir, "state.json"))
 	require.NoError(t, err)
 
-	assert.Contains(t, string(data), fmt.Sprintf(`"key":"%s","value":"%s"`,
-		base64.StdEncoding.EncodeToString([]byte(key)),
-		base64.StdEncoding.EncodeToString([]byte(value))))
+	assert.Contains(t, string(data), fmt.Sprintf(`"key":"%s","value":"%s"`, key, value))
 }
 
 func TestPersistentKVStoreInfo(t *testing.T) {

--- a/abci/example/kvstore/kvstore_test.go
+++ b/abci/example/kvstore/kvstore_test.go
@@ -2,6 +2,7 @@ package kvstore
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path"
@@ -136,7 +137,10 @@ func TestPersistentKVStoreKV(t *testing.T) {
 
 	data, err := os.ReadFile(path.Join(dir, "state.json"))
 	require.NoError(t, err)
-	assert.Contains(t, string(data), fmt.Sprintf(`"%s":"%s"`, key, value))
+
+	assert.Contains(t, string(data), fmt.Sprintf(`"key":"%s","value":"%s"`,
+		base64.StdEncoding.EncodeToString([]byte(key)),
+		base64.StdEncoding.EncodeToString([]byte(value))))
 }
 
 func TestPersistentKVStoreInfo(t *testing.T) {

--- a/abci/example/kvstore/state.go
+++ b/abci/example/kvstore/state.go
@@ -209,7 +209,7 @@ func (state *kvState) Load(from io.Reader) error {
 	item := exportItem{}
 	var err error
 	for err = decoder.Decode(&item); err == nil; err = decoder.Decode(&item) {
-		if err := batch.Set(item.Key, item.Value); err != nil {
+		if err := batch.Set([]byte(item.Key), []byte(item.Value)); err != nil {
 			return fmt.Errorf("error restoring state item %+v: %w", item, err)
 		}
 	}
@@ -249,7 +249,7 @@ func (state kvState) Save(to io.Writer) error {
 	defer iter.Close()
 
 	for ; iter.Valid(); iter.Next() {
-		item := exportItem{Key: iter.Key(), Value: iter.Value()}
+		item := exportItem{Key: string(iter.Key()), Value: string(iter.Value())}
 		if err := encoder.Encode(item); err != nil {
 			return fmt.Errorf("error encoding state item %+v: %w", item, err)
 		}
@@ -258,16 +258,9 @@ func (state kvState) Save(to io.Writer) error {
 	return nil
 }
 
-type StateExport struct {
-	Height        *int64            `json:"height,omitempty"`
-	InitialHeight *int64            `json:"initial_height,omitempty"`
-	AppHash       tmbytes.HexBytes  `json:"app_hash,omitempty"`
-	Items         map[string]string `json:"items,omitempty"` // we store items as string-encoded values
-}
-
 type exportItem struct {
-	Key   []byte `json:"key"`
-	Value []byte `json:"value"`
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 func (state *kvState) Close() error {

--- a/abci/example/kvstore/state_test.go
+++ b/abci/example/kvstore/state_test.go
@@ -32,9 +32,12 @@ func TestStateMarshalUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, encoded)
 
+	t.Log("encoded:", encoded.String())
+
 	decoded := NewKvState(dbm.NewMemDB(), 1)
 	err = decoded.Load(encoded)
 	require.NoError(t, err)
+	decoded.Print()
 
 	v1, err := decoded.Get([]byte("key1"))
 	require.NoError(t, err)
@@ -91,8 +94,8 @@ func TestStateLoad(t *testing.T) {
 				"height": 6531,
 				"app_hash": "1C9ECEC90E28D2461650418635878A5C91E49F47586ECF75F2B0CBB94E897112"
 			}
-			{"key":"a2V5MQ==","value":"dmFsdWUx"}
-			{"key":"a2V5Mg==","value":"dmFsdWUy"}`),
+			{"key":"key1","value":"value1"}
+			{"key":"key2","value":"value2"}`),
 			expectHeight:  6531,
 			expectAppHash: tmbytes.MustHexDecode("1C9ECEC90E28D2461650418635878A5C91E49F47586ECF75F2B0CBB94E897112"),
 			expectKeyVals: []keyVals{

--- a/abci/example/kvstore/state_test.go
+++ b/abci/example/kvstore/state_test.go
@@ -1,7 +1,7 @@
 package kvstore
 
 import (
-	"encoding/json"
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,13 +27,13 @@ func TestStateMarshalUnmarshal(t *testing.T) {
 	assert.NoError(t, state.UpdateAppHash(state, nil, nil))
 	apphash := state.GetAppHash()
 
-	encoded, err := json.MarshalIndent(state, "", "   ")
+	encoded := bytes.NewBuffer(nil)
+	err := state.Save(encoded)
 	require.NoError(t, err)
 	assert.NotEmpty(t, encoded)
-	t.Log(string(encoded))
 
 	decoded := NewKvState(dbm.NewMemDB(), 1)
-	err = json.Unmarshal(encoded, &decoded)
+	err = decoded.Load(encoded)
 	require.NoError(t, err)
 
 	v1, err := decoded.Get([]byte("key1"))
@@ -44,14 +44,14 @@ func TestStateMarshalUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, []byte("value2"), v2)
 
-	v3, err := decoded.Get([]byte("key2"))
+	v3, err := decoded.Get(key3)
 	require.NoError(t, err)
-	assert.EqualValues(t, []byte("value2"), v3)
+	assert.EqualValues(t, value3, v3)
 
 	assert.EqualValues(t, apphash, decoded.GetAppHash())
 }
 
-func TestStateUnmarshal(t *testing.T) {
+func TestStateLoad(t *testing.T) {
 	const initialHeight = 12345678
 	zeroAppHash := make(tmbytes.HexBytes, crypto.DefaultAppHashSize)
 	type keyVals struct {
@@ -89,11 +89,10 @@ func TestStateUnmarshal(t *testing.T) {
 			name: "full",
 			encoded: []byte(`{
 				"height": 6531,
-				"app_hash": "1C9ECEC90E28D2461650418635878A5C91E49F47586ECF75F2B0CBB94E897112",
-				"items": {
-				   "key1": "value1",
-				   "key2": "value2"
-				}}`),
+				"app_hash": "1C9ECEC90E28D2461650418635878A5C91E49F47586ECF75F2B0CBB94E897112"
+			}
+			{"key":"a2V5MQ==","value":"dmFsdWUx"}
+			{"key":"a2V5Mg==","value":"dmFsdWUy"}`),
 			expectHeight:  6531,
 			expectAppHash: tmbytes.MustHexDecode("1C9ECEC90E28D2461650418635878A5C91E49F47586ECF75F2B0CBB94E897112"),
 			expectKeyVals: []keyVals{
@@ -106,7 +105,7 @@ func TestStateUnmarshal(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			decoded := NewKvState(dbm.NewMemDB(), initialHeight)
-			err := json.Unmarshal(tc.encoded, &decoded)
+			err := decoded.Load(bytes.NewBuffer(tc.encoded))
 			if tc.expectDecodeError {
 				require.Error(t, err, "decode error expected")
 			} else {

--- a/abci/example/kvstore/tx.go
+++ b/abci/example/kvstore/tx.go
@@ -119,7 +119,7 @@ func execTx(tx types.Tx, roundState State) (abci.ExecTxResult, error) {
 
 // execPrepareTx is noop. tx data is considered as placeholder
 // and is substitute at the PrepareProposal.
-func execPrepareTx(_tx []byte) (abci.ExecTxResult, error) {
+func execPrepareTx(_ []byte) (abci.ExecTxResult, error) {
 	// noop
 	return abci.ExecTxResult{}, nil
 }

--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -658,7 +658,7 @@ func TestReactor_Backfill(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	const (

--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -658,7 +658,7 @@ func TestReactor_Backfill(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	const (

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"sort"
 	"strings"
 	"time"
 
-	"github.com/dashpay/tenderdash/abci/example/kvstore"
 	e2e "github.com/dashpay/tenderdash/test/e2e/pkg"
 	"github.com/dashpay/tenderdash/types"
 )
@@ -20,7 +18,11 @@ var (
 		"topology": {"single", "quad", "large"},
 		"initialState": {
 			"{}",
-			`{"items": {"initial01": "a", "initial02": "b", "initial03": "c"}}`,
+			`{}
+			{"key":"initial01","value": "a"}
+			{"key":"initial02","value":"b"}
+			{"key":"initial03","value":"c"}
+			`,
 		},
 
 		"validators": {"genesis", "initchain"},
@@ -113,13 +115,8 @@ type Options struct {
 
 // generateTestnet generates a single testnet with the given options.
 func generateTestnet(r *rand.Rand, opt map[string]interface{}) (e2e.Manifest, error) {
-	initialState := kvstore.StateExport{}
-	if opt["initialState"] != nil {
-		data := opt["initialState"].(string)
-		if err := json.Unmarshal([]byte(data), &initialState); err != nil {
-			return e2e.Manifest{}, fmt.Errorf("unmarshal initialState: %w", err)
-		}
-	}
+	initialState := opt["initialState"].(string)
+
 	manifest := e2e.Manifest{
 		IPv6:             ipv6.Choose(r).(bool),
 		InitialState:     initialState,

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -19,7 +19,7 @@ var (
 		"initialState": {
 			"{}",
 			`{}
-			{"key":"initial01","value": "a"}
+			{"key":"initial01","value":"a"}
 			{"key":"initial02","value":"b"}
 			{"key":"initial03","value":"c"}
 			`,

--- a/test/e2e/networks/dashcore.toml
+++ b/test/e2e/networks/dashcore.toml
@@ -2,7 +2,7 @@
 # functionality with a single network.
 
 initial_height = 1000
-initial_state = { items = { initial01 = "a", initial02 = "b", initial03 = "c" } }
+initial_state = '{} { "key":"initial01","value":"a"}{"key":"initial02","value":"b"}{"key":"initial03","value":"c"}'
 initial_core_chain_locked_height = 3400
 queue_type = "priority"
 log_level = "debug"

--- a/test/e2e/networks/dashcore.toml
+++ b/test/e2e/networks/dashcore.toml
@@ -7,9 +7,9 @@ initial_core_chain_locked_height = 3400
 queue_type = "priority"
 log_level = "debug"
 
-
-max_block_size = 1048576   # 1 MB
-max_evidence_size = 102400 # 100 kB
+# Tune block size for TestApp_TxTooBig
+max_block_size = 262144   # 0.25 MB
+max_evidence_size = 52428 # 50 kB
 
 [chainlock_updates]
 1000 = 3450

--- a/test/e2e/networks/rotate.toml
+++ b/test/e2e/networks/rotate.toml
@@ -2,9 +2,9 @@
 # functionality with a single network.
 
 initial_height = 1000
-initial_state = { items = { initial01 = "a", initial02 = "b", initial03 = "c" } }
+initial_state = '{}{ "key": "initial01","value":"a"} {"key":"initial02","value":"b"} {"key":"initial03" ,"value":"c" }'
 initial_core_chain_locked_height = 3400
-init_app_core_chain_locked_height = 2308                                          # should override initial_core_chain_locked_height
+init_app_core_chain_locked_height = 2308                                                                                # should override initial_core_chain_locked_height
 queue_type = "priority"
 log_level = "debug"
 

--- a/test/e2e/networks/rotate.toml
+++ b/test/e2e/networks/rotate.toml
@@ -8,8 +8,9 @@ init_app_core_chain_locked_height = 2308                                        
 queue_type = "priority"
 log_level = "debug"
 
-max_block_size = 1048576   # 1 MB
-max_evidence_size = 102400 # 100 kB
+# Tune block size for TestApp_TxTooBig
+max_block_size = 262144   # 0.25 MB
+max_evidence_size = 52428 # 50 kB
 
 [chainlock_updates]
 1000 = 3450

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-
-	"github.com/dashpay/tenderdash/abci/example/kvstore"
 )
 
 // Manifest represents a TOML testnet manifest.
@@ -31,7 +29,7 @@ type Manifest struct {
 
 	// InitialState is an initial set of key/value pairs for the application,
 	// set in genesis. Defaults to nothing.
-	InitialState kvstore.StateExport `toml:"initial_state"`
+	InitialState string `toml:"initial_state"`
 
 	// Validators is the initial validator set in genesis, given as node names
 	// and power (for Dash power must all be set to default power):

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/dashpay/dashd-go/btcjson"
 
-	"github.com/dashpay/tenderdash/abci/example/kvstore"
 	abci "github.com/dashpay/tenderdash/abci/types"
 	"github.com/dashpay/tenderdash/crypto"
 	"github.com/dashpay/tenderdash/crypto/bls12381"
@@ -77,7 +76,7 @@ type Testnet struct {
 	Dir                    string
 	IP                     *net.IPNet
 	InitialHeight          int64
-	InitialState           kvstore.StateExport
+	InitialState           string
 	Validators             ValidatorsMap
 	ValidatorUpdates       map[int64]ValidatorsMap
 	Nodes                  []*Node

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -202,13 +201,9 @@ func MakeGenesis(testnet *e2e.Testnet, genesisTime time.Time) (types.GenesisDoc,
 	sort.Slice(genesis.Validators, func(i, j int) bool {
 		return strings.Compare(genesis.Validators[i].Name, genesis.Validators[j].Name) == -1
 	})
-	if len(testnet.InitialState.Items) > 0 {
-		appState, err := json.Marshal(testnet.InitialState)
-		if err != nil {
-			return genesis, err
-		}
-		genesis.AppState = appState
-	}
+
+	genesis.AppState = []byte(testnet.InitialState)
+
 	return genesis, genesis.ValidateAndComplete()
 }
 

--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -223,8 +223,6 @@ func TestApp_TxTooBig(t *testing.T) {
 	mainCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	t.Helper()
-
 	testnet := loadTestnet(t)
 	nodes := testnet.Nodes
 
@@ -238,12 +236,13 @@ func TestApp_TxTooBig(t *testing.T) {
 		})
 	}
 
-	// we will use last client to check if txs were included in block
+	// we will use last client to check if txs were included in block, so we
+	// define it outside the loop
 	var client *http.HTTP
 	outcome := make([]txPair, 0, len(nodes))
 
 	start := time.Now()
-	/// First we broadcast to all nodes
+	/// Send to each node more txs than we can fit into block
 	for _, node := range nodes {
 		ctx, cancel := context.WithTimeout(mainCtx, broadcastTimeout)
 		defer cancel()

--- a/types/genesis.go
+++ b/types/genesis.go
@@ -75,7 +75,7 @@ type GenesisDoc struct {
 	ConsensusParams *ConsensusParams
 	Validators      []GenesisValidator
 	AppHash         tmbytes.HexBytes
-	AppState        json.RawMessage
+	AppState        []byte
 
 	// dash fields
 	InitialCoreChainLockedHeight uint32                 `json:"initial_core_chain_locked_height"`
@@ -92,7 +92,7 @@ type genesisDocJSON struct {
 	ConsensusParams *ConsensusParams   `json:"consensus_params,omitempty"`
 	Validators      []GenesisValidator `json:"validators,omitempty"`
 	AppHash         tmbytes.HexBytes   `json:"app_hash,omitempty"`
-	AppState        json.RawMessage    `json:"app_state,omitempty"`
+	AppState        []byte             `json:"app_state,omitempty"`
 
 	// dash fields
 	InitialCoreChainLockedHeight uint32                 `json:"initial_core_chain_locked_height,omitempty"`

--- a/types/genesis_test.go
+++ b/types/genesis_test.go
@@ -2,6 +2,7 @@
 package types
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -202,7 +203,8 @@ func TestGenesisCorrect(t *testing.T) {
 
 func TestBasicGenesisDoc(t *testing.T) {
 	// test a good one by raw json
-	genDocBytes := []byte(
+	appState := base64.StdEncoding.AppendEncode(nil, []byte(`{"account_owner": "Bob"}`))
+	genDocBytes := []byte(fmt.Sprintf(
 		`{
 			"genesis_time": "0001-01-01T00:00:00Z",
 			"chain_id": "test-chain-QDKdJr",
@@ -222,7 +224,7 @@ func TestBasicGenesisDoc(t *testing.T) {
 			"validator_quorum_hash":"43FF39CC1F41B9FC63DFA5B1EDF3F0CA3AD5CAFAE4B12B4FE9263B08BB50C4CC",
 			"validator_quorum_type":100,
 			"app_hash":"",
-			"app_state":{"account_owner": "Bob"},
+			"app_state":"%s",
 			"consensus_params": {
 				"synchrony":  {"precision": "1", "message_delay": "10"},
 				"timeout": {
@@ -237,8 +239,8 @@ func TestBasicGenesisDoc(t *testing.T) {
 				"block": {"max_bytes": "100"},
 				"evidence": {"max_age_num_blocks": "100", "max_age_duration": "10"}
 			}
-		}`,
-	)
+		}`, appState,
+	))
 	_, err := GenesisDocFromJSON(genDocBytes)
 	assert.NoError(t, err, "expected no error for good genDoc json")
 

--- a/types/vote_extension.go
+++ b/types/vote_extension.go
@@ -482,10 +482,7 @@ func (e ThresholdRawVoteExtension) SignItem(_ string, height int64, round int32,
 	// that reversal.
 	msgHash := tmbytes.Reverse(ext.Extension)
 
-	signItem, err := NewSignItemFromHash(quorumType, quorumHash, signRequestID, msgHash), nil
-	if err != nil {
-		return SignItem{}, err
-	}
+	signItem := NewSignItemFromHash(quorumType, quorumHash, signRequestID, msgHash)
 	// signItem.Msg left empty by purpose, as we don't want hash to be checked in Verify()
 
 	return signItem, nil


### PR DESCRIPTION
## Issue being fixed or feature implemented

TestApp_TxTooBig fails in GHA pipelines due to long execution time.
It is caused by JSON serialization within example kvstore application, which consumes significant amount of time and memory.

## What was done?

1. Instead of running the test on each node one by one, broadcast txs to all nodes first, and then check results in separate loop.
2. Refactored kvstore to use streaming JSON serialization and deserialization when saving/restoring state.
3. Changed `GenesisDoc.AppState` to `[]byte`
4. Updated e2e to use new format of initial app state
5. In e2e dashcore and rotate networks, decreased block size and evidence size to consume less resources during test

## How Has This Been Tested?

GHA

## Breaking Changes

Genesis doc AppState MUST be a base64-encoded bytes array, not JSON string.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
