### PR TITLE
fix(docker): ineffective PROXY_APP and ABCI env in entrypoint

### DIFF
--- a/DOCKER/docker-entrypoint.sh
+++ b/DOCKER/docker-entrypoint.sh
@@ -6,7 +6,7 @@ if [ ! -d "$TMHOME/config" ]; then
 	tenderdash init validator
 
 	sed -i \
-		-e "s/^proxy-app\s*=.*/proxy-app = \"$PROXY_APP\"/" \
+		-e "s/^address\s*=.*/address = \"$PROXY_APP\"/" \
 		-e "s/^moniker\s*=.*/moniker = \"$MONIKER\"/" \
 		-e 's/^addr-book-strict\s*=.*/addr-book-strict = false/' \
 		-e 's/^timeout-commit\s*=.*/timeout-commit = "500ms"/' \
@@ -17,7 +17,7 @@ if [ ! -d "$TMHOME/config" ]; then
 
 	if [ -n "$ABCI" ]; then
 		sed -i \
-			-e "s/^abci\s*=.*/abci = \"$ABCI\"/" \
+			-e "s/^transport\s*=.*/transport = \"$ABCI\"/" \
 			"$TMHOME/config/config.toml"
 	fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Env variables PROXY_APP and ABCI are ignored when using Docker images. It is caused by recent changes to the config file format.

## What was done?

Fixed issue in entrypoint.

## How Has This Been Tested?

Using rs-tenderdash-abci tests.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
