### PR TITLE
ci: add govulncheck vulnerability scanning

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,32 @@
+---
+name: Vulnerability Scan
+# Runs govulncheck to detect known vulnerabilities in Go dependencies.
+# The scan is GATING: the job fails if any vulnerability is found.
+# (Local scan on 2026-06-12 against this module returned: No vulnerabilities found.)
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - v[0-9]+.[0-9]+-dev
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6.3.0
+        with:
+          go-version: "1.26.4"
+
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1.0.4
+        with:
+          go-version-input: "1.26.4"
+          go-package: ./...

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -2,7 +2,6 @@
 name: Vulnerability Scan
 # Runs govulncheck to detect known vulnerabilities in Go dependencies.
 # The scan is GATING: the job fails if any vulnerability is found.
-# (Local scan on 2026-06-12 against this module returned: No vulnerabilities found.)
 on:
   pull_request:
   push:
@@ -17,16 +16,16 @@ jobs:
   govulncheck:
     name: govulncheck
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
-
       - uses: actions/setup-go@v6.3.0
         with:
           go-version: "1.26.4"
 
+      - uses: actions/checkout@v6
+
+      - name: Install BLS library
+        uses: ./.github/actions/bls
+
       - name: Run govulncheck
-        uses: golang/govulncheck-action@v1.0.4
-        with:
-          go-version-input: "1.26.4"
-          go-package: ./...
+        run: make vulncheck

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -27,5 +27,8 @@ jobs:
       - name: Install BLS library
         uses: ./.github/actions/bls
 
+      - name: Install libpcap
+        run: sudo apt-get update && sudo apt-get install --yes libpcap-dev
+
       - name: Run govulncheck
         run: make vulncheck

--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,11 @@ lint:
 	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8 run
 .PHONY: lint
 
+vulncheck:
+	@echo "--> Running vulnerability scanner"
+	go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
+.PHONY: vulncheck
+
 DESTINATION = ./index.html.md
 
 ###############################################################################


### PR DESCRIPTION
## Summary
- Adds `make vulncheck` running `govulncheck@v1.3.0` across all packages.
- Adds `.github/workflows/govulncheck.yml` — a **gating** CI job (fails on any vulnerability) on push + pull_request, mirroring the repo's Go 1.26.4 and action pins.

## Local govulncheck result (2026-06-12)
`No vulnerabilities found.` — clean scan, so the job is gating (no `continue-on-error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)