### PR TITLE
chore(types): detect quorum hash mismatch when verifying commit

### DIFF
--- a/types/validation_test.go
+++ b/types/validation_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -98,6 +99,15 @@ func TestValidatorSet_VerifyCommit_All(t *testing.T) {
 				vote.VoteExtensions,
 				&CommitSigns{
 					QuorumHash:  quorumHash,
+					QuorumSigns: QuorumSigns{BlockSign: vote2.BlockSignature, VoteExtensionSignatures: vote2.VoteExtensions.GetSignatures()},
+				},
+			), true},
+		// quorum hash mismatch
+		{"wrong quorum hash", chainID, vote.BlockID, vote.Height,
+			NewCommit(vote.Height, vote.Round, vote.BlockID,
+				vote.VoteExtensions,
+				&CommitSigns{
+					QuorumHash:  bytes.Repeat([]byte{0xaa}, crypto.QuorumHashSize),
 					QuorumSigns: QuorumSigns{BlockSign: vote2.BlockSignature, VoteExtensionSignatures: vote2.VoteExtensions.GetSignatures()},
 				},
 			), true},

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -914,6 +914,11 @@ func (vals *ValidatorSet) VerifyCommit(chainID string, blockID BlockID,
 	if err != nil {
 		return err
 	}
+	if !vals.QuorumHash.Equal(commit.QuorumHash) {
+		return fmt.Errorf("invalid commit -- wrong quorum hash: validator set uses %X, commit has %X",
+			vals.QuorumHash, commit.QuorumHash)
+
+	}
 	err = quorumSigns.Verify(vals.ThresholdPublicKey, NewQuorumSignsFromCommit(commit))
 	if err != nil {
 		return fmt.Errorf("invalid commit signatures for quorum(type=%v, hash=%X), thresholdPubKey=%X: %w",
@@ -991,7 +996,7 @@ func (vals *ValidatorSet) StringIndented(indent string) string {
 		return "nil-ValidatorSet"
 	}
 	var valStrings []string
-	vals.Iterate(func(index int, val *Validator) bool {
+	vals.Iterate(func(_index int, val *Validator) bool {
 		valStrings = append(valStrings, val.String())
 		return false
 	})
@@ -1021,7 +1026,7 @@ func (vals *ValidatorSet) StringIndentedBasic(indent string) string {
 		return "nil-ValidatorSet"
 	}
 	var valStrings []string
-	vals.Iterate(func(index int, val *Validator) bool {
+	vals.Iterate(func(_index int, val *Validator) bool {
 		valStrings = append(valStrings, val.ShortStringBasic())
 		return false
 	})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

If commit is created with a different quorum than it's verified, we don't have clear enough error.

## What was done?

Return better error on quorum hash mismatch.

## How Has This Been Tested?

GHA

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
