### PR TITLE
test(consensus): fix flaky TestEmitNewValidBlockEventOnCommitWithoutBlock

### DIFF
--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -2658,7 +2658,9 @@ func TestEmitNewValidBlockEventOnCommitWithoutBlock(t *testing.T) {
 	ensureNewValidBlock(t, validBlockCh, height, round)
 
 	rs := cs1.GetRoundState()
-	assert.EqualValues(t, cstypes.RoundStepPrecommit.String(), rs.Step.String())
+	// due to some delays, we might be on Precommit or ApplyCommit step,
+	// as these steps just follow one another with no delay
+	assert.Contains(t, []cstypes.RoundStepType{cstypes.RoundStepPrecommit, cstypes.RoundStepApplyCommit}, rs.Step)
 	assert.Nil(t, rs.ProposalBlock)
 	assert.True(t, rs.ProposalBlockParts.Header().Equals(blockID.PartSetHeader))
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

TestEmitNewValidBlockEventOnCommitWithoutBlock is flaky.

In the tested scenario, Tenderdash changes round step to Precommit, and then quickly advances to ApplyCommit step.

```
{"level":"debug","module":"consensus","module":"consensus","message":"updating state data step to Precommit on EnterPrecommitAction"}
{"level":"debug","module":"consensus","module":"consensus","commit_round":1,"new_height":1,"height":1,"round":1,"step":6,"message":"entering commit step"}
{"level":"debug","module":"consensus","module":"consensus","commit":"8E4B2F2E5D2E168704B334B47F2FE394F1674E181A79E79FDA50AC03AC08618D","proposal":"","message":"commit is for a block we do not know about; set ProposalBlock=nil"}
{"level":"debug","module":"consensus","module":"consensus","message":"updating state data step to ApplyCommit on EnterCommitAction"}
```

This makes the test flaky, as time between these steps is too small to reliably check assertions in the test.

## What was done?

Accept both steps as part of the test.

## How Has This Been Tested?

```
go test -count 1000 ./internal/consensus/ -run TestEmitNewValidBlockEventOnCommitWithoutBlock -test.v 
```

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
