### PR TITLE
refactor(config)!: remove deprecated timeouts from config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1049,20 +1049,6 @@ type ConsensusConfig struct {
 	// If it is set to true, the consensus engine will proceed to the next height
 	// as soon as the node has gathered votes from all of the validators on the network.
 	UnsafeBypassCommitTimeoutOverride *bool `mapstructure:"unsafe-bypass-commit-timeout-override"`
-
-	// Deprecated timeout parameters. These parameters are present in this struct
-	// so that they can be parsed so that validation can check if they have erroneously
-	// been included and provide a helpful error message.
-	// These fields should be completely removed in v0.37.
-	// See: https://github.com/tendermint/tendermint/issues/8188
-	DeprecatedTimeoutPropose        *interface{} `mapstructure:"timeout-propose"`
-	DeprecatedTimeoutProposeDelta   *interface{} `mapstructure:"timeout-propose-delta"`
-	DeprecatedTimeoutPrevote        *interface{} `mapstructure:"timeout-prevote"`
-	DeprecatedTimeoutPrevoteDelta   *interface{} `mapstructure:"timeout-prevote-delta"`
-	DeprecatedTimeoutPrecommit      *interface{} `mapstructure:"timeout-precommit"`
-	DeprecatedTimeoutPrecommitDelta *interface{} `mapstructure:"timeout-precommit-delta"`
-	DeprecatedTimeoutCommit         *interface{} `mapstructure:"timeout-commit"`
-	DeprecatedSkipTimeoutCommit     *interface{} `mapstructure:"skip-timeout-commit"`
 }
 
 // DefaultConsensusConfig returns a default configuration for the consensus service
@@ -1141,30 +1127,7 @@ func (cfg *ConsensusConfig) ValidateBasic() error {
 
 func (cfg *ConsensusConfig) DeprecatedFieldWarning() error {
 	var fields []string
-	if cfg.DeprecatedSkipTimeoutCommit != nil {
-		fields = append(fields, "skip-timeout-commit")
-	}
-	if cfg.DeprecatedTimeoutPropose != nil {
-		fields = append(fields, "timeout-propose")
-	}
-	if cfg.DeprecatedTimeoutProposeDelta != nil {
-		fields = append(fields, "timeout-propose-delta")
-	}
-	if cfg.DeprecatedTimeoutPrevote != nil {
-		fields = append(fields, "timeout-prevote")
-	}
-	if cfg.DeprecatedTimeoutPrevoteDelta != nil {
-		fields = append(fields, "timeout-prevote-delta")
-	}
-	if cfg.DeprecatedTimeoutPrecommit != nil {
-		fields = append(fields, "timeout-precommit")
-	}
-	if cfg.DeprecatedTimeoutPrecommitDelta != nil {
-		fields = append(fields, "timeout-precommit-delta")
-	}
-	if cfg.DeprecatedTimeoutCommit != nil {
-		fields = append(fields, "timeout-commit")
-	}
+
 	if cfg.DeprecatedQuorumType != 0 {
 		fields = append(fields, "quorum-type")
 	}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Multiple fields in the consensus config file are marked as deprecated for quite a long time.

## What was done?

Removed deprecated fields:

* DeprecatedTimeoutPropose
* DeprecatedTimeoutProposeDelta
* DeprecatedTimeoutPrevote
* DeprecatedTimeoutPrevoteDelta
* DeprecatedTimeoutPrecommit
* DeprecatedTimeoutPrecommitDelta
* DeprecatedTimeoutCommit
* DeprecatedSkipTimeoutCommit

## How Has This Been Tested?

Github Actions

## Breaking Changes

The following fields are removed from config:

* timeout-propose
* timeout-propose-delta
* timeout-prevote
* timeout-prevote-delta
* timeout-precommit
* timeout-precommit-delta
* timeout-commit
* skip-timeout-commit

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
