### PR TITLE
refactor: replace creachadair/taskgroup with x/sync/errgroup and ban it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - dupl
     - errcheck
     - goconst
+    - gomodguard
     - gosec
     - govet
     - ineffassign
@@ -40,6 +41,13 @@ linters:
     goconst:
       min-len: 5
       min-occurrences: 5
+    gomodguard:
+      blocked:
+        modules:
+          - github.com/creachadair/taskgroup:
+              recommendations:
+                - golang.org/x/sync/errgroup
+              reason: "No longer trusted (anti-AI canary in upstream README); use golang.org/x/sync/errgroup."
     misspell:
       locale: US
     revive:

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 require (
 	github.com/bufbuild/buf v1.66.1
 	github.com/creachadair/atomicfile v0.4.1
-	github.com/creachadair/taskgroup v0.14.2
 	github.com/go-pkgz/jrpc v0.4.0
 	github.com/google/go-cmp v0.7.0
 	github.com/vektra/mockery/v2 v2.53.5

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,6 @@ github.com/creachadair/atomicfile v0.4.1 h1:72SopAy00u42/iL0p3CZILv51oUEem8uDbxU
 github.com/creachadair/atomicfile v0.4.1/go.mod h1:+PsFcWa9SZuK+xnykzupXErqESId5eCGsuqFWkazMQI=
 github.com/creachadair/mds v0.26.0 h1:MExm7XA3xrKa+r8ZS10Nb9SzWfm5GbG3xGp6P+ci9bo=
 github.com/creachadair/mds v0.26.0/go.mod h1:XtMfRW15sjd1iOi1Z1k+dq0pRsR5xPbulpoTrpyhk8w=
-github.com/creachadair/taskgroup v0.14.2 h1:vPHw50VFJ98Eb+h3S1RYRejK3DE0xpGCXb2ZFtHfFeA=
-github.com/creachadair/taskgroup v0.14.2/go.mod h1:FV5K1BzHUCnTVc04O1WLO+iLmvjfOTnYLTcZaC9ZxbM=
 github.com/creachadair/tomledit v0.0.29 h1:dB5CbdwJMpn/fmfAPTAAleXF/KJwY0Ggc1eL/zvZRgk=
 github.com/creachadair/tomledit v0.0.29/go.mod h1:4SoTXxzHgvzHRMIJPw+o6zK/yXii4VjLrb6/3gCQnyA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -8,8 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/creachadair/taskgroup"
 	sync "github.com/sasha-s/go-deadlock"
+	"golang.org/x/sync/errgroup"
 
 	abciclient "github.com/dashpay/tenderdash/abci/client"
 	abci "github.com/dashpay/tenderdash/abci/types"
@@ -784,11 +784,12 @@ func (txmp *TxMempool) recheckTransactions(ctx context.Context) {
 	// Issue CheckTx calls for each remaining transaction, and when all the
 	// rechecks are complete signal watchers that transactions may be available.
 	go func() {
-		g, start := taskgroup.New(nil).Limit(2 * runtime.NumCPU())
+		var g errgroup.Group
+		g.SetLimit(2 * runtime.NumCPU())
 
 		for _, wtx := range wtxs {
 			wtx := wtx
-			start(func() error {
+			g.Go(func() error {
 				if err := ctx.Err(); err != nil {
 					txmp.logger.Trace("recheck txs task canceled", "err", err, "tx", wtx.hash.String())
 					return err

--- a/scripts/keymigrate/migrate.go
+++ b/scripts/keymigrate/migrate.go
@@ -15,10 +15,11 @@ import (
 	"math/rand"
 	"runtime"
 	"strconv"
+	"sync"
 
 	dbm "github.com/cometbft/cometbft-db"
-	"github.com/creachadair/taskgroup"
 	"github.com/google/orderedcode"
+	"golang.org/x/sync/errgroup"
 )
 
 type (
@@ -632,19 +633,29 @@ func Migrate(ctx context.Context, storeName string, db dbm.DB) error {
 		return err
 	}
 
-	var errs []string
-	g, start := taskgroup.New(func(err error) error {
-		errs = append(errs, err.Error())
-		return err
-	}).Limit(runtime.NumCPU())
+	var (
+		g    errgroup.Group
+		mu   sync.Mutex
+		errs []string
+	)
+	g.SetLimit(runtime.NumCPU())
 
 	for _, key := range keys {
 		key := key
-		start(func() error {
+		g.Go(func() error {
 			if err := ctx.Err(); err != nil {
+				mu.Lock()
+				errs = append(errs, err.Error())
+				mu.Unlock()
 				return err
 			}
-			return replaceKey(db, storeName, key)
+			if err := replaceKey(db, storeName, key); err != nil {
+				mu.Lock()
+				errs = append(errs, err.Error())
+				mu.Unlock()
+				return err
+			}
+			return nil
 		})
 	}
 	if g.Wait() != nil {


### PR DESCRIPTION
## Issue being fixed or feature implemented

`golang.org/x/sync/errgroup` is already a **direct** dependency
(`go.mod` has `golang.org/x/sync v0.20.0`), so swapping to it and removing
taskgroup is a **net dependency removal** — one fewer module in `go.mod`/`go.sum`.

## What was done?

Replaced taskgroup with `golang.org/x/sync/errgroup` at the only two call sites,
dropped the dependency, and added a CI-enforced ban so it can't return.

**1. `internal/mempool/mempool.go` (recheck loop) — trivial drop-in.**
`taskgroup.New(nil).Limit(2*runtime.NumCPU())` becomes a zero-value
`errgroup.Group` with `SetLimit(2*runtime.NumCPU())`; `start(...)` becomes
`g.Go(...)`. `errgroup.Go` blocks until a worker slot frees up, exactly
reproducing taskgroup's `Limit`+`start` blocking-when-full behavior. The
launch-loop → `Flush` → `Wait` ordering and the task body are unchanged, and
the result is still discarded (`_ = g.Wait()`).

**2. `scripts/keymigrate/migrate.go` (`Migrate`) — one concurrency subtlety.**
taskgroup invoked its error handler **serially** from a single goroutine, which
is why the original `errs = append(...)` aggregation was lock-free. errgroup runs
task funcs **concurrently**, so the aggregation is now guarded by a `sync.Mutex`
to avoid a data race. The point of the original handler was to collect *all*
errors (not just the first), so that behavior is preserved — every failing task
appends its error before returning. The exact error message format
(`"encountered errors during migration: %q"`) is unchanged. Verified clean under
`go test -race`.

**3. Dependency drop.** `go mod tidy` removes
`github.com/creachadair/taskgroup v0.14.2` from both `go.mod` and `go.sum`
(the shared `creachadair/mds` transitive dep stays — it's pulled by other
`creachadair/*` modules).

**4. CI-enforced ban (`.golangci.yml`).** Enabled the `gomodguard` linter
(golangci-lint v2 schema, matching the pinned `@v2.8`) with a single
blocked-modules entry for taskgroup — recommending `golang.org/x/sync/errgroup`
and citing the trust reason. No `allowed` list, so no other module is affected.
Any future taskgroup import now fails lint.

## How Has This Been Tested?

- `make build` — green (BLS native dependency + `tenderdash` binary link).
- `go vet ./internal/mempool/... ./scripts/keymigrate/...` — clean.
- `go test -race -count=1 -tags deadlock ./internal/mempool/...` — pass.
- `go test -race -count=1 ./scripts/keymigrate/...` — pass (mutex prevents the
  aggregation data race).
- `golangci-lint@v2.8 config verify` — config validates against the v2.8 schema.
- `golangci-lint@v2.8` — **no gomodguard violation** (taskgroup is gone), and the
  ban was positively verified: temporarily re-adding the import produces
  `import of package github.com/creachadair/taskgroup is blocked ... golang.org/x/sync/errgroup is a recommended module (gomodguard)`.
- `gofmt -l` / `goimports -local github.com/dashpay/tenderdash` — clean on both
  edited files.
- `go mod tidy` leaves no further diff; `taskgroup` absent from `go.mod`/`go.sum`.

## Breaking Changes

None. Internal/tooling refactor only — no public API, wire format, or behavior
change. Concurrency semantics at both call sites are preserved.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an external dependency and migrated concurrent task orchestration throughout the codebase to an alternative library.
  * Updated linting rules to prevent reintroduction of the removed dependency and enforce recommended practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->