### PR TITLE
fix(config): ignore abci section on seeds

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -134,29 +134,36 @@ func (cfg *Config) SetRoot(root string) *Config {
 // ValidateBasic performs basic validation (checking param bounds, etc.) and
 // returns an error if any check fails.
 func (cfg *Config) ValidateBasic() error {
+	var errs error
 
-	if err := cfg.Abci.ValidateBasic(); err != nil {
-		return fmt.Errorf("error in [abci] section: %w", err)
-	}
 	if err := cfg.BaseConfig.ValidateBasic(); err != nil {
-		return err
+		errs = multierror.Append(errs, err)
 	}
+
+	// ignore [abci] section on seed nodes
+	if cfg.Mode != ModeSeed {
+		if err := cfg.Abci.ValidateBasic(); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error in [abci] section: %w", err))
+		}
+	}
+
 	if err := cfg.RPC.ValidateBasic(); err != nil {
-		return fmt.Errorf("error in [rpc] section: %w", err)
+		errs = multierror.Append(errs, fmt.Errorf("error in [rpc] section: %w", err))
 	}
 	if err := cfg.Mempool.ValidateBasic(); err != nil {
-		return fmt.Errorf("error in [mempool] section: %w", err)
+		errs = multierror.Append(errs, fmt.Errorf("error in [mempool] section: %w", err))
 	}
 	if err := cfg.StateSync.ValidateBasic(); err != nil {
-		return fmt.Errorf("error in [statesync] section: %w", err)
+		errs = multierror.Append(errs, fmt.Errorf("error in [statesync] section: %w", err))
 	}
 	if err := cfg.Consensus.ValidateBasic(); err != nil {
-		return fmt.Errorf("error in [consensus] section: %w", err)
+		errs = multierror.Append(errs, fmt.Errorf("error in [consensus] section: %w", err))
 	}
 	if err := cfg.Instrumentation.ValidateBasic(); err != nil {
-		return fmt.Errorf("error in [instrumentation] section: %w", err)
+		errs = multierror.Append(errs, fmt.Errorf("error in [instrumentation] section: %w", err))
 	}
-	return nil
+
+	return errs
 }
 
 func (cfg *Config) DeprecatedFieldWarning() error {

--- a/config/config.go
+++ b/config/config.go
@@ -473,6 +473,11 @@ func TestAbciConfig() *AbciConfig {
 func (cfg *AbciConfig) ValidateBasic() error {
 	var err error
 
+	if cfg == nil {
+		err = multierror.Append(err, errors.New("[abci] config section is nil"))
+		return err
+	}
+
 	for key := range cfg.Other {
 		err = multierror.Append(err, fmt.Errorf("unknown field: %s", key))
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

On seeds, `[abci]` section is unused and should be ignored.


## What was done?

* ignore `[abci]` section on seed nodes
* report errors from multiple sections at one run


## How Has This Been Tested?

Added unit test


## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
