### PR TITLE
feat(consensus): connect to all other quorum members

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1165,15 +1165,16 @@ type ConsensusConfig struct {
 // DefaultConsensusConfig returns a default configuration for the consensus service
 func DefaultConsensusConfig() *ConsensusConfig {
 	return &ConsensusConfig{
-		WalPath:                      filepath.Join(defaultDataDir, "cs.wal", "wal"),
-		WalSkipRoundsToLast:          false,
-		CreateEmptyBlocks:            true,
-		CreateEmptyBlocksInterval:    0 * time.Second,
-		PeerGossipSleepDuration:      100 * time.Millisecond,
-		PeerQueryMaj23SleepDuration:  2000 * time.Millisecond,
-		DoubleSignCheckHeight:        int64(0),
-		DontAutoPropose:              false,
-		ValidatorConnectionAlgorithm: ValidatorConnectionAlgorithmDIP6,
+		WalPath:                     filepath.Join(defaultDataDir, "cs.wal", "wal"),
+		WalSkipRoundsToLast:         false,
+		CreateEmptyBlocks:           true,
+		CreateEmptyBlocksInterval:   0 * time.Second,
+		PeerGossipSleepDuration:     100 * time.Millisecond,
+		PeerQueryMaj23SleepDuration: 2000 * time.Millisecond,
+		DoubleSignCheckHeight:       int64(0),
+		DontAutoPropose:             false,
+		// TODO: Change to DIP6 or update docs that default is "all"
+		ValidatorConnectionAlgorithm: ValidatorConnectionAlgorithmAll,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -553,6 +553,15 @@ create-empty-blocks-interval = "{{ .Consensus.CreateEmptyBlocksInterval }}"
 peer-gossip-sleep-duration = "{{ .Consensus.PeerGossipSleepDuration }}"
 peer-query-maj23-sleep-duration = "{{ .Consensus.PeerQueryMaj23SleepDuration }}"
 
+# ValidatorConnectionAlgorithm defines the algorithm used to select the
+# validators to which direct connection should be established.
+# Possible values are:
+# - "all" - validators establish direct connections to all other validators in the current quorum
+# - "dip6" - validators establish direct connections to a subset of other validators, determined according to DIP-6
+#
+# Defaults to "dip6".
+validator-connection-algorithm = "{{ .Consensus.ValidatorConnectionAlgorithm }}"
+
 ### Unsafe Timeout Overrides ###
 
 # These fields provide temporary overrides for the Timeout consensus parameters.

--- a/dash/quorum/selectpeers/allvalidators.go
+++ b/dash/quorum/selectpeers/allvalidators.go
@@ -1,0 +1,31 @@
+package selectpeers
+
+import (
+	"github.com/dashpay/tenderdash/types"
+)
+
+type allValidatorsSelector struct {
+}
+
+var _ ValidatorSelector = (*allValidatorsSelector)(nil)
+
+// NewAllValidatorsSelector creates new implementation of validator selector algorithm
+// that selects all validators except local node
+func NewAllValidatorsSelector() ValidatorSelector {
+	return &allValidatorsSelector{}
+}
+
+// SelectValidators implements ValidtorSelector.
+// SelectValidators selects all validators from `validatorSetMembers`, except local node
+func (s *allValidatorsSelector) SelectValidators(
+	validatorSetMembers []*types.Validator,
+	me *types.Validator,
+) ([]*types.Validator, error) {
+	ret := make([]*types.Validator, 0, len(validatorSetMembers)-1)
+	for _, val := range validatorSetMembers {
+		if !val.ProTxHash.Equal(me.ProTxHash) {
+			ret = append(ret, val)
+		}
+	}
+	return ret, nil
+}

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -46,7 +46,13 @@ var (
 	ErrPrivValidatorNotSet = errors.New("priv-validator is not set")
 )
 
-var msgQueueSize = 1000
+// msgInfoQueue must fit info about all votes from all validators 100 for Dash Evo mainnet),
+// multiplied by number of peers that can broadcast these votes (also assuming 100),
+// multiplied by some factor (here 2) to address multiple rounds.
+//
+// Note this allows potential OOM condition if we put 20 000 proposal block of size
+// types.BlockPartSizeBytes==64 kB, what gives us 1.2 GB of memory usage.
+var msgQueueSize = 100 * 100 * 2
 
 // msgs from the reactor which may update the state
 type msgInfo struct {

--- a/internal/consensus/state_add_prop_block.go
+++ b/internal/consensus/state_add_prop_block.go
@@ -166,6 +166,7 @@ func (c *AddProposalBlockPartAction) addProposalBlockPart(
 				"height", stateData.RoundState.Height,
 				"round", stateData.RoundState.Round,
 				"hash", stateData.ProposalBlock.Hash(),
+				"peer", peerID,
 			)
 			// We received a commit before the block
 			// Transit to AddCommit
@@ -180,6 +181,7 @@ func (c *AddProposalBlockPartAction) addProposalBlockPart(
 			"hash", stateData.ProposalBlock.Hash(),
 			"round_height", stateData.RoundState.GetHeight(),
 			"num_txs", len(stateData.ProposalBlock.Txs),
+			"peer", peerID,
 		)
 
 		c.eventPublisher.PublishCompleteProposalEvent(stateData.CompleteProposalEvent())

--- a/internal/consensus/state_prevoter.go
+++ b/internal/consensus/state_prevoter.go
@@ -38,7 +38,7 @@ func newPrevote(logger log.Logger, voteSigner *voteSigner, blockExec *blockExecu
 func (p *prevoter) Do(ctx context.Context, stateData *StateData) error {
 	err := stateData.isValidForPrevote()
 	if err != nil {
-		keyVals := append(prevoteKeyVals(stateData), "error", err)
+		keyVals := append(prevoteKeyVals(stateData), "err", err)
 
 		if !errors.Is(err, errPrevoteProposalBlockNil) {
 			p.logger.Error("prevote is invalid", keyVals...)

--- a/internal/evidence/verify_test.go
+++ b/internal/evidence/verify_test.go
@@ -84,9 +84,9 @@ func TestVerifyDuplicateVoteEvidence(t *testing.T) {
 			Timestamp:        defaultEvidenceTime,
 		}
 		if c.valid {
-			assert.Nil(t, evidence.VerifyDuplicateVote(ev, chainID, valSet), "evidence should be valid")
+			assert.Nil(t, evidence.VerifyDuplicateVote(ev, chainID, valSet, logger), "evidence should be valid")
 		} else {
-			assert.NotNil(t, evidence.VerifyDuplicateVote(ev, chainID, valSet), "evidence should be invalid")
+			assert.NotNil(t, evidence.VerifyDuplicateVote(ev, chainID, valSet, logger), "evidence should be invalid")
 		}
 	}
 

--- a/internal/p2p/conn/connection.go
+++ b/internal/p2p/conn/connection.go
@@ -273,7 +273,7 @@ func (c *MConnection) String() string {
 }
 
 func (c *MConnection) flush() {
-	c.logger.Trace("Flush", "conn", c)
+	// c.logger.Trace("Flush", "conn", c)
 	err := c.bufConnWriter.Flush()
 	if err != nil {
 		c.logger.Debug("MConnection flush failed", "err", err)
@@ -304,7 +304,7 @@ func (c *MConnection) Send(chID ChannelID, msgBytes []byte) bool {
 		return false
 	}
 
-	c.logger.Trace("Send", "channel", chID, "conn", c, "msgBytes", msgBytes)
+	// c.logger.Trace("Send", "channel", chID, "conn", c, "msgBytes", msgBytes)
 
 	// Send message to channel.
 	channel, ok := c.channelsIdx[chID]
@@ -557,7 +557,7 @@ FOR_LOOP:
 				break FOR_LOOP
 			}
 			if msgBytes != nil {
-				c.logger.Trace("Received bytes", "chID", channelID, "msgBytes", msgBytes)
+				// c.logger.Trace("Received bytes", "chID", channelID, "msgBytes", msgBytes)
 				// NOTE: This means the reactor.Receive runs in the same thread as the p2p recv routine
 				c.onReceive(ctx, channelID, msgBytes)
 			}
@@ -735,7 +735,7 @@ func (ch *channel) writePacketMsgTo(w io.Writer) (n int, err error) {
 // complete, which is owned by the caller and will not be modified.
 // Not goroutine-safe
 func (ch *channel) recvPacketMsg(packet tmp2p.PacketMsg) ([]byte, error) {
-	ch.logger.Trace("Read PacketMsg", "conn", ch.conn, "packet", packet)
+	// ch.logger.Trace("Read PacketMsg", "conn", ch.conn, "packet", packet)
 	var recvCap, recvReceived = ch.desc.RecvMessageCapacity, len(ch.recving) + len(packet.Data)
 	if recvCap < recvReceived {
 		return nil, fmt.Errorf("received message exceeds available capacity: %v < %v", recvCap, recvReceived)

--- a/node/node.go
+++ b/node/node.go
@@ -444,7 +444,9 @@ func makeNode(
 			dcm,
 			dashquorum.WithLogger(vcLogger),
 			dashquorum.WithValidatorsSet(state.Validators),
-			dashquorum.WithStateStore(stateStore))
+			dashquorum.WithStateStore(stateStore),
+			dashquorum.WithSelectionAlgorithm(cfg.Consensus.ValidatorConnectionAlgorithm),
+		)
 		if err != nil {
 			return nil, combineCloseError(err, makeCloser(closers))
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -324,7 +324,7 @@ func makeNode(
 	blockSync := !onlyValidatorIsUs(state, proTxHash) // TODO compare with this: blockSync := cfg.BlockSync.Enable && !weAreOnlyValidator
 	waitSync := stateSync || blockSync
 
-	csState, err := consensus.NewState(logger.With("module", "consensus"),
+	csState, err := consensus.NewState(logger.With("module", "consensus", "node_id", nodeKey.ID),
 		cfg.Consensus,
 		stateStore,
 		blockExec,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Time between generation of a proposal and delivery to last validator is too high. To improve this, we can establish direct connections between all validators in the quorum.


## What was done?

Implemented validator connection selector `allValidatorsSelector` that selects all validators in the quorum except self.

Introduced new config option:

```
[consensus]
# ValidatorConnectionAlgorithm defines the algorithm used to select the
# validators to which direct connection should be established.
# Possible values are:
# - "all" - validators establish direct connections to all other validators in the current quorum
# - "dip6" - validators establish direct connections to a subset of other validators, determined according to DIP-6
#
# Defaults to "dip6".
validator-connection-algorithm = "{{ .Consensus.ValidatorConnectionAlgorithm }}"
```

## How Has This Been Tested?

NOT TESTED YET


## Breaking Changes

None - backwards-compatible

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
