### PR TITLE
fix(types): preserve validator voting power threshold

### DIFF
--- a/internal/state/current_round_state.go
+++ b/internal/state/current_round_state.go
@@ -326,6 +326,9 @@ func valsetUpdate(
 			if err != nil {
 				return nil, err
 			}
+			if params.VotingPowerThreshold != nil {
+				nValSet.VotingPowerThreshold = *params.VotingPowerThreshold
+			}
 		} else {
 			// if we don't have proTxHash, NewValidatorSetWithLocalNodeProTxHash behaves like NewValidatorSet
 			nValSet = types.NewValidatorSetCheckPublicKeys(validatorUpdates, thresholdPubKey,

--- a/internal/state/current_round_state_test.go
+++ b/internal/state/current_round_state_test.go
@@ -1,0 +1,60 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	abci "github.com/dashpay/tenderdash/abci/types"
+	"github.com/dashpay/tenderdash/crypto/encoding"
+	"github.com/dashpay/tenderdash/types"
+)
+
+func TestValsetUpdateVotingPowerThreshold(t *testing.T) {
+	currentVals, _ := types.RandValidatorSet(4)
+	currentVals.VotingPowerThreshold = 33
+
+	threshold := uint64(55)
+	params := types.ValidatorParams{PubKeyTypes: []string{"bls12381"}, VotingPowerThreshold: &threshold}
+
+	removedVal := types.TM2PB.NewValidatorUpdate(currentVals.Validators[0].PubKey, 0,
+		currentVals.Validators[0].ProTxHash, currentVals.Validators[0].NodeAddress.String())
+	thresholdPubKey := encoding.MustPubKeyToProto(currentVals.ThresholdPublicKey)
+
+	testCases := []struct {
+		name   string
+		update *abci.ValidatorSetUpdate
+	}{
+		{
+			name: "same quorum",
+			update: &abci.ValidatorSetUpdate{
+				ValidatorUpdates:   []abci.ValidatorUpdate{removedVal},
+				ThresholdPublicKey: thresholdPubKey,
+				QuorumHash:         currentVals.QuorumHash,
+			},
+		},
+		{
+			name:   "new quorum",
+			update: currentVals.ABCIEquivalentValidatorUpdates(),
+		},
+		{
+			name: "no validator updates",
+			update: &abci.ValidatorSetUpdate{
+				ThresholdPublicKey: thresholdPubKey,
+				QuorumHash:         currentVals.QuorumHash,
+			},
+		},
+	}
+
+	testCases[1].update.QuorumHash = append(testCases[1].update.QuorumHash[:0:0], testCases[1].update.QuorumHash...)
+	testCases[1].update.QuorumHash[0]++
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			valSet, err := valsetUpdate(tc.update, currentVals, params)
+			require.NoError(t, err)
+			require.Equal(t, threshold, valSet.VotingPowerThreshold)
+		})
+	}
+}

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -306,12 +306,13 @@ func (vals *ValidatorSet) Copy() *ValidatorSet {
 		return nil
 	}
 	valset := &ValidatorSet{
-		Validators:         validatorListCopy(vals.Validators),
-		ThresholdPublicKey: vals.ThresholdPublicKey,
-		QuorumHash:         vals.QuorumHash,
-		QuorumType:         vals.QuorumType,
-		HasPublicKeys:      vals.HasPublicKeys,
-		proposerIndex:      vals.proposerIndex,
+		Validators:           validatorListCopy(vals.Validators),
+		ThresholdPublicKey:   vals.ThresholdPublicKey,
+		QuorumHash:           vals.QuorumHash,
+		QuorumType:           vals.QuorumType,
+		HasPublicKeys:        vals.HasPublicKeys,
+		VotingPowerThreshold: vals.VotingPowerThreshold,
+		proposerIndex:        vals.proposerIndex,
 	}
 
 	return valset

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -218,6 +218,7 @@ func TestValidatorSetValidateBasic(t *testing.T) {
 
 func TestCopy(t *testing.T) {
 	vset, _ := RandValidatorSet(10)
+	vset.VotingPowerThreshold = 123
 	vsetHash := vset.Hash()
 	if len(vsetHash) == 0 {
 		t.Fatalf("ValidatorSet had unexpected zero hash")
@@ -229,6 +230,7 @@ func TestCopy(t *testing.T) {
 	if !bytes.Equal(vsetHash, vsetCopyHash) {
 		t.Fatalf("ValidatorSet copy had wrong hash. Orig: %X, Copy: %X", vsetHash, vsetCopyHash)
 	}
+	require.Equal(t, vset.VotingPowerThreshold, vsetCopy.VotingPowerThreshold)
 }
 
 func BenchmarkValidatorSetCopy(b *testing.B) {


### PR DESCRIPTION
# Summary

- Preserve `ValidatorSet.VotingPowerThreshold` in `ValidatorSet.Copy()`.
- Reapply `ValidatorParams.VotingPowerThreshold` after same-quorum `UpdateWithChangeSet()` updates.
- Add focused regression coverage for copy and validator-set update paths.

Stacked on #1315.

## Validation

- Built BLS locally from `third_party/bls-signatures` with `CMAKE_POLICY_VERSION_MINIMUM=3.5` to support the local CMake version.
- `GOCACHE=/tmp/tenderdash-go-build-cache CGO_ENABLED=1 CGO_CXXFLAGS="..." CGO_LDFLAGS="..." go test ./types ./internal/state`
- Pre-PR code review gate: `ship`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent updates to validator set voting power thresholds during validator configuration changes, ensuring data integrity across all validator set modification scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/tenderdash/pull/1316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->