### PR TITLE
fix: active validators not always connected to each other

### DIFF
--- a/dash/quorum/validator_conn_executor.go
+++ b/dash/quorum/validator_conn_executor.go
@@ -264,7 +264,7 @@ func (vc *ValidatorConnExecutor) resolveNodeID(va *types.ValidatorAddress) error
 			va.NodeID = address.NodeID
 			return nil // success
 		}
-		vc.logger.Debug(
+		vc.logger.Trace(
 			"warning: validator node id lookup method failed",
 			"url", va.String(),
 			"method", method,
@@ -305,7 +305,7 @@ func (vc *ValidatorConnExecutor) ensureValidatorsHaveNodeIDs(validators []*types
 	for _, validator := range validators {
 		err := vc.resolveNodeID(&validator.NodeAddress)
 		if err != nil {
-			vc.logger.Error("cannot determine node id for validator, skipping", "url", validator.String(), "error", err)
+			vc.logger.Warn("cannot determine node id for validator, skipping", "url", validator.String(), "error", err)
 			continue
 		}
 		results = append(results, validator)

--- a/internal/p2p/dash_dialer.go
+++ b/internal/p2p/dash_dialer.go
@@ -110,12 +110,14 @@ func (cm *routerDashDialer) lookupIPPort(ctx context.Context, ip net.IP, port ui
 	for _, nodeID := range peers {
 		addresses := cm.peerManager.Addresses(nodeID)
 		for _, addr := range addresses {
-			if endpoints, err := addr.Resolve(ctx); err != nil {
+			if endpoints, err := addr.Resolve(ctx); err == nil {
 				for _, item := range endpoints {
 					if item.IP.Equal(ip) && item.Port == port {
 						return item.NodeAddress(nodeID), nil
 					}
 				}
+			} else {
+				cm.logger.Warn("lookupIPPort: failed to resolve address", "peer", nodeID, "address", addr, "err", err)
 			}
 		}
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -73,9 +73,6 @@ type nodeImpl struct {
 	shutdownOps    closer
 	rpcEnv         *rpccore.Environment
 	prometheusSrv  *http.Server
-
-	// Dash
-	validatorConnExecutor *dashquorum.ValidatorConnExecutor
 }
 
 // newDefaultNode returns a Tendermint node with default settings for the
@@ -254,6 +251,8 @@ func makeNode(
 		if err != nil {
 			return nil, combineCloseError(err, makeCloser(closers))
 		}
+	} else {
+		logger.Debug("ProTxHash not set, so we are not a validator; skipping ValidatorConnExecutor initialization")
 	}
 
 	// TODO construct node here:
@@ -268,15 +267,13 @@ func makeNode(
 
 		eventSinks:     eventSinks,
 		indexerService: indexerService,
-		services:       []service.Service{eventBus},
+		services:       []service.Service{eventBus, validatorConnExecutor},
 
 		initialState: state,
 		stateStore:   stateStore,
 		blockStore:   blockStore,
 
 		shutdownOps: makeCloser(closers),
-
-		validatorConnExecutor: validatorConnExecutor,
 
 		rpcEnv: &rpccore.Environment{
 			ProxyApp: proxyApp,

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -672,7 +672,7 @@ func TestNodeSetEventSink(t *testing.T) {
 
 	logger := log.NewNopLogger()
 
-	setupTest := func(t *testing.T, conf *config.Config) []indexer.EventSink {
+	setupTest := func(t *testing.T, _conf *config.Config) []indexer.EventSink {
 		eventBus := eventbus.NewDefault(logger.With("module", "events"))
 		require.NoError(t, eventBus.Start(ctx))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

There is a `ValidatorConnExecutor` service that ensures that each active validator is connected to at least some other validators that are members of the same quorum. 

Unfortunately, after some backports/refactorings, this service is not started correctly anymore.

## What was done?

* fixed start issue
* decreased log levels in ValidatorConnExecutor 

## How Has This Been Tested?

Start e2e tests and monitor logs

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
