### PR TITLE
feat(config): allow configuration of check TX timeout for rpc and p2p tx broadcast

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -517,6 +517,13 @@ type RPCConfig struct {
 	// See https://github.com/tendermint/tendermint/issues/3435
 	TimeoutBroadcastTxCommit time.Duration `mapstructure:"timeout-broadcast-tx-commit"`
 
+	// Timeout of transaction broadcast to mempool; 0 to disable.
+	//
+	// This setting affects timeout of CheckTX operations used before
+	// adding transaction to the mempool. If the operation takes longer,
+	// the transaction is rejected with an error.
+	TimeoutBroadcastTx time.Duration `mapstructure:"timeout-broadcast-tx"`
+
 	// Maximum size of request body, in bytes
 	MaxBodyBytes int64 `mapstructure:"max-body-bytes"`
 
@@ -564,6 +571,7 @@ func DefaultRPCConfig() *RPCConfig {
 		EventLogMaxItems:             0,
 
 		TimeoutBroadcastTxCommit: 10 * time.Second,
+		TimeoutBroadcastTx:       0,
 
 		MaxBodyBytes:   int64(1000000), // 1MB
 		MaxHeaderBytes: 1 << 20,        // same as the net/http default
@@ -601,6 +609,9 @@ func (cfg *RPCConfig) ValidateBasic() error {
 	}
 	if cfg.TimeoutBroadcastTxCommit < 0 {
 		return errors.New("timeout-broadcast-tx-commit can't be negative")
+	}
+	if cfg.TimeoutBroadcastTx < 0 {
+		return errors.New("timeout-broadcast-tx can't be negative")
 	}
 	if cfg.MaxBodyBytes < 0 {
 		return errors.New("max-body-bytes can't be negative")

--- a/config/config.go
+++ b/config/config.go
@@ -830,6 +830,10 @@ type MempoolConfig struct {
 	// has existed in the mempool at least TTLNumBlocks number of blocks or if
 	// it's insertion time into the mempool is beyond TTLDuration.
 	TTLNumBlocks int64 `mapstructure:"ttl-num-blocks"`
+
+	// Timeout of check TX operations received from other nodes.
+	// Use 0 to disable.
+	TimeoutCheckTx time.Duration `mapstructure:"timeout-check-tx"`
 }
 
 // DefaultMempoolConfig returns a default configuration for the Tendermint mempool.
@@ -838,12 +842,13 @@ func DefaultMempoolConfig() *MempoolConfig {
 		Broadcast: true,
 		// Each signature verification takes .5ms, Size reduced until we implement
 		// ABCI Recheck
-		Size:         5000,
-		MaxTxsBytes:  1024 * 1024 * 1024, // 1GB
-		CacheSize:    10000,
-		MaxTxBytes:   1024 * 1024, // 1MB
-		TTLDuration:  0 * time.Second,
-		TTLNumBlocks: 0,
+		Size:           5000,
+		MaxTxsBytes:    1024 * 1024 * 1024, // 1GB
+		CacheSize:      10000,
+		MaxTxBytes:     1024 * 1024, // 1MB
+		TTLDuration:    0 * time.Second,
+		TTLNumBlocks:   0,
+		TimeoutCheckTx: 0,
 	}
 }
 
@@ -874,6 +879,9 @@ func (cfg *MempoolConfig) ValidateBasic() error {
 	}
 	if cfg.TTLNumBlocks < 0 {
 		return errors.New("ttl-num-blocks can't be negative")
+	}
+	if cfg.TimeoutCheckTx < 0 {
+		return errors.New("timeout-check-tx can't be negative")
 	}
 	return nil
 }

--- a/config/toml.go
+++ b/config/toml.go
@@ -433,6 +433,10 @@ ttl-duration = "{{ .Mempool.TTLDuration }}"
 # it's insertion time into the mempool is beyond ttl-duration.
 ttl-num-blocks = {{ .Mempool.TTLNumBlocks }}
 
+// Timeout of check TX operations received from other nodes, using p2p protocol.
+// Use 0 to disable.
+timeout-check-tx = "{{ .Mempool.TimeoutCheckTx }}"
+
 #######################################################
 ###         State Sync Configuration Options        ###
 #######################################################

--- a/config/toml.go
+++ b/config/toml.go
@@ -433,8 +433,8 @@ ttl-duration = "{{ .Mempool.TTLDuration }}"
 # it's insertion time into the mempool is beyond ttl-duration.
 ttl-num-blocks = {{ .Mempool.TTLNumBlocks }}
 
-// Timeout of check TX operations received from other nodes, using p2p protocol.
-// Use 0 to disable.
+# Timeout of check TX operations received from other nodes, using p2p protocol.
+# Use 0 to disable.
 timeout-check-tx = "{{ .Mempool.TimeoutCheckTx }}"
 
 #######################################################

--- a/config/toml.go
+++ b/config/toml.go
@@ -273,6 +273,13 @@ event-log-max-items = {{ .RPC.EventLogMaxItems }}
 # See https://github.com/tendermint/tendermint/issues/3435
 timeout-broadcast-tx-commit = "{{ .RPC.TimeoutBroadcastTxCommit }}"
 
+# Timeout of transaction broadcast to mempool; 0 to disable.
+#
+# This setting affects timeout of CheckTX operations used before
+# adding transaction to the mempool. If the operation takes longer,
+# the transaction is rejected with an error.
+timeout-broadcast-tx = "{{ .RPC.TimeoutBroadcastTx }}"
+
 # Maximum size of request body, in bytes
 max-body-bytes = {{ .RPC.MaxBodyBytes }}
 

--- a/internal/mempool/p2p_msg_handler_test.go
+++ b/internal/mempool/p2p_msg_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	abcitypes "github.com/dashpay/tenderdash/abci/types"
+	"github.com/dashpay/tenderdash/config"
 	"github.com/dashpay/tenderdash/internal/p2p"
 	tmrequire "github.com/dashpay/tenderdash/internal/test/require"
 	"github.com/dashpay/tenderdash/libs/log"
@@ -18,6 +19,7 @@ import (
 func TestMempoolP2PMessageHandler(t *testing.T) {
 	ctx := context.Background()
 	logger := log.NewTestingLogger(t)
+	cfg := config.DefaultMempoolConfig()
 	peerID1 := types.NodeID("peer1")
 	ids := NewMempoolIDs()
 	ids.ReserveForPeer(peerID1)
@@ -69,6 +71,7 @@ func TestMempoolP2PMessageHandler(t *testing.T) {
 				logger:  logger,
 				checker: mockTxChecker,
 				ids:     ids,
+				config:  cfg,
 			}
 			err := hd.Handle(ctx, nil, &tc.envelope)
 			tmrequire.Error(t, tc.wantErr, err)

--- a/internal/mempool/reactor.go
+++ b/internal/mempool/reactor.go
@@ -74,7 +74,7 @@ func (r *Reactor) OnStart(ctx context.Context) error {
 		r.logger.Info("tx broadcasting is disabled")
 	}
 	go func() {
-		err := r.p2pClient.Consume(ctx, consumerHandler(r.logger, r.mempool, r.ids))
+		err := r.p2pClient.Consume(ctx, consumerHandler(r.logger, r.mempool.config, r.mempool, r.ids))
 		if err != nil {
 			r.logger.Error("failed to consume p2p checker messages", "error", err)
 		}


### PR DESCRIPTION
## Issue being fixed or feature implemented

In #749 , we introduced timeout for CheckTx operation and hardcoded it to 1 second. 
In this PR, we add option to define this timeout in config file.

## What was done?

Added `[mempool].timeout-check-tx` and `[rpc].timeout-broadcast-tx` to config file. Defaults to 0 what means "disabled" (no timeout).

## How Has This Been Tested?

Not tested yet :) 

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
