### PR TITLE
fix: non-active validators can't verify evidence signatures

### DIFF
--- a/internal/evidence/pool.go
+++ b/internal/evidence/pool.go
@@ -544,6 +544,13 @@ func (evpool *Pool) updateState(state sm.State) {
 	evpool.state = state
 }
 
+// hasPublicKeys returns true if we have public keys of the current validator set.
+func (evpool *Pool) hasPublicKeys() bool {
+	evpool.mtx.Lock()
+	defer evpool.mtx.Unlock()
+	return evpool.state.Validators.HasPublicKeys
+}
+
 // processConsensusBuffer converts all the duplicate votes witnessed from consensus
 // into DuplicateVoteEvidence. It sets the evidence timestamp to the block height
 // from the most recently committed block.

--- a/internal/evidence/pool_test.go
+++ b/internal/evidence/pool_test.go
@@ -528,6 +528,7 @@ func initializeValidatorState(
 		ThresholdPublicKey: validator.PubKey,
 		QuorumType:         quorumType,
 		QuorumHash:         quorumHash,
+		HasPublicKeys:      true,
 	}
 
 	return initializeStateFromValidatorSet(t, valSet, height)

--- a/internal/evidence/reactor.go
+++ b/internal/evidence/reactor.go
@@ -111,6 +111,7 @@ func (r *Reactor) handleEvidenceMessage(ctx context.Context, envelope *p2p.Envel
 		if !r.evpool.state.Validators.HasPublicKeys {
 			// silently drop the message
 			logger.Debug("dropping evidence message as we are not a validator", "evidence", envelope.Message)
+			return nil
 		}
 
 		// Process the evidence received from a peer

--- a/internal/evidence/reactor.go
+++ b/internal/evidence/reactor.go
@@ -108,9 +108,9 @@ func (r *Reactor) handleEvidenceMessage(ctx context.Context, envelope *p2p.Envel
 		//
 		// TODO: We need to figure out how to handle evidence from non-validator nodes, to avoid scenarios where some
 		// evidence is lost.
-		if !r.evpool.state.Validators.HasPublicKeys {
+		if !r.evpool.hasPublicKeys() {
 			// silently drop the message
-			logger.Debug("dropping evidence message as we are not a validator", "evidence", envelope.Message)
+			logger.Debug("dropping evidence message as we don't have validator public keys", "evidence", envelope.Message)
 			return nil
 		}
 

--- a/internal/evidence/reactor.go
+++ b/internal/evidence/reactor.go
@@ -101,6 +101,18 @@ func (r *Reactor) handleEvidenceMessage(ctx context.Context, envelope *p2p.Envel
 
 	switch msg := envelope.Message.(type) {
 	case *tmproto.Evidence:
+
+		// Only accept evidence if we are an active validator.
+		// On other hosts, signatures in evidence (if any) cannot be verified due to lack of validator public keys,
+		// and it creates risk of adding invalid evidence to the pool.
+		//
+		// TODO: We need to figure out how to handle evidence from non-validator nodes, to avoid scenarios where some
+		// evidence is lost.
+		if !r.evpool.state.Validators.HasPublicKeys {
+			// silently drop the message
+			logger.Debug("dropping evidence message as we are not a validator", "evidence", envelope.Message)
+		}
+
 		// Process the evidence received from a peer
 		// Evidence is sent and received one by one
 		ev, err := types.EvidenceFromProto(msg)

--- a/internal/evidence/verify_test.go
+++ b/internal/evidence/verify_test.go
@@ -84,9 +84,9 @@ func TestVerifyDuplicateVoteEvidence(t *testing.T) {
 			Timestamp:        defaultEvidenceTime,
 		}
 		if c.valid {
-			assert.Nil(t, evidence.VerifyDuplicateVote(ev, chainID, valSet), "evidence should be valid")
+			assert.Nil(t, evidence.VerifyDuplicateVote(ev, chainID, valSet, logger), "evidence should be valid")
 		} else {
-			assert.NotNil(t, evidence.VerifyDuplicateVote(ev, chainID, valSet), "evidence should be invalid")
+			assert.NotNil(t, evidence.VerifyDuplicateVote(ev, chainID, valSet, logger), "evidence should be invalid")
 		}
 	}
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Nodes that are not active validators don't have access to public keys of validators, so they cannot verify signatures in evidence.

## What was done?

1. Non-validators don't verify signatures
2. Non-validators don't add evidence to evidence pool, to avoid adding fake evidence

## How Has This Been Tested?

GHA

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
