### PR TITLE
feat(consensus): confirm votes on vote bit set receipt

### DIFF
--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -246,7 +246,7 @@ func (g *msgGossiper) GossipVote(ctx context.Context, rs cstypes.RoundState, prs
 		"proto_vote_size", protoVote.Size(),
 	})
 	logger.Trace("syncing vote message")
-	err := g.sync(ctx, protoVote, updatePeerVote(g.ps, vote))
+	err := g.sync(ctx, protoVote, nil)
 	if err != nil {
 		logger.Error("failed to sync vote message to the peer", "error", err)
 	}
@@ -400,12 +400,6 @@ func updatePeerCommit(ps *PeerState, commit *types.Commit) func() error {
 	return func() error {
 		ps.SetHasCommit(commit)
 		return nil
-	}
-}
-
-func updatePeerVote(ps *PeerState, vote *types.Vote) func() error {
-	return func() error {
-		return ps.SetHasVote(vote)
 	}
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Nodes mark votes as delivered directly after sending them to their peers, what is not always the case.

In case of high load, some votes might not be processed successfully and dropped (due to too long queue).
In this case, node will never these votes again, what can lead to chain halt on that node due to "starvation".

## What was done?

Votes are not marked as delivered directly after sending. Instead, VoteSetBits message is sent after accepting a vote, and the peer marks vote as delivered after it received VoteSetBits.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
