### PR TITLE
fix(state): handle ValidatorSetUpdate with no validator changes

### DIFF
--- a/abci/types/types.pb.go
+++ b/abci/types/types.pb.go
@@ -3843,6 +3843,21 @@ func (m *ValidatorUpdate) GetNodeAddress() string {
 	return ""
 }
 
+// ValidatorSetUpdate represents a change in the validator set.
+// It can be used to add, remove, or update a validator.
+//
+// Validator set update consists of multiple ValidatorUpdate records,
+// each of them can be used to add, remove, or update a validator, according to the
+// following rules:
+//
+// 1. If a validator with the same public key already exists in the validator set
+// and power is greater than 0, the existing validator will be updated with the new power.
+// 2. If a validator with the same public key already exists in the validator set
+// and power is 0, the existing validator will be removed from the validator set.
+// 3. If a validator with the same public key does not exist in the validator set and the power is greater than 0,
+// a new validator will be added to the validator set.
+// 4. As a special case, if quorum hash has changed, all existing validators will be removed before applying
+// the new validator set update.
 type ValidatorSetUpdate struct {
 	ValidatorUpdates   []ValidatorUpdate `protobuf:"bytes,1,rep,name=validator_updates,json=validatorUpdates,proto3" json:"validator_updates"`
 	ThresholdPublicKey crypto.PublicKey  `protobuf:"bytes,2,opt,name=threshold_public_key,json=thresholdPublicKey,proto3" json:"threshold_public_key"`

--- a/internal/state/current_round_state.go
+++ b/internal/state/current_round_state.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/rs/zerolog"
+
 	abci "github.com/dashpay/tenderdash/abci/types"
 	tmbytes "github.com/dashpay/tenderdash/libs/bytes"
 	tmtypes "github.com/dashpay/tenderdash/proto/tendermint/types"
 	"github.com/dashpay/tenderdash/types"
-	"github.com/rs/zerolog"
 )
 
 const (
@@ -341,6 +342,16 @@ func valsetUpdate(
 			nValSet = types.NewValidatorSetWithLocalNodeProTxHash(validatorUpdates, thresholdPubKey,
 				currentVals.QuorumType, quorumHash, nodeProTxHash)
 		}
+	} else {
+		// validators not changed, but we might have a new quorum hash or threshold public key
+		if !quorumHash.IsZero() {
+			nValSet.QuorumHash = quorumHash
+		}
+
+		if thresholdPubKey != nil {
+			nValSet.ThresholdPublicKey = thresholdPubKey
+		}
 	}
+
 	return nValSet, nil
 }

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -730,7 +730,7 @@ func execBlock(
 		logger.Error("executing block", "err", err)
 		return responseFinalizeBlock, err
 	}
-	logger.Info("executed block", "height", block.Height)
+	logger.Debug("executed block", "height", block.Height)
 
 	return responseFinalizeBlock, nil
 }

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -798,6 +798,21 @@ message ValidatorUpdate {
   string node_address = 4 [(gogoproto.nullable) = true];
 }
 
+// ValidatorSetUpdate represents a change in the validator set.
+// It can be used to add, remove, or update a validator.
+//
+// Validator set update consists of multiple ValidatorUpdate records,
+// each of them can be used to add, remove, or update a validator, according to the
+// following rules:
+//
+// 1. If a validator with the same public key already exists in the validator set
+// and power is greater than 0, the existing validator will be updated with the new power.
+// 2. If a validator with the same public key already exists in the validator set
+// and power is 0, the existing validator will be removed from the validator set.
+// 3. If a validator with the same public key does not exist in the validator set and the power is greater than 0,
+// a new validator will be added to the validator set.
+// 4. As a special case, if quorum hash has changed, all existing validators will be removed before applying
+// the new validator set update.
 message ValidatorSetUpdate {
   repeated ValidatorUpdate    validator_updates    = 1 [(gogoproto.nullable) = false];
   tendermint.crypto.PublicKey threshold_public_key = 2 [(gogoproto.nullable) = false];

--- a/spec/abci++/api.md
+++ b/spec/abci++/api.md
@@ -1179,7 +1179,21 @@ Validator
 <a name="tendermint-abci-ValidatorSetUpdate"></a>
 
 ### ValidatorSetUpdate
+ValidatorSetUpdate represents a change in the validator set.
+It can be used to add, remove, or update a validator.
 
+Validator set update consists of multiple ValidatorUpdate records,
+each of them can be used to add, remove, or update a validator, according to the
+following rules:
+
+1. If a validator with the same public key already exists in the validator set
+and power is greater than 0, the existing validator will be updated with the new power.
+2. If a validator with the same public key already exists in the validator set
+and power is 0, the existing validator will be removed from the validator set.
+3. If a validator with the same public key does not exist in the validator set and the power is greater than 0,
+a new validator will be added to the validator set.
+4. As a special case, if quorum hash has changed, all existing validators will be removed before applying
+the new validator set update.
 
 
 | Field | Type | Label | Description |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

If no validators were provided in ValidatorSetUpdate, the request was ignored.

## What was done?

If no validators are provided in ValidatorSetUpdate, quorum hash and threshold public key are still updated in the validator set.

Documented ValidatorSetUpdate in abci proto definitions file.
 


## How Has This Been Tested?

Added unit test.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
