### PR TITLE
refactor(mempool): use tmsync.Waker when txs are available

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -768,6 +768,8 @@ func (cs *State) handleTimeout(
 }
 
 func (cs *State) handleTxsAvailable(ctx context.Context, stateData *StateData) {
+	// TODO: Change to trace
+	cs.logger.Debug("new transactions are available", "height", stateData.Height, "round", stateData.Round, "step", stateData.Step)
 	// We only need to do this for round 0.
 	if stateData.Round != 0 {
 		return

--- a/internal/consensus/vote_signer.go
+++ b/internal/consensus/vote_signer.go
@@ -34,7 +34,9 @@ func (s *voteSigner) signAddVote(
 	}
 	// If the node not in the validator set, do nothing.
 	if !stateData.Validators.HasProTxHash(s.privValidator.ProTxHash) {
-		s.logger.Error("do nothing, node is not a part of validator set")
+		s.logger.Error("do nothing, node is not a part of validator set",
+			"protxhash", s.privValidator.ProTxHash.ShortString(),
+			"validators", stateData.Validators)
 		return nil
 	}
 	keyVals := []any{"height", stateData.Height, "round", stateData.Round, "quorum_hash", stateData.Validators.QuorumHash}

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -782,6 +782,9 @@ func (txmp *TxMempool) recheckTransactions(ctx context.Context) {
 		// When recheck is complete, trigger a notification for more transactions.
 		_ = g.Wait()
 
+		txmp.mtx.Lock()
+		defer txmp.mtx.Unlock()
+
 		txmp.notifyTxsAvailable()
 	}()
 }

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -49,10 +49,12 @@ type TxMempool struct {
 	// Synchronized fields, protected by mtx.
 	mtx                  *sync.RWMutex
 	notifiedTxsAvailable bool
-	txsAvailable         *tmsync.Waker
-	preCheck             PreCheckFunc
-	postCheck            PostCheckFunc
-	height               int64 // the latest height passed to Update
+	// txsAvailable is a waker that triggers when transactions are available in the mempool.
+	// Can be nil if not enabled with EnableTxsAvailable.
+	txsAvailable *tmsync.Waker
+	preCheck     PreCheckFunc
+	postCheck    PostCheckFunc
+	height       int64 // the latest height passed to Update
 
 	txs        *clist.CList // valid transactions (passed CheckTx)
 	txByKey    map[types.TxKey]*clist.CElement
@@ -79,6 +81,7 @@ func NewTxMempool(
 		txByKey:      make(map[types.TxKey]*clist.CElement),
 		txBySender:   make(map[string]*clist.CElement),
 	}
+
 	if cfg.CacheSize > 0 {
 		txmp.cache = NewLRUTxCache(cfg.CacheSize)
 	}
@@ -147,12 +150,26 @@ func (txmp *TxMempool) EnableTxsAvailable() {
 	txmp.mtx.Lock()
 	defer txmp.mtx.Unlock()
 
+	if txmp.txsAvailable != nil {
+		if err := txmp.txsAvailable.Close(); err != nil {
+			txmp.logger.Error("failed to close txsAvailable", "err", err)
+		}
+	}
 	txmp.txsAvailable = tmsync.NewWaker()
 }
 
 // TxsAvailable returns a channel which fires once for every height, and only
 // when transactions are available in the mempool. It is thread-safe.
-func (txmp *TxMempool) TxsAvailable() <-chan struct{} { return txmp.txsAvailable.Sleep() }
+//
+// Note: returned channel might never close if EnableTxsAvailable() was not called before
+// calling this function.
+func (txmp *TxMempool) TxsAvailable() <-chan struct{} {
+	if txmp.txsAvailable == nil {
+		return make(<-chan struct{})
+	}
+
+	return txmp.txsAvailable.Sleep()
+}
 
 // CheckTx adds the given transaction to the mempool if it fits and passes the
 // application's ABCI CheckTx method.

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dashpay/tenderdash/config"
 	"github.com/dashpay/tenderdash/internal/libs/clist"
 	tmstrings "github.com/dashpay/tenderdash/internal/libs/strings"
+	tmsync "github.com/dashpay/tenderdash/internal/libs/sync"
 	"github.com/dashpay/tenderdash/libs/log"
 	"github.com/dashpay/tenderdash/types"
 )
@@ -48,7 +49,7 @@ type TxMempool struct {
 	// Synchronized fields, protected by mtx.
 	mtx                  *sync.RWMutex
 	notifiedTxsAvailable bool
-	txsAvailable         chan struct{} // one value sent per height when mempool is not empty
+	txsAvailable         *tmsync.Waker
 	preCheck             PreCheckFunc
 	postCheck            PostCheckFunc
 	height               int64 // the latest height passed to Update
@@ -146,12 +147,12 @@ func (txmp *TxMempool) EnableTxsAvailable() {
 	txmp.mtx.Lock()
 	defer txmp.mtx.Unlock()
 
-	txmp.txsAvailable = make(chan struct{}, 1)
+	txmp.txsAvailable = tmsync.NewWaker()
 }
 
 // TxsAvailable returns a channel which fires once for every height, and only
 // when transactions are available in the mempool. It is thread-safe.
-func (txmp *TxMempool) TxsAvailable() <-chan struct{} { return txmp.txsAvailable }
+func (txmp *TxMempool) TxsAvailable() <-chan struct{} { return txmp.txsAvailable.Sleep() }
 
 // CheckTx adds the given transaction to the mempool if it fits and passes the
 // application's ABCI CheckTx method.
@@ -761,8 +762,7 @@ func (txmp *TxMempool) recheckTransactions(ctx context.Context) {
 
 		// When recheck is complete, trigger a notification for more transactions.
 		_ = g.Wait()
-		txmp.mtx.Lock()
-		defer txmp.mtx.Unlock()
+
 		txmp.notifyTxsAvailable()
 	}()
 }
@@ -817,6 +817,11 @@ func (txmp *TxMempool) purgeExpiredTxs(blockHeight int64) {
 	}
 }
 
+// notifyTxsAvailable triggers a notification that transactions are available in
+// the mempool. It is a no-op if the mempool is empty or if a notification has
+// already been sent.
+//
+// No locking is required to call this method.
 func (txmp *TxMempool) notifyTxsAvailable() {
 	if txmp.Size() == 0 {
 		return // nothing to do
@@ -826,9 +831,6 @@ func (txmp *TxMempool) notifyTxsAvailable() {
 		// channel cap is 1, so this will send once
 		txmp.notifiedTxsAvailable = true
 
-		select {
-		case txmp.txsAvailable <- struct{}{}:
-		default:
-		}
+		txmp.txsAvailable.Wake()
 	}
 }

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -47,8 +47,7 @@ type TxMempool struct {
 	txsBytes int64 // atomic: the total size of all transactions in the mempool, in bytes
 
 	// Synchronized fields, protected by mtx.
-	mtx                  *sync.RWMutex
-	notifiedTxsAvailable bool
+	mtx *sync.RWMutex
 	// txsAvailable is a waker that triggers when transactions are available in the mempool.
 	// Can be nil if not enabled with EnableTxsAvailable.
 	txsAvailable *tmsync.Waker
@@ -413,7 +412,6 @@ func (txmp *TxMempool) Update(
 	}
 
 	txmp.height = blockHeight
-	txmp.notifiedTxsAvailable = false
 
 	if newPreFn != nil {
 		txmp.preCheck = newPreFn
@@ -838,16 +836,13 @@ func (txmp *TxMempool) purgeExpiredTxs(blockHeight int64) {
 // the mempool. It is a no-op if the mempool is empty or if a notification has
 // already been sent.
 //
-// No locking is required to call this method.
+// Caller should hold txmp.mtx read lock.
 func (txmp *TxMempool) notifyTxsAvailable() {
 	if txmp.Size() == 0 {
 		return // nothing to do
 	}
 
-	if txmp.txsAvailable != nil && !txmp.notifiedTxsAvailable {
-		// channel cap is 1, so this will send once
-		txmp.notifiedTxsAvailable = true
-
+	if txmp.txsAvailable != nil {
 		txmp.txsAvailable.Wake()
 	}
 }

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -412,8 +412,10 @@ func (txmp *TxMempool) Update(
 			len(blockTxs), len(deliverTxResponses)))
 	}
 
-	txmp.height = blockHeight
-	txmp.notifiedTxsAvailable = false
+	if txmp.height != blockHeight {
+		txmp.height = blockHeight
+		txmp.notifiedTxsAvailable = false
+	}
 
 	if newPreFn != nil {
 		txmp.preCheck = newPreFn

--- a/internal/mempool/reactor.go
+++ b/internal/mempool/reactor.go
@@ -29,7 +29,8 @@ type Reactor struct {
 
 	cfg     *config.MempoolConfig
 	mempool *TxMempool
-	ids     *IDs
+	// Peer IDs assigned for peers
+	ids *IDs
 
 	peerEvents p2p.PeerEventSubscriber
 	p2pClient  *client.Client

--- a/internal/mempool/reactor.go
+++ b/internal/mempool/reactor.go
@@ -29,8 +29,7 @@ type Reactor struct {
 
 	cfg     *config.MempoolConfig
 	mempool *TxMempool
-	// Peer IDs assigned for peers
-	ids *IDs
+	ids     *IDs // Peer IDs assigned for peers
 
 	peerEvents p2p.PeerEventSubscriber
 	p2pClient  *client.Client


### PR DESCRIPTION
## Issue being fixed or feature implemented

Small refactor to reuse already implemented tmsync.Waker instead of chan.

## What was done?

Replaced `txsAvailable chan struct{}` with `tmsync.Waker`

## How Has This Been Tested?

GHA

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
