### PR TITLE
feat(store): rollback --store flag to to include block store in rollback

### DIFF
--- a/cmd/tenderdash/commands/rollback_test.go
+++ b/cmd/tenderdash/commands/rollback_test.go
@@ -48,7 +48,7 @@ func TestRollbackIntegration(t *testing.T) {
 	t.Run("Rollback", func(t *testing.T) {
 		time.Sleep(time.Second)
 		require.NoError(t, app.Rollback())
-		height, _, err = commands.RollbackState(cfg)
+		height, _, err = commands.RollbackState(cfg, false)
 		require.NoError(t, err, "%d", height)
 	})
 	t.Run("Restart", func(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -358,6 +358,57 @@ func (bs *BlockStore) PruneBlocks(height int64) (uint64, error) {
 	return pruned, nil
 }
 
+// DeleteBlock removes the block at the given height, including its parts and commit.
+// It returns the number of blocks removed, which is always 1 in this case.
+func (bs *BlockStore) DeleteBlock(height int64) (uint64, error) {
+	if height <= 0 {
+		return 0, fmt.Errorf("height must be greater than 0")
+	}
+
+	// Check if block exists at this height
+	blockMeta := bs.LoadBlockMeta(height)
+	if blockMeta == nil {
+		return 0, fmt.Errorf("block at height %d does not exist", height)
+	}
+
+	batch := bs.db.NewBatch()
+	defer batch.Close()
+
+	// Delete the hash key corresponding to the block meta's hash
+	if err := batch.Delete(blockHashKey(blockMeta.BlockID.Hash)); err != nil {
+		return 0, fmt.Errorf("failed to delete hash key: %X: %w", blockHashKey(blockMeta.BlockID.Hash), err)
+	}
+
+	// Delete block meta
+	if err := batch.Delete(blockMetaKey(height)); err != nil {
+		return 0, fmt.Errorf("failed to delete block meta at height %d: %w", height, err)
+	}
+
+	// Delete block parts
+	for i := 0; i < int(blockMeta.BlockID.PartSetHeader.Total); i++ {
+		if err := batch.Delete(blockPartKey(height, i)); err != nil {
+			return 0, fmt.Errorf("failed to delete block part at height %d, index %d: %w", height, i, err)
+		}
+	}
+
+	// Delete block commit
+	if err := batch.Delete(blockCommitKey(height)); err != nil {
+		return 0, fmt.Errorf("failed to delete block commit at height %d: %w", height, err)
+	}
+
+	// Delete seen commit at this height if it exists
+	if err := batch.Delete(seenCommitAtKey(height)); err != nil {
+		return 0, fmt.Errorf("failed to delete seen commit at height %d: %w", height, err)
+	}
+
+	// Write all deletions atomically
+	if err := batch.WriteSync(); err != nil {
+		return 0, fmt.Errorf("failed to write deletions for height %d: %w", height, err)
+	}
+
+	return 1, nil
+}
+
 // pruneRange is a generic function for deleting a range of values based on the lowest
 // height up to but excluding retainHeight. For each key/value pair, an optional hook can be
 // executed before the deletion itself is made. pruneRange will use batch delete to delete


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

This change introduces a new store flag to the rollback command, allowing users to optionally roll back the block store to match the state height after a rollback operation. This feature is required to ensure consistency between the block store and state during recovery scenarios.


## What was done?

Updated the rollback command to include the store flag.
Modified the RollbackState function to conditionally roll back the block store based on the flag.
Added documentation for the store flag in the command description.


## How Has This Been Tested?

1. Verified the rollback functionality with and without the store flag in a local testnet full node.
2. Ensured that the block store height matches the state height after rollback when the store flag is set.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional flag to the rollback command, allowing users to roll back the block store along with the state.

- **Bug Fixes**
  - Improved error handling during block deletion when rolling back the block store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->