### PR TITLE
build: dev releases fails due to invalid tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 OUTPUT ?= build/tenderdash
 BUILDDIR ?= $(CURDIR)/build
 REPO_NAME ?= github.com/dashevo/tenderdash
-BUILD_TAGS ?= tenderdash,netgo,osusergo
+BUILD_TAGS ?= tenderdash netgo osusergo
 # If building a release, please checkout the version tag to get the correct version setting
 ifneq ($(shell git symbolic-ref -q --short HEAD),)
 VERSION := unreleased-$(shell git symbolic-ref -q --short HEAD)-$(shell git rev-parse HEAD)

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -38,6 +38,7 @@ where flags can be one of:
     -r=<x.y.z-dev.n>, --release=<x.y.z-dev.n> - release number, like 0.7.0 (REQUIRED)
     --cleanup - clean up before releasing; it can remove your local changes
     -C=<path> - path to local Tenderdash repository
+    -s, --sign - generate signed binaries
     -h, --help - display this help message
 
 ## Examples
@@ -94,6 +95,10 @@ function parseArgs {
             displayHelp
             shift
             exit 0
+            ;;
+        -s | --sign)
+            SIGN=1
+            shift 1
             ;;
         *)
             error "Unrecoginzed command line argument '${arg}';  try '$0 --help'"
@@ -406,4 +411,6 @@ sleep 5 # wait for the release to be finalized
 success "Release ${NEW_PACKAGE_VERSION} created successfully."
 success "Accept it at: $(getReleaseUrl)"
 
-buildAndUploadArtifacts
+if [ -n "${SIGN}"  ];then
+    buildAndUploadArtifacts
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Build of dev release fails due to mixing of comma- and space-separated tags in the build command.

Introduced in #854 

## What was done?

Use space-separated tags in build command

## How Has This Been Tested?

GHA + local build

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
