### PR TITLE
fix(types): don't reject valid Platform quorums (8-of-12) in ValidateBasic

### DIFF
--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -162,28 +162,11 @@ func (vals *ValidatorSet) ValidateBasic() error {
 		return fmt.Errorf("voting power threshold %d is too large", vals.VotingPowerThreshold)
 	}
 
-	threshold := vals.QuorumVotingThresholdPower()
-	totalPower := vals.TotalVotingPower()
-	switch len(vals.Validators) {
-	case 1, 2:
-		// For validator sets containing 1 or 2 validators, the threshold MUST be equal to the total voting power.
-		if totalPower != threshold {
-			return fmt.Errorf("with 1 or 2 validators, quorum voting power %d must be equal to threshold %d", totalPower, threshold)
-		}
-	case 3:
-		// For validator set with 3 validators, the threshold MUST be equal or greater than 2/3 of the total voting power.
-		if threshold < totalPower*2/3 {
-			return fmt.Errorf("%d-members quorum voting power %d is less than threshold %d",
-				len(vals.Validators), totalPower, vals.VotingPowerThreshold)
-		}
-	default:
-		// For validator sets containing more than 3 validators, the threshold MUST be at least 2/3 + 1 of the total voting power.
-		if threshold < (totalPower*2/3)+1 {
-			return fmt.Errorf("voting threshold %d of quorum with power %d MUST be at least 2/3*%d+1 = %d",
-				threshold, totalPower, totalPower, (totalPower*2/3)+1)
-
-		}
-	}
+	// NOTE: We intentionally do NOT validate the quorum voting threshold against
+	// the total voting power here. The threshold is determined by the LLMQ quorum
+	// type produced by Dash Core (e.g. llmq_devnet_platform is 8-of-12, exactly
+	// 2/3), and enforcing a stricter "2/3 + 1" rule rejects otherwise valid
+	// quorums and prevents the node from starting. See dashpay/tenderdash#1314.
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Removes the quorum voting-threshold validation in `ValidatorSet.ValidateBasic()` that prevents a node from starting when given a valid `llmq_devnet_platform` quorum.

Since **v1.5.0**, Tenderdash fails replay in a restart loop with:

```
ERROR: failed to start node: error on replay: validator set updates: voting threshold 800 of quorum with power 1200 MUST be at least 2/3*1200+1 = 801
```

`llmq_devnet_platform` is defined as **8-of-12** (`dash/llmq/llmq.go`), which is *exactly* 2/3 — threshold `8 * 100 = 800` of total power `12 * 100 = 1200`. The check added in #1052 requires more than 3-member sets to have a threshold of at least `2/3 + 1 = 801`, so it rejects the quorum Dash Core actually produces.

The voting threshold is dictated by the LLMQ quorum type formed by Core, not by Tenderdash, so enforcing a stricter rule here makes otherwise-valid quorums unstartable.

Fixes #1314.

## Changes

- Remove the `switch len(vals.Validators)` threshold-vs-total-power block from `ValidatorSet.ValidateBasic()` (introduced in #1052, absent in v1.4.x).
- Keep the `VotingPowerThreshold` overflow guard.

This restores the pre-#1052 `ValidateBasic()` behavior for this code path.

## Notes / alternatives

The block was also internally inconsistent: `case 3` allowed exactly 2/3 (`threshold < totalPower*2/3`) while the `default` branch required strictly more (`threshold < (totalPower*2/3)+1`), so 3-member platform quorums passed but 12-member ones did not.

If a strict BFT threshold is desired in the future, it should be coordinated with Dash Core's LLMQ quorum definitions (or driven via the `voting_power_threshold` consensus param), rather than enforced unilaterally in `ValidateBasic()` where it rejects quorums Core considers valid.

## Test plan

- [ ] CI: `go build ./...`
- [ ] CI: `go test ./types/...` — existing `TestValidatorSetValidateBasic` cases still pass (none assert the removed threshold errors; the 1-validator and 4-validator "good" cases continue to validate).
- [ ] Manual: start a node against a `llmq_devnet_platform` (8-of-12) quorum and confirm replay no longer fails.

> Note: Go is not installed in the authoring environment, so build/tests were not run locally — relying on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed quorum voting threshold validation to accept valid configurations that were previously rejected due to overly strict enforcement rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/tenderdash/pull/1315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->