### PR TITLE
build: add signed binaries to releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@
 OUTPUT ?= build/tenderdash
 BUILDDIR ?= $(CURDIR)/build
 REPO_NAME ?= github.com/dashevo/tenderdash
-BUILD_TAGS ?= tenderdash
+BUILD_TAGS ?= tenderdash,netgo,osusergo
 # If building a release, please checkout the version tag to get the correct version setting
 ifneq ($(shell git symbolic-ref -q --short HEAD),)
 VERSION := unreleased-$(shell git symbolic-ref -q --short HEAD)-$(shell git rev-parse HEAD)
 else
 VERSION := $(shell git describe --tags)
 endif
-LD_FLAGS = -X ${REPO_NAME}/version.TMCoreSemVer=$(VERSION)
+LD_FLAGS = -X ${REPO_NAME}/version.TMCoreSemVer=$(VERSION) -linkmode 'external' -extldflags '-static'
 BUILD_FLAGS = -mod=readonly -ldflags "$(LD_FLAGS)"
 HTTPS_GIT := https://${REPO_NAME}.git
 BUILD_IMAGE := ghcr.io/tendermint/docker-build-proto

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD_TAGS ?= tenderdash
 ifneq ($(shell git symbolic-ref -q --short HEAD),)
 VERSION := unreleased-$(shell git symbolic-ref -q --short HEAD)-$(shell git rev-parse HEAD)
 else
-VERSION := $(shell git describe)
+VERSION := $(shell git describe --tags)
 endif
 LD_FLAGS = -X ${REPO_NAME}/version.TMCoreSemVer=$(VERSION)
 BUILD_FLAGS = -mod=readonly -ldflags "$(LD_FLAGS)"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Users want our binaries to be signed


## What was done?

Release script now builds and signs released binaries


## How Has This Been Tested?

When releasing v1.1.0

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
