### PR TITLE
fix: address already in use

### DIFF
--- a/DOCKER/docker-entrypoint.sh
+++ b/DOCKER/docker-entrypoint.sh
@@ -27,3 +27,14 @@ if [ ! -d "$TMHOME/config" ]; then
 fi
 
 exec tenderdash "$@"
+local exit_code=$?
+
+# TODO: Workaround for busy port problem happening with docker restart policy
+#   we are trying to start a new container but previous process still not release
+#   the port. Must be fix with graceful shutdown of tenderdash process.
+if [ $exit_code -ne 0 ] && [ "$1" == "start" ]; then
+  echo "Sleeping for 10 seconds as workaround for the busy port problem. See entrypoint code for details."
+  sleep 10
+fi
+
+exit $error_code

--- a/DOCKER/docker-entrypoint.sh
+++ b/DOCKER/docker-entrypoint.sh
@@ -1,5 +1,30 @@
 #!/bin/bash
-set -e
+
+
+# TODO: Workaround for busy port problem happening with docker restart policy
+#  we are trying to start a new container but previous process still not release
+#  the port.
+
+#  As a workaround we are sleeping for 10 seconds after the tenderdash process
+#  exits with non-zero exit code.
+#
+#  Must be fix with graceful shutdown of tenderdash process.
+
+got_signal=false
+
+# Function to handle signals and forward them to the tenderdash process
+# shellcheck disable=SC2317
+_forward_signal() {
+  echo "Caught signal! Forwarding to tenderdash process."
+  got_signal=true
+  kill -s "$1" "$child"
+}
+
+# Trap signals and forward them to the tenderdash process
+trap '_forward_signal TERM' SIGTERM
+trap '_forward_signal INT' SIGINT
+trap '_forward_signal HUP' SIGHUP
+trap '_forward_signal QUIT' SIGQUIT
 
 if [ ! -d "$TMHOME/config" ]; then
 	echo "Running tenderdash init to create a single node (default) configuration for docker run."
@@ -26,15 +51,15 @@ if [ ! -d "$TMHOME/config" ]; then
 	mv "$TMHOME/config/genesis.json.new" "$TMHOME/config/genesis.json"
 fi
 
-exec tenderdash "$@"
-local exit_code=$?
+# Start tenderdash in the background
+tenderdash "$@" &
+child=$!
+wait "$child"
+exit_code=$?
 
-# TODO: Workaround for busy port problem happening with docker restart policy
-#   we are trying to start a new container but previous process still not release
-#   the port. Must be fix with graceful shutdown of tenderdash process.
-if [ $exit_code -ne 0 ] && [ "$1" == "start" ]; then
+if [ $got_signal == false ] && [ $exit_code -ne 0 ] && [ "$1" == "start" ]; then
   echo "Sleeping for 10 seconds as workaround for the busy port problem. See entrypoint code for details."
   sleep 10
 fi
 
-exit $error_code
+exit $exit_code


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
 "Error": "driver failed programming external connectivity on endpoint dashmate_devnet-molotov-drive_tenderdash-1 (4a531e194624e830ef487082276645b79a5d9c6b37e888bfdf10dbe55ac7b8fc): failed to bind port 10.0.50.116:36660/tcp: Error starting userland proxy: listen tcp4 10.0.50.116:36660: bind: address already in use",
```
Most probably it happening because we do not close all connections before we panic so when docker restart the container we still have some incoming on the interface

## What was done?
<!--- Describe your changes in detail -->
**This is a temporary workaround!** A proper solution should be a graceful shutdown of tenderdash networking on panic.

- Added 10 seconds of sleep if tenderdash exits with non-zero code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
