### PR TITLE
feat(abciclient): support timeouts in abci calls

### DIFF
--- a/abci/client/client.go
+++ b/abci/client/client.go
@@ -53,14 +53,17 @@ type requestAndResponse struct {
 	*types.Request
 	*types.Response
 
-	mtx    sync.Mutex
+	mtx sync.Mutex
+	// context for the request; we check if it's not expired before sending
+	ctx    context.Context
 	signal chan struct{}
 }
 
-func makeReqRes(req *types.Request) *requestAndResponse {
+func makeReqRes(ctx context.Context, req *types.Request) *requestAndResponse {
 	return &requestAndResponse{
 		Request:  req,
 		Response: nil,
+		ctx:      ctx,
 		signal:   make(chan struct{}),
 	}
 }

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -265,7 +265,7 @@ func (cli *socketClient) drainQueue() {
 	cli.mtx.Lock()
 	defer cli.mtx.Unlock()
 
-	cli.reqQueue = make(chan *requestAndResponse, RequestQueueSize)
+	cli.reqQueue = make(chan *requestAndResponse)
 	// mark all in-flight messages as resolved (they will get cli.Error())
 	for req := cli.reqSent.Front(); req != nil; req = req.Next() {
 		reqres := req.Value.(*requestAndResponse)

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -265,7 +265,6 @@ func (cli *socketClient) drainQueue() {
 	cli.mtx.Lock()
 	defer cli.mtx.Unlock()
 
-	cli.reqQueue = make(chan *requestAndResponse)
 	// mark all in-flight messages as resolved (they will get cli.Error())
 	for req := cli.reqSent.Front(); req != nil; req = req.Next() {
 		reqres := req.Value.(*requestAndResponse)

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -13,15 +13,9 @@ import (
 	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dashpay/tenderdash/abci/types"
-	tmsync "github.com/dashpay/tenderdash/internal/libs/sync"
 	"github.com/dashpay/tenderdash/libs/log"
 	tmnet "github.com/dashpay/tenderdash/libs/net"
 	"github.com/dashpay/tenderdash/libs/service"
-)
-
-const (
-	// Maximum number of requests stored in the request queue
-	RequestQueueSize = 1
 )
 
 // This is goroutine-safe, but users should beware that the application in
@@ -36,8 +30,6 @@ type socketClient struct {
 
 	// Requests queue
 	reqQueue chan *requestAndResponse
-	// Wake up sender when new request is added to the queue.
-	reqWaker *tmsync.Waker
 
 	mtx     sync.Mutex
 	err     error
@@ -52,8 +44,7 @@ var _ Client = (*socketClient)(nil)
 func NewSocketClient(logger log.Logger, addr string, mustConnect bool) Client {
 	cli := &socketClient{
 		logger:   logger,
-		reqQueue: make(chan *requestAndResponse, RequestQueueSize),
-		reqWaker: tmsync.NewWaker(),
+		reqQueue: make(chan *requestAndResponse),
 
 		mustConnect: mustConnect,
 		addr:        addr,
@@ -129,20 +120,19 @@ func (cli *socketClient) Error() error {
 
 // Add the request to the pending messages queue.
 //
-// Note that you still need to wake up sendRequestsRoutine writing to `cli.reqSignal`
+// If the context `ctx` is canceled, return ctx.Err().
 func (cli *socketClient) enqueue(ctx context.Context, reqres *requestAndResponse) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-reqres.ctx.Done():
-		return reqres.ctx.Err()
 	case cli.reqQueue <- reqres:
 		return nil
 	}
 }
 
-// Remove the first request from the queue and return it.
-// If the context is canceled, return nil.
+// Block until first request arrives, then return it.
+//
+// If the context `ctx` is canceled, return nil.
 func (cli *socketClient) dequeue(ctx context.Context) *requestAndResponse {
 	select {
 	case item := <-cli.reqQueue:
@@ -155,13 +145,7 @@ func (cli *socketClient) dequeue(ctx context.Context) *requestAndResponse {
 func (cli *socketClient) sendRequestsRoutine(ctx context.Context, conn io.Writer) {
 	bw := bufio.NewWriter(conn)
 	for {
-		// wait for new message to arrive
-		select {
-		case <-ctx.Done():
-			return
-		case <-cli.reqSleep():
-		}
-
+		// dequeue will block until a message arrives
 		for reqres := cli.dequeue(ctx); reqres != nil; reqres = cli.dequeue(ctx) {
 			if err := reqres.ctx.Err(); err != nil {
 				// request expired, skip it
@@ -260,9 +244,6 @@ func (cli *socketClient) doRequest(ctx context.Context, req *types.Request) (*ty
 		return nil, err
 	}
 
-	// Asynchronously wake up the sender.
-	cli.reqWake()
-
 	// wait for response for our request
 	select {
 	case <-reqres.ctx.Done():
@@ -284,31 +265,12 @@ func (cli *socketClient) drainQueue() {
 	cli.mtx.Lock()
 	defer cli.mtx.Unlock()
 
-	if err := cli.reqWaker.Close(); err != nil {
-		cli.logger.Debug("abci.socketClient failed to close waker", "err", err)
-	}
-	cli.reqWaker = tmsync.NewWaker()
-
 	cli.reqQueue = make(chan *requestAndResponse, RequestQueueSize)
 	// mark all in-flight messages as resolved (they will get cli.Error())
 	for req := cli.reqSent.Front(); req != nil; req = req.Next() {
 		reqres := req.Value.(*requestAndResponse)
 		reqres.markDone()
 	}
-}
-
-func (cli *socketClient) reqWake() {
-	cli.mtx.Lock()
-	defer cli.mtx.Unlock()
-
-	cli.reqWaker.Wake()
-}
-
-func (cli *socketClient) reqSleep() <-chan struct{} {
-	cli.mtx.Lock()
-	defer cli.mtx.Unlock()
-
-	return cli.reqWaker.Sleep()
 }
 
 //----------------------------------------

--- a/abci/client/socket_client_test.go
+++ b/abci/client/socket_client_test.go
@@ -1,0 +1,120 @@
+package abciclient
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dashpay/tenderdash/abci/server"
+	"github.com/dashpay/tenderdash/abci/types"
+	"github.com/dashpay/tenderdash/abci/types/mocks"
+	"github.com/dashpay/tenderdash/libs/log"
+)
+
+// TestSocketClientTimeout tests that the socket client times out correctly.
+func TestSocketClientTimeout(t *testing.T) {
+	const (
+		Success              = 0
+		FailDuringEnqueue    = 1
+		FailDuringProcessing = 2
+
+		baseTime = 10 * time.Millisecond
+	)
+	type testCase struct {
+		name            string
+		timeout         time.Duration
+		enqueueSleep    time.Duration
+		processingSleep time.Duration
+		expect          int
+	}
+	testCases := []testCase{
+		{name: "immediate", timeout: baseTime, enqueueSleep: 0, processingSleep: 0, expect: Success},
+		{name: "small enqueue delay", timeout: 4 * baseTime, enqueueSleep: 1 * baseTime, processingSleep: 0, expect: Success},
+		{name: "small processing delay", timeout: 4 * baseTime, enqueueSleep: 0, processingSleep: 1 * baseTime, expect: Success},
+		{name: "within timeout", timeout: 4 * baseTime, enqueueSleep: 1 * baseTime, processingSleep: 1 * baseTime, expect: Success},
+		{name: "timeout during enqueue", timeout: 3 * baseTime, enqueueSleep: 4 * baseTime, processingSleep: 1 * baseTime, expect: FailDuringEnqueue},
+		{name: "timeout during processing", timeout: 4 * baseTime, enqueueSleep: 1 * baseTime, processingSleep: 4 * baseTime, expect: FailDuringProcessing},
+	}
+
+	logger := log.NewTestingLogger(t)
+
+	for i, tc := range testCases {
+		i := i
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			// wait until all threads end, otherwise we'll get data race in t.Log()
+			wg := sync.WaitGroup{}
+			defer wg.Wait()
+
+			mainCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			socket := "unix://" + t.TempDir() + "/socket." + strconv.Itoa(i)
+
+			checkTxExecuted := atomic.Bool{}
+
+			app := mocks.NewApplication(t)
+			app.On("Echo", mock.Anything, mock.Anything).Return(&types.ResponseEcho{}, nil).Maybe()
+			app.On("Info", mock.Anything, mock.Anything).Run(func(_ mock.Arguments) {
+				wg.Add(1)
+				logger.Debug("Info before sleep")
+				time.Sleep(tc.enqueueSleep)
+				logger.Debug("Info after sleep")
+				wg.Done()
+			}).Return(&types.ResponseInfo{}, nil).Maybe()
+			app.On("CheckTx", mock.Anything, mock.Anything).Run(func(_ mock.Arguments) {
+				wg.Add(1)
+				logger.Debug("CheckTx before sleep")
+				checkTxExecuted.Store(true)
+				time.Sleep(tc.processingSleep)
+				logger.Debug("CheckTx after sleep")
+				wg.Done()
+			}).Return(&types.ResponseCheckTx{}, nil).Maybe()
+
+			service, err := server.NewServer(logger, socket, "socket", app)
+			require.NoError(t, err)
+			svr := service.(*server.SocketServer)
+			err = svr.Start(mainCtx)
+			require.NoError(t, err)
+			defer svr.Stop()
+
+			cli := NewSocketClient(logger, socket, true).(*socketClient)
+
+			err = cli.Start(mainCtx)
+			require.NoError(t, err)
+			defer cli.Stop()
+
+			reqCtx, reqCancel := context.WithTimeout(context.Background(), tc.timeout)
+			defer reqCancel()
+			// Info is here just to block for some time, so we don't want to enforce timeout on it
+
+			wg.Add(1)
+			go func() {
+				_, _ = cli.Info(mainCtx, &types.RequestInfo{})
+				wg.Done()
+			}()
+
+			time.Sleep(1 * time.Millisecond) // ensure the goroutine has started
+
+			_, err = cli.CheckTx(reqCtx, &types.RequestCheckTx{})
+			switch tc.expect {
+			case Success:
+				require.NoError(t, err)
+				require.True(t, checkTxExecuted.Load())
+			case FailDuringEnqueue:
+				require.Error(t, err)
+				require.False(t, checkTxExecuted.Load())
+			case FailDuringProcessing:
+				require.Error(t, err)
+				require.True(t, checkTxExecuted.Load())
+			}
+		})
+	}
+}

--- a/internal/mempool/p2p_msg_handler.go
+++ b/internal/mempool/p2p_msg_handler.go
@@ -13,6 +13,12 @@ import (
 	"github.com/dashpay/tenderdash/types"
 )
 
+const (
+	// CheckTxTimeout is the maximum time we wait for CheckTx to return.
+	// TODO: Change to config option
+	CheckTxTimeout = 1 * time.Second
+)
+
 type (
 	mempoolP2PMessageHandler struct {
 		logger  log.Logger
@@ -54,8 +60,7 @@ func (h *mempoolP2PMessageHandler) Handle(ctx context.Context, _ *client.Client,
 		SenderNodeID: envelope.From,
 	}
 	for _, tx := range protoTxs {
-		// TODO add configuration for timeout
-		subCtx, subCtxCancel := context.WithTimeout(ctx, 1*time.Second)
+		subCtx, subCtxCancel := context.WithTimeout(ctx, CheckTxTimeout)
 		defer subCtxCancel()
 
 		if err := h.checker.CheckTx(subCtx, tx, nil, txInfo); err != nil {

--- a/internal/mempool/p2p_msg_handler.go
+++ b/internal/mempool/p2p_msg_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/dashpay/tenderdash/internal/p2p"
 	"github.com/dashpay/tenderdash/internal/p2p/client"
@@ -53,7 +54,10 @@ func (h *mempoolP2PMessageHandler) Handle(ctx context.Context, _ *client.Client,
 		SenderNodeID: envelope.From,
 	}
 	for _, tx := range protoTxs {
-		if err := h.checker.CheckTx(ctx, tx, nil, txInfo); err != nil {
+		subCtx, subCtxCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer subCtxCancel()
+
+		if err := h.checker.CheckTx(subCtx, tx, nil, txInfo); err != nil {
 			if errors.Is(err, types.ErrTxInCache) {
 				// if the tx is in the cache,
 				// then we've been gossiped a
@@ -63,13 +67,11 @@ func (h *mempoolP2PMessageHandler) Handle(ctx context.Context, _ *client.Client,
 				// problem.
 				continue
 			}
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				// Do not propagate context
-				// cancellation errors, but do
-				// not continue to check
-				// transactions from this
-				// message if we are shutting down.
-				return err
+
+			// In case of ctx cancelation, we return error as we are most likely shutting down.
+			// Otherwise we just reject the tx.
+			if errCtx := ctx.Err(); errCtx != nil {
+				return errCtx
 			}
 			logger.Error("checktx failed for tx",
 				"tx", fmt.Sprintf("%X", types.Tx(tx).Hash()),

--- a/internal/mempool/p2p_msg_handler.go
+++ b/internal/mempool/p2p_msg_handler.go
@@ -54,7 +54,8 @@ func (h *mempoolP2PMessageHandler) Handle(ctx context.Context, _ *client.Client,
 		SenderNodeID: envelope.From,
 	}
 	for _, tx := range protoTxs {
-		subCtx, subCtxCancel := context.WithTimeout(ctx, 5*time.Second)
+		// TODO add configuration for timeout
+		subCtx, subCtxCancel := context.WithTimeout(ctx, 1*time.Second)
 		defer subCtxCancel()
 
 		if err := h.checker.CheckTx(subCtx, tx, nil, txInfo); err != nil {

--- a/internal/p2p/client/client.go
+++ b/internal/p2p/client/client.go
@@ -224,10 +224,15 @@ func (c *Client) GetSyncStatus(ctx context.Context) error {
 }
 
 // SendTxs sends a transaction to the peer
-func (c *Client) SendTxs(ctx context.Context, peerID types.NodeID, tx types.Tx) error {
+func (c *Client) SendTxs(ctx context.Context, peerID types.NodeID, tx ...types.Tx) error {
+	txs := make([][]byte, len(tx))
+	for i := 0; i < len(tx); i++ {
+		txs[i] = tx[i]
+	}
+
 	return c.Send(ctx, p2p.Envelope{
 		To:      peerID,
-		Message: &protomem.Txs{Txs: [][]byte{tx}},
+		Message: &protomem.Txs{Txs: txs},
 	})
 }
 

--- a/internal/rpc/core/mempool.go
+++ b/internal/rpc/core/mempool.go
@@ -23,6 +23,9 @@ import (
 // https://docs.tendermint.com/master/rpc/#/Tx/broadcast_tx_async
 // Deprecated and should be removed in 0.37
 func (env *Environment) BroadcastTxAsync(ctx context.Context, req *coretypes.RequestBroadcastTx) (*coretypes.ResultBroadcastTx, error) {
+	ctx, cancel := context.WithTimeout(ctx, mempool.CheckTxTimeout)
+	defer cancel()
+
 	go func() { _ = env.Mempool.CheckTx(ctx, req.Tx, nil, mempool.TxInfo{}) }()
 
 	return &coretypes.ResultBroadcastTx{Hash: req.Tx.Hash()}, nil
@@ -37,7 +40,7 @@ func (env *Environment) BroadcastTxSync(ctx context.Context, req *coretypes.Requ
 // DeliverTx result.
 // More: https://docs.tendermint.com/master/rpc/#/Tx/broadcast_tx_sync
 func (env *Environment) BroadcastTx(ctx context.Context, req *coretypes.RequestBroadcastTx) (*coretypes.ResultBroadcastTx, error) {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, mempool.CheckTxTimeout)
 	defer cancel()
 
 	resCh := make(chan *abci.ResponseCheckTx, 1)

--- a/internal/rpc/core/mempool.go
+++ b/internal/rpc/core/mempool.go
@@ -37,6 +37,9 @@ func (env *Environment) BroadcastTxSync(ctx context.Context, req *coretypes.Requ
 // DeliverTx result.
 // More: https://docs.tendermint.com/master/rpc/#/Tx/broadcast_tx_sync
 func (env *Environment) BroadcastTx(ctx context.Context, req *coretypes.RequestBroadcastTx) (*coretypes.ResultBroadcastTx, error) {
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+
 	resCh := make(chan *abci.ResponseCheckTx, 1)
 	err := env.Mempool.CheckTx(
 		ctx,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Some transactions, like CheckTx, should time out if not processed within some reasonable time period. 
This helps avoid system overload.


## What was done?

In ABCI Socket Client, added a context which is checked before sending message. If message was waiting too long in a queue and context expired, error is returned.

CheckTX in gRPC (*BroadcastTx) and p2p was limited to 1 second.

## How Has This Been Tested?

GHA + testing on devnet.

## Breaking Changes

Some GRPC and P2P requests can return context canceled error.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
