### PR TITLE
fix(types): don't log all txs in block

### DIFF
--- a/libs/log/testing.go
+++ b/libs/log/testing.go
@@ -118,6 +118,16 @@ func (tw *TestingLogger) AssertMatch(re *regexp.Regexp) {
 	tw.Logger = tw.Logger.Level(zerolog.DebugLevel)
 }
 
+// AssertContains defines assertions to check for each subsequent
+// log item. It must be called before the log is generated.
+// Assertion will pass if at least one log contains `s`.
+//
+// Note that assertions are only executed on logs matching defined log level.
+// Use NewTestingLoggerWithLevel(t, zerolog.LevelDebugValue) to control this.
+func (tw *TestingLogger) AssertContains(s string) {
+	tw.AssertMatch(regexp.MustCompile(regexp.QuoteMeta(s)))
+}
+
 // Run implements zerolog.Hook.
 // Execute all log assertions against a message.
 func (tw *TestingLogger) checkAssertions(msg string) {

--- a/types/block.go
+++ b/types/block.go
@@ -303,9 +303,9 @@ func (b *Block) MarshalZerologObject(e *zerolog.Event) {
 
 	e.Interface("header", b.Header)
 	e.Interface("core_chain_lock", b.CoreChainLock)
-	e.Interface("data", b.Data)
+	e.Object("data", &b.Data)
 	e.Interface("evidence", b.Evidence)
-	e.Interface("last_commit", b.LastCommit)
+	e.Object("last_commit", b.LastCommit)
 }
 
 // FromProto sets a protobuf Block to the given pointer.
@@ -1062,8 +1062,7 @@ func (data *Data) MarshalZerologObject(e *zerolog.Event) {
 	e.Bool("nil", false)
 
 	e.Str("hash", data.Hash().ShortString())
-	e.Int("num_txs", len(data.Txs))
-	e.Array("txs", &data.Txs)
+	e.Object("txs", data.Txs)
 }
 
 // DataFromProto takes a protobuf representation of Data &

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dashpay/tenderdash/crypto/bls12381"
 	"github.com/dashpay/tenderdash/crypto/merkle"
 	tmbytes "github.com/dashpay/tenderdash/libs/bytes"
+	"github.com/dashpay/tenderdash/libs/log"
 	tmrand "github.com/dashpay/tenderdash/libs/rand"
 	tmtime "github.com/dashpay/tenderdash/libs/time"
 	tmproto "github.com/dashpay/tenderdash/proto/tendermint/types"
@@ -211,6 +212,36 @@ func TestBlockSize(t *testing.T) {
 	if size <= 0 {
 		t.Fatal("Size of the block is zero or negative")
 	}
+}
+
+// Given a block with more than `maxLoggedTxs` transactions,
+// when we marshal it for logging,
+// then we should see short hashes of the first `maxLoggedTxs` transactions in the log message, ending with "..."
+func TestBlockMarshalZerolog(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewTestingLogger(t)
+
+	txs := make(Txs, 0, 2*maxLoggedTxs)
+	expectTxs := make(Txs, 0, maxLoggedTxs)
+	for i := 0; i < 2*maxLoggedTxs; i++ {
+		txs = append(txs, Tx(fmt.Sprintf("tx%d", i)))
+		if i < maxLoggedTxs {
+			expectTxs = append(expectTxs, txs[i])
+		}
+	}
+
+	block := MakeBlock(1, txs, randCommit(ctx, t, 1, RandStateID()), nil)
+
+	// define assertions
+	expected := fmt.Sprintf(",\"txs\":{\"num_txs\":%d,\"hashes\":[", 2*maxLoggedTxs)
+	for i := 0; i < maxLoggedTxs; i++ {
+		expected += "\"" + expectTxs[i].Hash().ShortString() + "\","
+	}
+	expected += "\"...\"]}"
+	logger.AssertContains(expected)
+
+	// execute test
+	logger.Info("test block", "block", block)
 }
 
 func TestBlockString(t *testing.T) {


### PR DESCRIPTION
## Issue being fixed or feature implemented

When logging block (also occurs on INFO level), all full transactions that are part of this block are logged.


## What was done?

Only log short hashes of transactions for no more than 20 txs. Append "..." at the end if there are more than 20 txs.

## How Has This Been Tested?

Added unit test

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
