### PR TITLE
fix(libs): go-deadlock slows down clist

### DIFF
--- a/internal/libs/clist/clist.go
+++ b/internal/libs/clist/clist.go
@@ -14,7 +14,8 @@ to ensure garbage collection of removed elements.
 import (
 	"fmt"
 
-	sync "github.com/sasha-s/go-deadlock"
+	// This is performance-critical code, so we don't use go-deadlock
+	"sync"
 )
 
 // MaxLength is the max allowed number of elements a linked list is


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Under load, Tenderdash slows down significantly due to expensive logic inside go-deadlock, used in clist object.

go-deadlock processes backtrace, with takes much resources.


## What was done?

go-deadlock not used in clist library


## How Has This Been Tested?

Tested during performance tests and tuning of Dash Drive.

## Breaking Changes

None 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
