### PR TITLE
fix(node): genesis.json not loaded on restart before genesis block is mined

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -719,7 +719,8 @@ func loadStateFromDBOrGenesisDocProvider(stateStore sm.Store, genDoc *types.Gene
 		return sm.State{}, err
 	}
 
-	if state.IsEmpty() {
+	// If genesis state wasn't mined yet (last block height is 0), we assume that loaded state should be wiped
+	if state.IsEmpty() || state.LastBlockHeight == 0 {
 		// 2. If it's not there, derive it from the genesis doc
 		state, err = sm.MakeGenesisState(genDoc)
 		if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

If Tenderdash crashes/restarts before mining first (genesis) block, it persists some initial state and reuses it after restart.
It means that any changes to the `genesis.json` file are not loaded on restart..

## What was done?

Discard persisted state when persisted height is 0.

## How Has This Been Tested?

e2e tests

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
