### PR TITLE
chore: add AI agent instructions and streamline style guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# Copilot Instructions
+
+Follow all rules defined in `AGENTS.md` — it is the single source of truth
+for code conventions, repo structure, build/test commands, security policy,
+and common pitfalls.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,12 +8,13 @@ It does not duplicate details from the style guide; instead, it references the s
 Follow the rules in `STYLE_GUIDE.md`. Do not duplicate them here or in other
 agent configuration files.
 
-Key points (see `STYLE_GUIDE.md` for the full list):
+## Code quality and security
 
-- Format code with `gofmt` / `goimports`.
-- Use [golangci-lint](https://github.com/golangci/golangci-lint) configured
-  via `.golangci.yml`.
-- Do not use `TODO`; file an issue instead. Use `BUG` / `FIXME` sparingly.
+1. Ensure all changed code passes the linter.
+2. Ensure the code is thread-safe. Check memory leaks, deadlocks and race conditions.
+3. Review implementation to find any security issues. Identify and verify edge cases. Check known security issues.
+4. If unsure, explicitly report any potential security issues, gaps, missing features and TODO items.
+
 
 ## Repo Structure and Key Directories
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,11 +45,11 @@ and regenerate with `make proto-gen`.
 # Build (includes BLS native dependency)
 make build
 
-# Run all unit tests with race detector
-go test -race -timeout=5m ./...
+# Run all unit tests with race detector (matches CI: CGO, BLS, -tags=deadlock, -p 1)
+make test_race
 
-# Run a single package's tests
-go test -race -timeout=5m ./dash/quorum/...
+# Run all unit tests without race detector (matches CI configuration)
+make test
 
 # Lint
 make lint
@@ -73,7 +73,7 @@ make format
 
 - Main development branch is the highest-versioned `vMAJOR.MINOR-dev` branch.
   Find it with: `git branch -r --list 'origin/v[0-9]*-dev' --sort=-version:refname | head -1`
-- Create feature branches from the development branch; open PRs back into it. 
+- Create feature branches from the development branch; open PRs back into it.
 - Keep commits focused and well-described.
 - Use conventional commit format for commit and PR titles.
 - PR descriptions: read `.github/PULL_REQUEST_TEMPLATE.md`, fill in every

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,11 +71,13 @@ make format
 
 ## Branching and PR Workflow
 
-- Main development branch is the most recent one with name in format `vMAJOR.MINOR-dev`, for example `v0.10-dev`.
+- Main development branch is the highest-versioned `vMAJOR.MINOR-dev` branch.
+  Find it with: `git branch -r --list 'origin/v[0-9]*-dev' --sort=-version:refname | head -1`
 - Create feature branches from the development branch; open PRs back into it. 
 - Keep commits focused and well-described.
-- PR descriptions should follow `.github/PULL_REQUEST_TEMPLATE.md`
 - Use conventional commit format for commit and PR titles.
+- PR descriptions: read `.github/PULL_REQUEST_TEMPLATE.md`, fill in every
+  section, base content on the full diff against the target branch.
 
 
 ## Security and Privacy (secrets, keys, logs)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# AGENTS
+
+This file defines the minimum rules for AI agents working on Tenderdash.
+It does not duplicate details from the style guide; instead, it references the source.
+
+## Code Conventions and Style (Go, tests, comments)
+
+Follow the rules in `STYLE_GUIDE.md`. Do not duplicate them here or in other
+agent configuration files.
+
+Key points (see `STYLE_GUIDE.md` for the full list):
+
+- Format code with `gofmt` / `goimports`.
+- Use [golangci-lint](https://github.com/golangci/golangci-lint) configured
+  via `.golangci.yml`.
+- Do not use `TODO`; file an issue instead. Use `BUG` / `FIXME` sparingly.
+
+## Repo Structure and Key Directories
+
+Key directories:
+
+- `abci/` – Application BlockChain Interface (app ↔ consensus boundary)
+- `cmd/` – CLI/binary entrypoints
+- `config/` – configuration structs, defaults, and config tests
+- `crypto/` – cryptographic primitives and key handling
+- `dash/` – Dash-specific components (quorums, validators, etc.)
+- `docs/` – documentation
+- `internal/` – internal (unexported) packages
+- `libs/` – shared utility libraries
+- `node/` – node setup, lifecycle, and reactor wiring
+- `proto/` – protobuf definitions (source of truth for wire types)
+- `rpc/` – JSON-RPC server and client
+- `spec/` – protocol specification
+- `types/` – domain types (Block, Vote, Commit, etc.)
+- `test/` – integration tests and test support
+- `tools/`, `scripts/` – helper tools and automation scripts
+
+**Do not edit generated files** (e.g. `*.pb.go`). Edit the `.proto` source
+and regenerate with `make proto-gen`.
+
+## Building, Testing, and Linting
+
+```bash
+# Build (includes BLS native dependency)
+make build
+
+# Run all unit tests with race detector
+go test -race -timeout=5m ./...
+
+# Run a single package's tests
+go test -race -timeout=5m ./dash/quorum/...
+
+# Lint
+make lint
+
+# Format
+make format
+```
+
+## Working with Dependencies and Tools (Go modules, Buf, etc.)
+
+- Go dependencies are managed via Go Modules. Only update required modules.
+- To review newer versions: `go list -u -m all`.
+- If build issues arise, use `go mod tidy`.
+- Protobufs: `buf` and `gogoproto` are required.
+  - Lint: `make proto-lint`
+  - Breaking changes: `make proto-check-breaking`
+  - Generation: `make proto-gen`
+  - Formatting: `make proto-format` (requires `clang-format`)
+
+## Branching and PR Workflow
+
+- Main development branch is the most recent one with name in format `vMAJOR.MINOR-dev`, for example `v0.10-dev`.
+- Create feature branches from the development branch; open PRs back into it. 
+- Keep commits focused and well-described.
+- PR descriptions should follow `.github/PULL_REQUEST_TEMPLATE.md`
+- Use conventional commit format for commit and PR titles.
+
+
+## Security and Privacy (secrets, keys, logs)
+
+- Private keys and configuration files containing keys are secret: do not log
+  them or commit them to the repo.
+- Particularly sensitive files: `config/priv_validator_key.json`,
+  `config/node_key.json`, TLS keys (`tls-key-file` in config).
+
+## Common Pitfalls
+
+- BLS native dependency must be built before Go binaries (`make build` handles
+  this; standalone `go build` may fail).
+- `*.pb.go` files are generated — never edit them by hand.
+- `gogoproto` extensions (e.g., `nullable`, `customtype`) can produce
+  unexpected Go types; always check the generated code after proto changes.
+- Some packages under `internal/` import `dash/` types; be mindful of import
+  cycles when moving code between packages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code Instructions
+
+Follow all rules defined in `AGENTS.md` — it is the single source of truth
+for code conventions, repo structure, build/test commands, security policy,
+and common pitfalls.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -27,6 +27,7 @@ scroll down and understand the functionality of it just as well as you do. A loo
 
 ## General
 
+* Don't Repeat Yourself. Search the code base and well-maintained public modules before writing new code.
 * Use `gofmt` (or `goimport`) to format all code upon saving it.  (If you use VIM, check out vim-go).
 * Use a linter (see below) and generally try to keep the linter happy (where it makes sense).
 * Think about documentation, and try to leave godoc comments, when it will help new developers.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -39,7 +39,7 @@ understand the functionality. A loose example:
 
 ## Linters
 
-* Lint your changes to the code base, not the whole project
+* Lint your changes to the code base, not the whole project.
 * [golangci-lint](https://github.com/golangci/golangci-lint) — see `.golangci.yml` for configuration.
 
 ## Naming and Conventions

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,163 +1,85 @@
 # Go Coding Style Guide
 
-In order to keep our code looking good with lots of programmers working on it, it helps to have a "style guide", so all
-the code generally looks quite similar. This doesn't mean there is only one "right way" to write code, or even that this
-standard is better than your style.  But if we agree to a number of stylistic practices, it makes it much easier to read
-and modify new code. Please feel free to make suggestions if there's something you would like to add or modify.
-
-We expect all contributors to be familiar with [Effective Go](https://golang.org/doc/effective_go.html)
-(and it's recommended reading for all Go programmers anyways). Additionally, we generally agree with the suggestions
- in [Uber's style guide](https://github.com/uber-go/guide/blob/master/style.md) and use that as a starting point.
-
+This guide establishes shared stylistic conventions for the Tenderdash codebase.
+We expect all contributors to be familiar with [Effective Go](https://golang.org/doc/effective_go.html).
+We also use [Uber's style guide](https://github.com/uber-go/guide/blob/master/style.md) as a starting point.
 
 ## Code Structure
 
-Perhaps more key for code readability than good commenting is having the right structure. As a rule of thumb, try to write
-in a logical order of importance, taking a little time to think how to order and divide the code such that someone could
-scroll down and understand the functionality of it just as well as you do. A loose example of such order would be:
+Try to write in a logical order of importance so that someone scrolling down can
+understand the functionality. A loose example:
 
 * Constants, global and package-level variables
 * Main Struct
-* Options (only if they are seen as critical to the struct else they should be placed in another file)
+* Options (only if critical to the struct; otherwise place in another file)
 * Initialization / Start and stop of the service
 * Msgs/Events
-* Public Functions (In order of most important)
+* Public functions (in order of importance)
 * Private/helper functions
-* Auxiliary structs and function (can also be above private functions or in a separate file)
+* Auxiliary structs and functions (can also be in a separate file)
 
 ## General
 
-* Don't Repeat Yourself. Search the code base and well-maintained public modules before writing new code.
-* Use `gofmt` (or `goimport`) to format all code upon saving it.  (If you use VIM, check out vim-go).
-* Use a linter (see below) and generally try to keep the linter happy (where it makes sense).
-* Think about documentation, and try to leave godoc comments, when it will help new developers.
-* Every package should have a high level doc.go file to describe the purpose of that package, its main functions, and any other relevant information.
-* `TODO` should not be used. If important enough should be recorded as an issue.
-* `BUG` / `FIXME` should be used sparingly to guide future developers on some of the vulnerabilities of the code.
-* `XXX` can be used in work-in-progress (prefixed with "WIP:" on github) branches but they must be removed before approving a PR.
-* Applications (e.g. clis/servers) *should* panic on unexpected unrecoverable errors and print a stack trace.
+* Don't Repeat Yourself. Search the codebase before writing new code.
+* Less code is better. Review code after implementation to ensure it cannot be written in a shorter form.
+* Use `gofmt` (or `goimports`) to format all code upon saving.
+* Use a linter (see below) and keep it happy where it makes sense.
+* Leave godoc comments when they will help new developers.
+* `TODO` should not be used. If important enough, file an issue.
+* `BUG` / `FIXME` should be used sparingly.
+* `XXX` may appear in WIP branches but must be removed before merging.
+* Applications (e.g. CLIs/servers) *should* panic on unexpected unrecoverable
+  errors and print a stack trace.
 
 ## Comments
 
-* Use a space after comment deliminter (ex. `// your comment`).
-* Many comments are not sentences. These should begin with a lower case letter and end without a period.
-* Conversely, sentences in comments should be sentenced-cased and end with a period.
+* Use a space after the comment delimiter (e.g. `// your comment`).
+* Non-sentence comments should begin with a lower case letter and end without a period.
+* Sentence comments should be sentence-cased and end with a period.
 
 ## Linters
 
-These must be applied to all (Go) repos.
+* Lint your changes to the code base, not the whole project
+* [golangci-lint](https://github.com/golangci/golangci-lint) — see `.golangci.yml` for configuration.
 
-* [shellcheck](https://github.com/koalaman/shellcheck)
-* [golangci-lint](https://github.com/golangci/golangci-lint) (covers all important linters)
-    * See the `.golangci.yml` file in each repo for linter configuration.
+## Naming and Conventions
 
-## Various
+* Reserve "Save" and "Load" for long-running persistence operations. For parsing bytes, use "Encode" or "Decode".
+* Functions that return functions should have the suffix `Fn`.
+* Names should not [stutter](https://blog.golang.org/package-names). For example, avoid:
 
-* Reserve "Save" and "Load" for long-running persistence operations. When parsing bytes, use "Encode" or "Decode".
-* Maintain consistency across the codebase.
-* Functions that return functions should have the suffix `Fn`
-* Names should not [stutter](https://blog.golang.org/package-names). For example, a struct generally shouldn’t have
-  a field named after itself; e.g., this shouldn't occur:
+  ```go
+  type middleware struct {
+  	middleware Middleware
+  }
+  ```
 
-``` golang
-type middleware struct {
-	middleware Middleware
-}
-```
-
-* In comments, use "iff" to mean, "if and only if".
-* Product names are capitalized, like "Tendermint", "Basecoin", "Protobuf", etc except in command lines: `tendermint --help`
-* Acronyms are all capitalized, like "RPC", "gRPC", "API".  "MyID", rather than "MyId".
-* Prefer errors.New() instead of fmt.Errorf() unless you're actually using the format feature with arguments.
+* Product names are capitalized ("Tenderdash", "Protobuf") except in command lines: `tenderdash --help`.
+* Acronyms are all-caps: "RPC", "gRPC", "API", "MyID" (not "MyId").
+* Prefer `errors.New()` over `fmt.Errorf()` unless you need format arguments.
 
 ## Importing Libraries
 
-Sometimes it's necessary to rename libraries to avoid naming collisions or ambiguity.
-
-* Use [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)
-* Separate imports into blocks - one for the standard lib, one for external libs and one for application libs.
-* Here are some common library labels for consistency:
-    * dbm "github.com/cometbft/cometbft-db"
-    * tmcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
-    * tmcfg "github.com/tendermint/tendermint/config/tendermint"
-    * tmtypes "github.com/tendermint/tendermint/types"
-* Never use anonymous imports (the `.`), for example, `tmlibs/common` or anything else.
-* When importing a pkg from the `tendermint/libs` directory, prefix the pkg alias with tm.
-    * tmbits "github.com/tendermint/tendermint/libs/bits"
-* tip: Use the `_` library import to import a library for initialization effects (side effects)
-
-## Dependencies
-
-* Dependencies should be pinned by a release tag, or specific commit, to avoid breaking `go get` when external dependencies are updated.
-* Refer to the [contributing](CONTRIBUTING.md) document for more details
+* Use [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports).
+* Separate imports into three blocks: standard library, external, and application.
+* Never use dot imports (`.`).
+* Use the `_` import for side-effect-only imports.
 
 ## Testing
 
-* The first rule of testing is: we add tests to our code
-* The second rule of testing is: we add tests to our code
-* For Golang testing:
-    * Make use of table driven testing where possible and not-cumbersome
-        * [Inspiration](https://dave.cheney.net/2013/06/09/writing-table-driven-tests-in-go)
-    * Make use of [assert](https://godoc.org/github.com/stretchr/testify/assert) and [require](https://godoc.org/github.com/stretchr/testify/require)
-* When using mocks, it is recommended to use Testify [mock] (<https://pkg.go.dev/github.com/stretchr/testify/mock>
- ) along with [Mockery](https://github.com/vektra/mockery) for autogeneration
+* All code must have tests.
+* Use table-driven tests where possible and not cumbersome.
+* Use [assert](https://pkg.go.dev/github.com/stretchr/testify/assert) and [require](https://pkg.go.dev/github.com/stretchr/testify/require) from testify.
+* For mocks, use Testify [mock](https://pkg.go.dev/github.com/stretchr/testify/mock) with [Mockery](https://github.com/vektra/mockery) for autogeneration.
 
 ## Errors
 
-* Ensure that errors are concise, clear and traceable.
-* Use stdlib errors package.
-* For wrapping errors, use `fmt.Errorf()` with `%w`.
-* Panic is appropriate when an internal invariant of a system is broken, while all other cases (in particular,
-  incorrect or invalid usage) should return errors.
-
-## Config
-
-* Currently the TOML filetype is being used for config files
-* A good practice is to store per-user config files under `~/.[yourAppName]/config.toml`
-
-## CLI
-
-* When implementing a CLI use [Cobra](https://github.com/spf13/cobra) and [Viper](https://github.com/spf13/viper).
-* Helper messages for commands and flags must be all lowercase.
-* Instead of using pointer flags (eg. `FlagSet().StringVar`) use Viper to retrieve flag values (eg. `viper.GetString`)
-    * The flag key used when setting and getting the flag should always be stored in a
-   variable taking the form `FlagXxx` or `flagXxx`.
-    * Flag short variable descriptions should always start with a lower case character as to remain consistent with
-   the description provided in the default `--help` flag.
-
-## Version
-
-* Every repo should have a version/version.go file that mimics the Tendermint Core repo
-* We read the value of the constant version in our build scripts and hence it has to be a string
+* Ensure errors are concise, clear, and traceable.
+* Use the stdlib `errors` package.
+* Wrap errors with `fmt.Errorf()` and `%w`.
+* Panic only when an internal invariant is broken. All other cases should return errors.
 
 ## Non-Go Code
 
-* All non-Go code (`*.proto`, `Makefile`, `*.sh`), where there is no common
-   agreement on style, should be formatted according to
-   [EditorConfig](http://editorconfig.org/) config:
-
-   ```toml
-   # top-most EditorConfig file
-   root = true
-
-   # Unix-style newlines with a newline ending every file
-   [*]
-   charset = utf-8
-   end_of_line = lf
-   insert_final_newline = true
-   trim_trailing_whitespace = true
-
-   [Makefile]
-   indent_style = tab
-
-   [*.sh]
-   indent_style = tab
-
-   [*.proto]
-   indent_style = space
-   indent_size = 2
-   ```
-
-   Make sure the file above (`.editorconfig`) are in the root directory of your
-   repo and you have a [plugin for your
-   editor](http://editorconfig.org/#download) installed.
+All non-Go code (`*.proto`, `Makefile`, `*.sh`) should be formatted according
+to the [EditorConfig](http://editorconfig.org/) in the repo root (`.editorconfig`).


### PR DESCRIPTION
## Issue being fixed or feature implemented

No existing documentation for AI coding agents (Claude Code, GitHub Copilot) to follow when contributing to Tenderdash. The style guide also contained verbose, outdated prose referencing Tendermint/CometBFT.

## What was done?

- Added `AGENTS.md` with minimum rules for AI agents: repo structure, build/test/lint commands, branching workflow, security policy, and common pitfalls
- Added `CLAUDE.md` and `.github/copilot-instructions.md` as thin pointers to `AGENTS.md`
- Streamlined `STYLE_GUIDE.md` — removed verbose prose, outdated references, and sections duplicated elsewhere; added DRY and brevity principles

## How Has This Been Tested?

Documentation-only changes. Verified that referenced Makefile targets and directory paths are accurate.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new guidance documents outlining AI agent rules, project conventions, security/privacy guidance, and usage instructions for automated assistants.
  * Introduced a concise agent-specific instruction doc referencing the central conventions.
  * Rewrote and reorganized the style guide for clearer, standardized coding and contribution practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->