### PR TITLE
fix: retry dash core requests when they fail

### DIFF
--- a/privval/dash_core_signer_client.go
+++ b/privval/dash_core_signer_client.go
@@ -74,7 +74,7 @@ func (sc *DashCoreSignerClient) Close() error {
 // Implement PrivValidator
 
 // Ping sends a ping request to the remote signer and will retry 2 extra times if failure
-func (sc *DashCoreSignerClient) Ping() error {
+func (sc *DashCoreSignerClient) Ping(ctx context.Context) error {
 	var err error
 	for i := 0; i < 3; i++ {
 		if err = sc.ping(); err == nil {

--- a/privval/retry_signer_client.go
+++ b/privval/retry_signer_client.go
@@ -64,45 +64,50 @@ func (sc *RetrySignerClient) ExtractIntoValidator(ctx context.Context, quorumHas
 	}
 }
 
-func (sc *RetrySignerClient) GetPubKey(ctx context.Context, quorumHash crypto.QuorumHash) (crypto.PubKey, error) {
-	var (
-		pk  crypto.PubKey
-		err error
-	)
+// retry runs some code with retries and a timeout.
+// It implements exponential backoff.
+func retry[T any](ctx context.Context, sc *RetrySignerClient, fn func() (T, error)) (T, error) {
+	var zero T
+	backoff := sc.timeout
 	for i := 0; i < sc.retries || sc.retries == 0; i++ {
-		pk, err = sc.next.GetPubKey(ctx, quorumHash)
+		val, err := fn()
 		if err == nil {
-			return pk, nil
+			return val, nil
 		}
 		// If remote signer errors, we don't retry.
 		if _, ok := err.(*RemoteSignerError); ok {
-			return nil, err
+			return zero, err
 		}
-		time.Sleep(sc.timeout)
+		select {
+		case <-ctx.Done():
+			return zero, ctx.Err()
+		case <-time.After(backoff):
+			// Exponential backoff with a cap (e.g., 10x initial timeout)
+			if backoff < sc.timeout*10 {
+				backoff *= 2
+				if backoff > sc.timeout*10 {
+					backoff = sc.timeout * 10
+				}
+			}
+		}
 	}
-	return nil, fmt.Errorf("exhausted all attempts to get pubkey: %w", err)
+	return zero, fmt.Errorf("exhausted all attempts: %w", ctx.Err())
+}
+
+func (sc *RetrySignerClient) GetPubKey(ctx context.Context, quorumHash crypto.QuorumHash) (crypto.PubKey, error) {
+	return retry(ctx, sc, func() (crypto.PubKey, error) {
+		return sc.next.GetPubKey(ctx, quorumHash)
+	})
 }
 
 func (sc *RetrySignerClient) GetProTxHash(ctx context.Context) (crypto.ProTxHash, error) {
-	var (
-		proTxHash crypto.ProTxHash
-		err       error
-	)
-	for i := 0; i < sc.retries || sc.retries == 0; i++ {
-		proTxHash, err = sc.next.GetProTxHash(ctx)
+	return retry(ctx, sc, func() (crypto.ProTxHash, error) {
+		proTxHash, err := sc.next.GetProTxHash(ctx)
 		if len(proTxHash) != crypto.ProTxHashSize {
 			return nil, fmt.Errorf("retrySignerClient proTxHash is invalid size")
 		}
-		if err == nil {
-			return proTxHash, nil
-		}
-		// If remote signer errors, we don't retry.
-		if _, ok := err.(*RemoteSignerError); ok {
-			return nil, err
-		}
-		time.Sleep(sc.timeout)
-	}
-	return nil, fmt.Errorf("exhausted all attempts to get protxhash: %w", err)
+		return proTxHash, err
+	})
 }
 
 func (sc *RetrySignerClient) GetFirstQuorumHash(_ctx context.Context) (crypto.QuorumHash, error) {
@@ -110,77 +115,43 @@ func (sc *RetrySignerClient) GetFirstQuorumHash(_ctx context.Context) (crypto.Qu
 }
 
 func (sc *RetrySignerClient) GetThresholdPublicKey(ctx context.Context, quorumHash crypto.QuorumHash) (crypto.PubKey, error) {
-	var (
-		pk  crypto.PubKey
-		err error
-	)
-
-	t := time.NewTimer(sc.timeout)
-	for i := 0; i < sc.retries || sc.retries == 0; i++ {
-		pk, err = sc.next.GetThresholdPublicKey(ctx, quorumHash)
-		if err == nil {
-			return pk, nil
-		}
-		// If remote signer errors, we don't retry.
-		if _, ok := err.(*RemoteSignerError); ok {
-			return nil, err
-		}
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-t.C:
-			t.Reset(sc.timeout)
-		}
-	}
-	return nil, fmt.Errorf("exhausted all attempts to get pubkey: %w", err)
+	return retry(ctx, sc, func() (crypto.PubKey, error) {
+		return sc.next.GetThresholdPublicKey(ctx, quorumHash)
+	})
 }
-func (sc *RetrySignerClient) GetHeight(_ctx context.Context, quorumHash crypto.QuorumHash) (int64, error) {
-	return 0, fmt.Errorf("getHeight should not be called on asigner client %s", quorumHash.String())
+
+func (sc *RetrySignerClient) GetHeight(ctx context.Context, quorumHash crypto.QuorumHash) (int64, error) {
+	return retry(ctx, sc, func() (int64, error) {
+		return sc.next.GetHeight(ctx, quorumHash)
+	})
 }
 
 func (sc *RetrySignerClient) SignVote(
 	ctx context.Context, chainID string, quorumType btcjson.LLMQType, quorumHash crypto.QuorumHash,
 	vote *tmproto.Vote, _logger log.Logger) error {
-	var err error
-	for i := 0; i < sc.retries || sc.retries == 0; i++ {
-		err = sc.next.SignVote(ctx, chainID, quorumType, quorumHash, vote, nil)
-		if err == nil {
-			return nil
-		}
-		// If remote signer errors, we don't retry.
-		if _, ok := err.(*RemoteSignerError); ok {
-			return err
-		}
-		time.Sleep(sc.timeout)
-	}
-	return fmt.Errorf("exhausted all attempts to sign vote: %w", err)
+	_, err := retry(ctx, sc, func() (struct{}, error) {
+		return struct{}{}, sc.next.SignVote(ctx, chainID, quorumType, quorumHash, vote, nil)
+	})
+	return err
 }
 
 func (sc *RetrySignerClient) SignProposal(
 	ctx context.Context, chainID string, quorumType btcjson.LLMQType, quorumHash crypto.QuorumHash, proposal *tmproto.Proposal,
 ) (tmbytes.HexBytes, error) {
-	var signID []byte
-	var err error
-	for i := 0; i < sc.retries || sc.retries == 0; i++ {
-		signID, err = sc.next.SignProposal(ctx, chainID, quorumType, quorumHash, proposal)
-		if err == nil {
-			return signID, nil
-		}
-		// If remote signer errors, we don't retry.
-		if _, ok := err.(*RemoteSignerError); ok {
-			return nil, err
-		}
-		time.Sleep(sc.timeout)
-	}
-	return signID, fmt.Errorf("exhausted all attempts to sign proposal: %w", err)
+	return retry(ctx, sc, func() (tmbytes.HexBytes, error) {
+		return sc.next.SignProposal(ctx, chainID, quorumType, quorumHash, proposal)
+	})
 }
 
 func (sc *RetrySignerClient) UpdatePrivateKey(
-	_ctx context.Context, _privateKey crypto.PrivKey, _quorumHash crypto.QuorumHash, _thresholdPublicKey crypto.PubKey, _height int64,
+	ctx context.Context, privateKey crypto.PrivKey, quorumHash crypto.QuorumHash, thresholdPublicKey crypto.PubKey, height int64,
 ) {
-
+	// not retryable
+	sc.next.UpdatePrivateKey(ctx, privateKey, quorumHash, thresholdPublicKey, height)
 }
 
-func (sc *RetrySignerClient) GetPrivateKey(_ctx context.Context, _quorumHash crypto.QuorumHash) (crypto.PrivKey, error) {
-	return nil, nil
+func (sc *RetrySignerClient) GetPrivateKey(ctx context.Context, quorumHash crypto.QuorumHash) (crypto.PrivKey, error) {
+	return retry(ctx, sc, func() (crypto.PrivKey, error) {
+		return sc.next.GetPrivateKey(ctx, quorumHash)
+	})
 }

--- a/test/e2e/pkg/mockcoreserver/expect.go
+++ b/test/e2e/pkg/mockcoreserver/expect.go
@@ -103,7 +103,7 @@ func JRPCRequest(fns ...func(ctx context.Context, req btcjson.Request) error) Ex
 // JRPCParamsEmpty is a request expectation of empty JRPC params
 func JRPCParamsEmpty() ExpectFunc {
 	return JRPCRequest(func(ctx context.Context, req btcjson.Request) error {
-		if req.Params != nil && len(req.Params) > 0 {
+		if len(req.Params) > 0 {
 			return errors.New("jRPC request params should be empty")
 		}
 		return nil

--- a/test/e2e/pkg/mockcoreserver/server_test.go
+++ b/test/e2e/pkg/mockcoreserver/server_test.go
@@ -85,7 +85,7 @@ func TestDashCoreSignerPingMethod(t *testing.T) {
 	assert.NoError(t, err)
 	client, err := privval.NewDashCoreSignerClient(dashCoreRPCClient, btcjson.LLMQType_5_60, logger)
 	assert.NoError(t, err)
-	err = client.Ping()
+	err = client.Ping(ctx)
 	assert.NoError(t, err)
 	srv.Stop(ctx)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

When sign vote request to dash core fails, Tenderdash does not retry, what can cause network outage in case of network-wide dash core glitch.

## What was done?

Use retry for dash core sign requests (and more).

## How Has This Been Tested?

Local devnet

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
