### PR TITLE
fix(config): panic when loading invalid node key file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -300,6 +300,11 @@ func (cfg BaseConfig) LoadNodeKeyID() (types.NodeID, error) {
 	if err != nil {
 		return "", err
 	}
+
+	if err = nodeKey.Validate(); err != nil {
+		return "", fmt.Errorf("invalid node key file %s: %w", cfg.NodeKeyFile(), err)
+	}
+
 	nodeKey.ID = types.NodeIDFromPubKey(nodeKey.PubKey())
 	return nodeKey.ID, nil
 }

--- a/types/node_key.go
+++ b/types/node_key.go
@@ -44,7 +44,11 @@ func (nk *NodeKey) Validate() error {
 		return fmt.Errorf("invalid or empty private key")
 	}
 	if err := nk.ID.Validate(); err != nil {
-		return fmt.Errorf("invalid key ID: %w", err)
+		return fmt.Errorf("invalid node ID: %w", err)
+	}
+	keyID := NodeIDFromPubKey(nk.PrivKey.PubKey())
+	if nk.ID != keyID {
+		return fmt.Errorf("saved node ID %s does not match public key %s", nk.ID, keyID)
 	}
 	return nil
 }

--- a/types/node_key.go
+++ b/types/node_key.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/dashpay/tenderdash/crypto"
@@ -36,6 +37,16 @@ func (nk NodeKey) MarshalJSON() ([]byte, error) {
 	return json.Marshal(nodeKeyJSON{
 		ID: nk.ID, PrivKey: pk,
 	})
+}
+
+func (nk *NodeKey) Validate() error {
+	if nk.PrivKey == nil {
+		return fmt.Errorf("invalid or empty private key")
+	}
+	if err := nk.ID.Validate(); err != nil {
+		return fmt.Errorf("invalid key ID: %w", err)
+	}
+	return nil
 }
 
 func (nk *NodeKey) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

When node_key.json contains valid json but is malformed, commands like `tenderdash show-node-id` fail with panic.

## What was done?

Added validation


## How Has This Been Tested?

Manually with `tenderdash show-node-id`, added unit test.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
