### PR TITLE
build: e2e tests fail due to lack of docker-compose command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ build-binary:
 .PHONY: build-binary
 
 install:
-	$(GO) install $(BUILD_FLAGS) -tags $(BUILD_TAGS) ./cmd/tenderdash
+	$(GO) install $(BUILD_FLAGS) -tags '$(BUILD_TAGS)' ./cmd/tenderdash
 .PHONY: install
 
 $(BUILDDIR)/:
@@ -239,7 +239,7 @@ generate_test_cert:
 # dist builds binaries for all platforms and packages them for distribution
 # TODO add abci to these scripts
 dist:
-	@BUILD_TAGS=$(BUILD_TAGS) sh -c "'$(CURDIR)/scripts/dist.sh'"
+	@BUILD_TAGS='$(BUILD_TAGS)' sh -c "'$(CURDIR)/scripts/dist.sh'"
 .PHONY: dist
 
 go-mod-cache: go.sum
@@ -260,7 +260,7 @@ draw_deps:
 
 get_deps_bin_size:
 	@# Copy of build recipe with additional flags to perform binary size analysis
-	$(eval $(shell go build -work -a $(BUILD_FLAGS) -tags $(BUILD_TAGS) -o $(BUILDDIR)/ ./cmd/tendermint/ 2>&1))
+	$(eval $(shell go build -work -a $(BUILD_FLAGS) -tags '$(BUILD_TAGS)' -o $(BUILDDIR)/ ./cmd/tendermint/ 2>&1))
 	@find $(WORK) -type f -name "*.a" | xargs -I{} du -hxs "{}" | sort -rh | sed -e s:${WORK}/::g > deps_bin_size.log
 	@echo "Results can be found here: $(CURDIR)/deps_bin_size.log"
 .PHONY: get_deps_bin_size

--- a/Makefile
+++ b/Makefile
@@ -383,12 +383,12 @@ build_c-amazonlinux:
 # Run a 4-node testnet locally
 localnet-start: localnet-stop build-docker-localnode
 	@if ! [ -f build/node0/config/genesis.json ]; then docker run --rm -v $(CURDIR)/build:/tendermint:Z dashpay/tenderdash testnet --config /etc/tendermint/config-template.toml --o . --starting-ip-address 192.167.10.2; fi
-	docker-compose up
+	docker compose up
 .PHONY: localnet-start
 
 # Stop testnet
 localnet-stop:
-	docker-compose down
+	docker compose down
 .PHONY: localnet-stop
 
 # Build hooks for dredd, to skip or add information on some steps

--- a/docs/tools/docker-compose.md
+++ b/docs/tools/docker-compose.md
@@ -69,7 +69,7 @@ To change the number of validators / non-validators change the `localnet-start` 
 ```makefile
 localnet-start: localnet-stop
   @if ! [ -f build/node0/config/genesis.json ]; then docker run --rm -v $(CURDIR)/build:/tendermint:Z dashpay/tenderdash:localnode testnet --v 5 --n 3 --o . --populate-persistent-peers --starting-ip-address 192.167.10.2 ; fi
-  docker-compose up
+  docker compose up
 ```
 
 The command now will generate config files for 5 validators and 3

--- a/spec/ivy-proofs/README.md
+++ b/spec/ivy-proofs/README.md
@@ -27,7 +27,7 @@ The license above applies to all files in this folder.
 The easiest way to check the proofs is to use [Docker](https://www.docker.com/).
 
 1. Install [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/).
-2. Build a Docker image: `docker-compose build`
-3. Run the proofs inside the Docker container: `docker-compose run
+2. Build a Docker image: `docker compose build`
+3. Run the proofs inside the Docker container: `docker compose run
 tendermint-proof`. This will check all the proofs with the `ivy_check`
 command and write the output of `ivy_check` to a subdirectory of `./output/'

--- a/test/e2e/pkg/infra/docker/exec.go
+++ b/test/e2e/pkg/infra/docker/exec.go
@@ -10,14 +10,14 @@ import (
 // execCompose runs a Docker Compose command for a testnet.
 func execCompose(ctx context.Context, dir string, args ...string) error {
 	return exec.Command(ctx, append(
-		[]string{"docker-compose", "--ansi=never", "-f", filepath.Join(dir, "docker-compose.yml")},
+		[]string{"docker","compose", "--ansi=never", "-f", filepath.Join(dir, "docker-compose.yml")},
 		args...)...)
 }
 
 // execComposeVerbose runs a Docker Compose command for a testnet and displays its output.
 func execComposeVerbose(ctx context.Context, dir string, args ...string) error {
 	return exec.CommandVerbose(ctx, append(
-		[]string{"docker-compose", "--ansi=never", "-f", filepath.Join(dir, "docker-compose.yml")},
+		[]string{"docker","compose", "--ansi=never", "-f", filepath.Join(dir, "docker-compose.yml")},
 		args...)...)
 }
 

--- a/test/e2e/pkg/infra/docker/exec.go
+++ b/test/e2e/pkg/infra/docker/exec.go
@@ -10,14 +10,14 @@ import (
 // execCompose runs a Docker Compose command for a testnet.
 func execCompose(ctx context.Context, dir string, args ...string) error {
 	return exec.Command(ctx, append(
-		[]string{"docker","compose", "--ansi=never", "-f", filepath.Join(dir, "docker-compose.yml")},
+		[]string{"docker", "compose", "--ansi=never", "-f", filepath.Join(dir, "docker-compose.yml")},
 		args...)...)
 }
 
 // execComposeVerbose runs a Docker Compose command for a testnet and displays its output.
 func execComposeVerbose(ctx context.Context, dir string, args ...string) error {
 	return exec.CommandVerbose(ctx, append(
-		[]string{"docker","compose", "--ansi=never", "-f", filepath.Join(dir, "docker-compose.yml")},
+		[]string{"docker", "compose", "--ansi=never", "-f", filepath.Join(dir, "docker-compose.yml")},
 		args...)...)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

e2e tests stopped working due to missing `docker-compose` command


## What was done?

replaced with `docker` command with `compose` argument.

## How Has This Been Tested?

Run GHA tests

## Breaking Changes

None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
