### PR TITLE
fix(consensus): node stalled after client has stopped

### DIFF
--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -38,6 +38,10 @@ type socketClient struct {
 
 var _ Client = (*socketClient)(nil)
 
+var (
+	ErrClientStopped = errors.New("client has stopped")
+)
+
 // NewSocketClient creates a new socket client, which connects to a given
 // address. If mustConnect is true, the client will return an error upon start
 // if it fails to connect.
@@ -234,7 +238,7 @@ func (cli *socketClient) didRecvResponse(res *types.Response) error {
 
 func (cli *socketClient) doRequest(ctx context.Context, req *types.Request) (*types.Response, error) {
 	if !cli.IsRunning() {
-		return nil, errors.New("client has stopped")
+		return nil, ErrClientStopped
 	}
 
 	reqres := makeReqRes(ctx, req)

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -39,6 +39,7 @@ type socketClient struct {
 var _ Client = (*socketClient)(nil)
 
 var (
+	// ErrClientStopped is returned when client wasn't started yet or it was terminated with an error.
 	ErrClientStopped = errors.New("client has stopped")
 )
 

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	abciclient "github.com/dashpay/tenderdash/abci/client"
+	clientmocks "github.com/dashpay/tenderdash/abci/client/mocks"
 	"github.com/dashpay/tenderdash/abci/example/kvstore"
 	abci "github.com/dashpay/tenderdash/abci/types"
 	abcimocks "github.com/dashpay/tenderdash/abci/types/mocks"
@@ -22,6 +24,7 @@ import (
 	"github.com/dashpay/tenderdash/internal/mempool"
 	tmpubsub "github.com/dashpay/tenderdash/internal/pubsub"
 	tmquery "github.com/dashpay/tenderdash/internal/pubsub/query"
+	sm "github.com/dashpay/tenderdash/internal/state"
 	sf "github.com/dashpay/tenderdash/internal/state/test/factory"
 	"github.com/dashpay/tenderdash/internal/test/factory"
 	tmbytes "github.com/dashpay/tenderdash/libs/bytes"
@@ -3270,6 +3273,83 @@ func TestStateTryAddCommitCallsProcessProposal(t *testing.T) {
 	err = otherNode.ctrl.Dispatch(ctx, &TryAddCommitEvent{Commit: commit, PeerID: peerID}, &css1StateData)
 	assert.Equal(t, int64(2), css1StateData.Height)
 	assert.NoError(t, err)
+}
+
+// TestStateTryAddCommitPanicsOnClientError ensures that
+// given ABCI client that errors on ProcessProposal,
+// when new block is about to be processed,
+// then the TryAddCommitEvent causes a panic.
+func TestStateTryAddCommitPanicsOnClientError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	config := configSetup(t)
+	t.Helper()
+
+	// setup some node and commit
+	genDoc, privVals := factory.RandGenesisDoc(1, factory.ConsensusParams())
+	logger := consensusLogger(t)
+
+	state, err := sm.MakeGenesisState(genDoc)
+	require.NoError(t, err)
+
+	// Create a panicking app
+	app := clientmocks.NewClient(t)
+	app.On("ProcessProposal", mock.Anything, mock.Anything).
+		Return(&abci.ResponseProcessProposal{}, abciclient.ErrClientStopped).
+		Once()
+
+	// create a new consensus state
+	proTxHash, _ := privVals[0].GetProTxHash(ctx)
+	ctx = dash.ContextWithProTxHash(ctx, proTxHash)
+	consensusState := newStateWithConfig(ctx, t, logger, config, state, privVals[0], app)
+
+	stateData := consensusState.GetStateData()
+
+	// create proposal and a block to be processed
+	block, err := sf.MakeBlock(state, 1, &types.Commit{}, kvstore.ProtocolVersion)
+	require.NoError(t, err)
+	require.NotZero(t, block.Version.App)
+	block.CoreChainLockedHeight = 1
+
+	commit, err := factory.MakeCommit(
+		ctx,
+		block.BlockID(nil),
+		block.Height,
+		0,
+		stateData.Votes.Precommits(0),
+		state.Validators,
+		privVals,
+	)
+	require.NoError(t, err)
+
+	proposal := types.NewProposal(
+		block.Height,
+		block.CoreChainLockedHeight,
+		0,
+		-1,
+		commit.BlockID,
+		block.Time)
+
+	parts, err := block.MakePartSet(999999999)
+	require.NoError(t, err)
+
+	// emulate that the node has received proposal and block
+	peerID := stateData.Validators.Proposer().NodeAddress.NodeID
+	stateData.Proposal = proposal
+	stateData.ProposalBlock = block
+	stateData.ProposalBlockParts = parts
+	stateData.updateRoundStep(commit.Round, cstypes.RoundStepPrevote)
+
+	// invoke the TryAddCommitEvent to see if it will panic
+	ctx = msgInfoWithCtx(ctx, msgInfo{
+		Msg:         &CommitMessage{commit},
+		PeerID:      peerID,
+		ReceiveTime: time.Time{},
+	})
+
+	assert.Panics(t, func() {
+		_ = consensusState.ctrl.Dispatch(ctx, &TryAddCommitEvent{Commit: commit, PeerID: peerID}, &stateData)
+	})
 }
 
 // TestStateTimestamp_ProposalMatch tests that a validator prevotes a


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Tenderdash does not recover after ABCI client errors and stops.

## What was done?

Added proper error handling to panic on stopped client.
This causes restart of Tenderdash Docker container, reconnecting the client.

## How Has This Been Tested?

Added unit test

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new error variable, `ErrClientStopped`, for improved error reporting.

- **Bug Fixes**
  - Enhanced error handling in the commit verification process, now triggering a panic for specific error conditions.

- **Tests**
  - Added a new test to verify panic behavior on client errors.
  - Updated existing tests for more comprehensive checks and clarity.

- **Documentation**
  - Comments updated for clarity regarding error implications and verification processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->