### PR TITLE
fix(router): router.chDesc concurrent map iteration and write in pqueue

### DIFF
--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -224,8 +224,10 @@ func (r *Router) createQueueFactory(ctx context.Context) (func(int) queue, error
 			if size%2 != 0 {
 				size++
 			}
-
+			// lock to prevent r.chDescs from being modified while constructing the queue
+			r.channelMtx.RLock()
 			q := newPQScheduler(r.logger, r.metrics, r.lc, r.chDescs, uint(size)/2, uint(size)/2, defaultCapacity)
+			r.channelMtx.RUnlock()
 			q.start(ctx)
 			return q
 		}, nil

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -214,6 +214,9 @@ func NewRouter(
 	return router, nil
 }
 
+// createQueueFactory creates a queue factory function based on the queue type
+//
+// Caller should hold the r.channelMtx RLock.
 func (r *Router) createQueueFactory(ctx context.Context) (func(int) queue, error) {
 	switch r.options.QueueType {
 	case queueTypeFifo:
@@ -224,10 +227,7 @@ func (r *Router) createQueueFactory(ctx context.Context) (func(int) queue, error
 			if size%2 != 0 {
 				size++
 			}
-			// lock to prevent r.chDescs from being modified while constructing the queue
-			r.channelMtx.RLock()
 			q := newPQScheduler(r.logger, r.metrics, r.lc, r.chDescs, uint(size)/2, uint(size)/2, defaultCapacity)
-			r.channelMtx.RUnlock()
 			q.start(ctx)
 			return q
 		}, nil
@@ -603,7 +603,10 @@ func (r *Router) getOrMakeQueue(peerID types.NodeID, channels ChannelIDSet) queu
 		return peerQueue
 	}
 
+	r.channelMtx.RLock()
 	peerQueue := r.queueFactory(queueBufferDefault)
+	r.channelMtx.RUnlock()
+
 	r.peerQueues[peerID] = peerQueue
 	r.peerChannels[peerID] = channels
 	return peerQueue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

```
 fatal error: concurrent map iteration and map write                                                                                                                                   │
010.57942s full01         |                                                                                                                                                                                       │
010.57944s full01         | goroutine 605 gp=0xc0000ff180 m=3 mp=0xc000069008 [running]:                                                                                                                          │
010.57945s full01         | runtime.fatal({0x1c34522?, 0xc0000b4c38?})                                                                                                                                            │
010.57945s full01         |     /usr/local/go/src/runtime/panic.go:1042 +0x5c fp=0xc0011c56a8 sp=0xc0011c5678 pc=0x44dd9c                                                                                         │
010.57946s full01         | runtime.mapiternext(0xc0011c58e0)                                                                                                                                                     │
010.57947s full01         |     /usr/local/go/src/runtime/map.go:869 +0x45 fp=0xc0011c5738 sp=0xc0011c56a8 pc=0x41e105                                                                                            │
010.57948s full01         | runtime.mapiterinit(0x4523f5?, 0xc000513a10, 0xc0011c58e0)                                                                                                                            │
010.57949s full01         |     /usr/local/go/src/runtime/map.go:859 +0x179 fp=0xc0011c5758 sp=0xc0011c5738 pc=0x41e079                                                                                           │
010.57950s full01         | github.com/dashpay/tenderdash/internal/p2p.newPQScheduler({0x1f3d220, 0xc00058f880}, 0xc00002c200, 0xc000303680, 0xc000513a10, 0x10, 0x10, 0xf42400)                                  │
010.57952s full01         |     /src/tenderdash/internal/p2p/pqueue.go:108 +0x10f fp=0xc0011c5960 sp=0xc0011c5758 pc=0x147a70f                                                                                    │
010.57952s full01         | github.com/dashpay/tenderdash/internal/p2p.(*Router).createQueueFactory.func1(0x20)                                                                                                   │
010.57953s full01         |     /src/tenderdash/internal/p2p/router.go:228 +0x105 fp=0xc0011c5a20 sp=0xc0011c5960 pc=0x147e945                                                                                    │
010.57954s full01         | github.com/dashpay/tenderdash/internal/p2p.(*Router).getOrMakeQueue(0xc0001ff0e0, {0xc0003ac1e8, 0x28}, 0xc000386db0)                                                                 │
010.59023s full01         |     /src/tenderdash/internal/p2p/router.go:610 +0x1e2 fp=0xc0011c5b30 sp=0xc0011c5a20 pc=0x1484482                                                                                    │
010.59023s full01         | github.com/dashpay/tenderdash/internal/p2p.(*Router).routePeer(0xc0001ff0e0, {0x1f3aa58, 0xc00059b260}, {0xc0003ac1e8, 0x28}, {0x1f3eb70, 0xc0005980b0}, 0xc000386db0)                │
010.59030s full01         |     /src/tenderdash/internal/p2p/router.go:713 +0x1af fp=0xc0011c5f50 sp=0xc0011c5b30 pc=0x148656f                                                                                    │
010.59232s full01         | github.com/dashpay/tenderdash/internal/p2p.(*Router).connectPeer.gowrap1()                                                                                                            │
010.59238s full01         |     /src/tenderdash/internal/p2p/router.go:599 +0x99 fp=0xc0011c5fe0 sp=0xc0011c5f50 pc=0x1484259                                                                                     │
010.59245s full01         | runtime.goexit({})                                                                                                                                                                    │
010.59252s full01         |     /usr/local/go/src/runtime/asm_amd64.s:1695 +0x1 fp=0xc0011c5fe8 sp=0xc0011c5fe0 pc=0x489421                                                                                       │
010.59258s full01         | created by github.com/dashpay/tenderdash/internal/p2p.(*Router).connectPeer in goroutine 227                                                                                          │
010.59265s full01         |     /src/tenderdash/internal/p2p/router.go:599 +0x1153                       
```


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?

GHA

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
