### PR TITLE
build(deps): bump alpine to 3.21, golang to 1.23.6

### DIFF
--- a/.github/actions/bls/action.yml
+++ b/.github/actions/bls/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.23.2"
+        go-version: "1.23.6"
     - uses: actions/checkout@v2
       with:
         submodules: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5.3.0
         with:
-          go-version: "1.23.2"
+          go-version: "1.23.6"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5.3.0
         with:
-          go-version: "1.23.2"
+          go-version: "1.23.6"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5.3.0
         with:
-          go-version: "1.23.2"
+          go-version: "1.23.6"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5.3.0
         with:
-          go-version: "1.23.2"
+          go-version: "1.23.6"
 
       - uses: actions/checkout@v4
 
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5.3.0
         with:
-          go-version: "1.23.2"
+          go-version: "1.23.6"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5.3.0
         with:
-          go-version: "1.23.2"
+          go-version: "1.23.6"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.8.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-go@v5.3.0
         if: env.GIT_DIFF
         with:
-          go-version: "^1.23.2"
+          go-version: "^1.23.6"
 
       - name: Install dependencies
         if: env.GIT_DIFF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v5.3.0
         with:
-          go-version: "1.23.2"
+          go-version: "1.23.6"
 
       - name: Build
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-go@v5.3.0
         if: env.GIT_DIFF
         with:
-          go-version: "1.23.2"
+          go-version: "1.23.6"
 
       - name: Install libpcap
         if: env.GIT_DIFF

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -5,7 +5,7 @@
 # * image - creates final image of minimal size
 
 ARG ALPINE_VERSION=3.19
-ARG GOLANG_VERSION=1.23.2
+ARG GOLANG_VERSION=1.23.6
 #################################
 # STAGE 1: install dependencies #
 #################################

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -4,7 +4,7 @@
 # * compile - builds final binaries
 # * image - creates final image of minimal size
 
-ARG ALPINE_VERSION=3.19
+ARG ALPINE_VERSION=3.21
 ARG GOLANG_VERSION=1.23.6
 #################################
 # STAGE 1: install dependencies #

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ requirements if installing from source.
 
 | Requirement | Notes            |
 |-------------|------------------|
-| Go version  | Go1.23.2 or higher |
+| Go version  | Go1.23.6 or higher |
 
 ## Versioning
 

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -596,7 +596,7 @@ This will populate the `go.mod` with a release number followed by a hash for Ten
 ```go
 module github.com/<username>/kvstore
 
-go 1.23.2
+go 1.23.6
 
 require (
  github.com/dgraph-io/badger/v3 v3.2103.2

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -454,7 +454,7 @@ This will populate the `go.mod` with a release number followed by a hash for Ten
 ```go
 module github.com/<username>/kvstore
 
-go 1.23.2
+go 1.23.6
 
 require (
  github.com/dgraph-io/badger/v3 v3.2103.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dashpay/tenderdash
 
-go 1.23.2
+go 1.23.6
 
 require (
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,5 +1,5 @@
 ## Stage 1 and 2 is copied from /DOCKER/Dockerfile
-ARG ALIPNE_VERSION=3.19
+ARG ALIPNE_VERSION=3.21
 ARG GOLANG_VERSION=1.23.6
 #################################
 # STAGE 1: install dependencies #

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,6 +1,6 @@
 ## Stage 1 and 2 is copied from /DOCKER/Dockerfile
 ARG ALIPNE_VERSION=3.19
-ARG GOLANG_VERSION=1.23.2
+ARG GOLANG_VERSION=1.23.6
 #################################
 # STAGE 1: install dependencies #
 #################################

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -1,7 +1,7 @@
 # fuzz
 
 Fuzzing for various packages in Tendermint using the fuzzing infrastructure included in
-Go 1.23.2.
+Go 1.23.6.
 
 Inputs:
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Go >= 1.23.5 is needed by #1041 

Unfortunately, it's not supported by Alpine 3.19, so we update to the newest one (3.21).

## What was done?

Updated Golang to 1.23.6
Updated Alpine to 3.21

## How Has This Been Tested?

GHA

## Breaking Changes

New version of go is required to build

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the Go environment from version 1.23.2 to 1.23.6 across CI pipelines, testing workflows, and Docker builds to enhance stability and performance.

- **Documentation**
  - Updated the minimum Go version requirement.
  - Enhanced tutorials with detailed, step-by-step guidance for setting up a new project, integrating a database, and testing transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->