### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ recommend keeping Tenderdash up-to-date.
 Before contributing to the project, please take a look at the [contributing
 guidelines](CONTRIBUTING.md) and the [style guide](STYLE_GUIDE.md). You may also find it helpful to
 read the [Tendermint specifications](./spec/README.md), and familiarize yourself with the
-[Architectural Decision Records (ADRs)](./docs/architecture/README.md) and [Request For Comments
-(RFCs)](./docs/rfc/README.md).
+[Architectural Decision Records (ADRs)](./docs/architecture/) and [Request For Comments
+(RFCs)](./docs/rfc/).
 
 ## Join us
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
A couple links pointed to non-existent docs

## What was done?
Changed links to point to directory instead

## How Has This Been Tested?
Locally

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated links in the README for Architectural Decision Records (ADRs) and Request For Comments (RFCs) to improve navigation.
	- Minor formatting adjustments for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->