### PR TITLE
fix(blocksync): potential deadlock in updateMonitor

### DIFF
--- a/internal/blocksync/synchronizer.go
+++ b/internal/blocksync/synchronizer.go
@@ -332,6 +332,8 @@ func (s *Synchronizer) advance() {
 }
 
 func (s *Synchronizer) updateMonitor() {
+	// get the current max peer height before locking to avoid deadlock
+	maxPeerHeight := s.peerStore.MaxHeight()
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
@@ -357,7 +359,7 @@ func (s *Synchronizer) updateMonitor() {
 	s.logger.Info(
 		"block sync rate",
 		"height", s.height,
-		"max_peer_height", s.peerStore.MaxHeight(),
+		"max_peer_height", maxPeerHeight,
 		"blocks/s", s.lastSyncRate,
 	)
 	s.lastMonitorUpdate = s.clock.Now()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

updateMonitor holds s.mtx and then calls s.peerStore.MaxHeight() inside the log. Elsewhere (e.g., removeTimedoutPeers -> FindTimedoutPeers -> RemovePeer) the order is peerStore -> s.mtx. This AB/BA ordering can deadlock under load.




## What was done?

Read max peer height before creating lock; it's only for logging anyway.

## How Has This Been Tested?

GHA

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
