### PR TITLE
 test(statesync): fix flaky TestReactor_Backfill 

### DIFF
--- a/internal/statesync/block_queue.go
+++ b/internal/statesync/block_queue.go
@@ -119,6 +119,7 @@ func (q *blockQueue) nextHeight() <-chan int64 {
 		return ch
 	}
 
+	// we check initialHeight instead of startHeight as also need to address the startTime which we don't have here
 	if q.terminal == nil && q.fetchHeight >= q.initialHeight {
 		// return and decrement the fetch height
 		ch <- q.fetchHeight

--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -261,7 +261,7 @@ func TestReactor_Sync(t *testing.T) {
 
 	appHash := []byte{1, 2, 3}
 
-	go handleLightBlockRequests(ctx, t, chain, rts.blockOutCh, rts.blockInCh, closeCh, 0)
+	go handleLightBlockRequests(ctx, t, chain, rts.blockOutCh, rts.blockInCh, closeCh, 0, 0)
 	go graduallyAddPeers(ctx, t, rts.peerUpdateCh, closeCh, 1*time.Second)
 	go handleSnapshotRequests(ctx, t, rts.snapshotOutCh, rts.snapshotInCh, closeCh, []snapshot{
 		{
@@ -549,7 +549,7 @@ func TestReactor_BlockProviders(t *testing.T) {
 	defer close(closeCh)
 
 	chain := buildLightBlockChain(ctx, t, 1, 10, time.Now(), rts.privVal)
-	go handleLightBlockRequests(ctx, t, chain, rts.blockOutCh, rts.blockInCh, closeCh, 0)
+	go handleLightBlockRequests(ctx, t, chain, rts.blockOutCh, rts.blockInCh, closeCh, 0, 0)
 
 	peers := rts.reactor.peers.All()
 	require.Len(t, peers, 2)
@@ -608,7 +608,7 @@ func TestReactor_StateProviderP2P(t *testing.T) {
 	defer close(closeCh)
 
 	chain := buildLightBlockChain(ctx, t, 1, 10, time.Now(), rts.privVal)
-	go handleLightBlockRequests(ctx, t, chain, rts.blockOutCh, rts.blockInCh, closeCh, 0)
+	go handleLightBlockRequests(ctx, t, chain, rts.blockOutCh, rts.blockInCh, closeCh, 0, 0)
 	go handleConsensusParamsRequest(ctx, t, rts.paramsOutCh, rts.paramsInCh, closeCh)
 
 	rts.reactor.cfg.UseP2P = true
@@ -689,7 +689,7 @@ func TestReactor_Backfill(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("failure rate: %d", tc.failureRate), func(t *testing.T) {
-			ctx, cancel := context.WithCancel(ctx)
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
 			t.Cleanup(leaktest.CheckTimeout(t, 1*time.Minute))
@@ -728,7 +728,7 @@ func TestReactor_Backfill(t *testing.T) {
 
 			closeCh := make(chan struct{})
 			defer close(closeCh)
-			go handleLightBlockRequests(ctx, t, chain, rts.blockOutCh, rts.blockInCh, closeCh, tc.failureRate)
+			go handleLightBlockRequests(ctx, t, chain, rts.blockOutCh, rts.blockInCh, closeCh, tc.failureRate, uint64(stopHeight))
 
 			err := rts.reactor.backfill(
 				ctx,
@@ -775,6 +775,19 @@ func retryUntil(ctx context.Context, t *testing.T, fn func() bool, timeout time.
 	}
 }
 
+// handleLightBlockRequests will handle light block requests and respond with the appropriate light block
+// based on the height of the request. It will also simulate failures based on the failure rate.
+// The function will return when the context is done.
+// # Arguments
+// * `ctx` - the context
+// * `t` - the testing.T instance
+// * `chain` - the light block chain
+// * `receiving` - the channel to receive requests
+// * `sending` - the channel to send responses
+// * `close` - the channel to close the function
+// * `failureRate` - the rate of failure
+// * `stopHeight` - minimum height for which to respond; below this height, the function will not respond to requests,
+// causing timeouts. Use 0 to disable this mechanism.
 func handleLightBlockRequests(
 	ctx context.Context,
 	t *testing.T,
@@ -782,7 +795,9 @@ func handleLightBlockRequests(
 	receiving chan p2p.Envelope,
 	sending chan p2p.Envelope,
 	close chan struct{},
-	failureRate int) {
+	failureRate int,
+	stopHeight uint64,
+) {
 	requests := 0
 	errorCount := 0
 	for {
@@ -791,6 +806,12 @@ func handleLightBlockRequests(
 			return
 		case envelope := <-receiving:
 			if msg, ok := envelope.Message.(*ssproto.LightBlockRequest); ok {
+				if msg.Height < stopHeight {
+					// this causes timeout; needed for backfill tests
+					// to ensure heights below stopHeight are not processed
+					// before all heights above stopHeight are processed
+					continue
+				}
 				if requests%10 >= failureRate {
 					lb, err := chain[int64(msg.Height)].ToProto()
 					require.NoError(t, err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

TestReactor_Backfill is flaky. 

Due to some timing constraints, sometimes backfill goes as low as height 8, while it should end on height 10.
This is caused by failure testing logic effectively "delaying" some blocks at higher heights.

## What was done?

1. Added mechanism to reject blocks below 10 to the tests.
2. Small refactoring of backfill error handling

## How Has This Been Tested?

```bash
#!/bin/bash -ex

while true; do
    go test -count 1 -timeout 60s ./internal/statesync/ -test.v -run TestReactor_Backfill 2>&1 | tee log.log
    if grep -q FAIL log.log; then
        echo "Test failed, stopping."
        break
    fi
    echo "================ Test passed, running again ================"
done
```

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
