### PR TITLE
build(dependabot): run dependabot on default branch, not master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,10 +18,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    target-branch: "master"
     open-pull-requests-limit: 10
     reviewers:
-      - shumkov
       - lklimek
     labels:
       - dependencies


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Dependabot targets its changes to the master branch, while in our workflow, it should be the default branch (like v1.1)

## What was done?

Fixed dependabot config, updated reviewers


## How Has This Been Tested?

Cannot be tested, to be tested after merge as it only applies when it's in the default branch.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
