### PR TITLE
fix(consensus): msg queue is too small for mainnet

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -46,7 +46,13 @@ var (
 	ErrPrivValidatorNotSet = errors.New("priv-validator is not set")
 )
 
-var msgQueueSize = 1000
+// msgInfoQueue must fit info about all votes from all validators 100 for Dash Evo mainnet),
+// multiplied by number of peers that can broadcast these votes (also assuming 100),
+// multiplied by some factor (here 2) to address multiple rounds.
+//
+// Note this allows potential OOM condition if we put 20 000 proposal block of size
+// types.BlockPartSizeBytes==64 kB, what gives us 1.2 GB of memory usage.
+var msgQueueSize = 100 * 100 * 2
 
 // msgs from the reactor which may update the state
 type msgInfo struct {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Internal message queue has a size of 1000, which is not big enough for a network with 100 validators.

## What was done?

Increased to 20 000.

## How Has This Been Tested?

GHA + devnet testing

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
