### PR TITLE
chore(release): fix release.sh bugs and rewrite RELEASES.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,8 @@ If you are a VS Code user, you may want to add the following to your `.vscode/se
 
 ## Release Notes
 
-Release notes are generated from commit messages by `scripts/release.sh`. Use
+Release notes are generated from commit messages by
+`scripts/release/release.sh`. Use
 clear conventional commit summaries so the release tooling can assemble accurate
 notes; `CHANGELOG_PENDING.md` is no longer maintained.
 
@@ -150,7 +151,8 @@ receives cherry-picked release-critical fixes and release updates.
 
 Note all pull requests should be squash merged. This keeps the commit history
 clean and makes it easy to reference the pull request where a change was
-introduced.
+introduced. The one exception is the full-release PR into `master`, which uses a
+merge commit (see [RELEASES.md](./RELEASES.md)).
 
 ### Development Procedure
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,8 +10,10 @@ the `vX.Y.Z` format; prereleases use `vX.Y.Z-dev.N` (e.g. `v1.6.0-dev.1`).
 | `vX.Y-dev` (e.g. `v1.6-dev`) | Active development; new work targets this branch |
 | `master` | Latest stable release; receives release updates and cherry-picked critical fixes |
 
-All pull requests are squash-merged. The script creates a short-lived
-`release_<version>` branch for each release and opens a PR from it.
+Normal contribution PRs and prerelease release-PRs are squash-merged; the
+full-release PR into `master` is the exception and uses a merge commit (the
+script prints the correct strategy for each release). The script creates a
+short-lived `release_<version>` branch for each release and opens a PR from it.
 
 ## Versioning rules
 
@@ -68,14 +70,16 @@ key required; skipped for routine dev prereleases).
 6. Creates a GitHub milestone `vX.Y` if it does not already exist.
 7. Opens a PR targeting `vX.Y-dev` (prerelease) or `master` (full release).
 8. Prints the merge strategy and waits for the PR to be merged.
-9. Creates a **draft** GitHub release with auto-generated notes.
+9. Creates a **draft** release targeting the merge branch via
+   `gh release create --draft … --target <branch>`, with auto-generated notes.
 
 After the script exits:
 
 - **Prerelease PR** — squash-merge into `vX.Y-dev`.
 - **Full release PR** — merge-commit into `master`.
-- Review the draft release on GitHub, then **publish** it. Publishing creates the
-  `vX.Y.Z` tag and triggers any downstream CI that watches tags.
+- Review the draft release on GitHub, then **publish** it to finalize the
+  release and ensure the `vX.Y.Z` tag exists on the remote. (Draft releases and
+  their tags are mutable and not guaranteed on the remote until published.)
 
 ### Signed binaries (--sign)
 
@@ -87,11 +91,13 @@ specific key.
 
 ## CI and build tooling
 
-`.github/workflows/release.yml` is triggered manually (`workflow_dispatch`) and
-runs `goreleaser` (config: `.goreleaser.yml`). It currently builds a full
-release when `$GITHUB_REF` starts with `refs/tags/`; it runs a validate-only
-build on pull requests. This workflow is separate from the script's own Docker
-cross-compile path used for signed binaries.
+`.github/workflows/release.yml` runs `goreleaser` (config: `.goreleaser.yml`)
+and is triggered **only** manually via `workflow_dispatch`. Its goreleaser
+release step runs only when the workflow is dispatched against a tag ref
+(`refs/tags/…`); a `pull_request`-gated validate build is also defined but never
+fires, because the workflow has no `pull_request` trigger. No workflow currently
+runs automatically on tag push or on pull requests. This workflow is independent
+of the release script's own Docker cross-compile path used for `--sign` binaries.
 
 ## Minor Release Checklist
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,258 +1,128 @@
 # Releases
 
-Tenderdash follows [semantic versioning](https://semver.org/) with each release
-following a `vX.Y.Z` format. Tenderdash is currently on major version 1 (v1.x);
-breaking changes require a major version increment. The development branch
-(latest `vMAJOR.MINOR-dev`, e.g. `v1.6-dev`) is used for active development and
-thus it is not advisable to build against it.
+Tenderdash follows [semantic versioning](https://semver.org/). Release tags use
+the `vX.Y.Z` format; prereleases use `vX.Y.Z-dev.N` (e.g. `v1.6.0-dev.1`).
 
-The latest changes are always initially merged into the development branch.
-Releases are specified using tags and are built from long-lived "backport"
-branches that are cut from the development branch when the release process
-begins.
-Each release "line" (e.g. 0.34 or 0.33) has its own long-lived backport branch,
-and the backport branches have names like `v0.34.x` or `v0.33.x`
-(literally, `x`; it is not a placeholder in this case). Tenderdash only
-maintains the last two releases at a time (the oldest release is predominantly
-just security patches).
+## Branch model
 
-## Backporting
+| Branch | Purpose |
+|---|---|
+| `vX.Y-dev` (e.g. `v1.6-dev`) | Active development; new work targets this branch |
+| `master` | Latest stable release; receives release updates and cherry-picked critical fixes |
 
-As non-breaking changes land on the development branch, they should also be backported
-to these backport branches.
+All pull requests are squash-merged. The script creates a short-lived
+`release_<version>` branch for each release and opens a PR from it.
 
-We use Mergify's [backport feature](https://mergify.io/features/backports) to automatically backport
-to the needed branch. There should be a label for any backport branch that you'll be targeting.
-To notify the bot to backport a pull request, mark the pull request with the label corresponding
-to the correct backport branch. For example, to backport to v0.35.x, add the label `S:backport-to-v0.35.x`.
-Once the original pull request is merged, the bot will try to cherry-pick the pull request
-to the backport branch. If the bot fails to backport, it will open a pull request.
-The author of the original pull request is responsible for solving the conflicts and
-merging the pull request.
+## Versioning rules
 
-### Creating a backport branch
+`scripts/release/release.sh` bumps **only** `TMVersionDefault` in
+`version/version.go`. Reviewers must manually decide whether to bump the other
+protocol versions by inspecting diffs since the last release:
 
-If this is the first release candidate for a minor version release, e.g.
-v0.25.0, you get to have the honor of creating the backport branch!
+- **`P2PProtocol`** — bump when p2p message format, channels, or proposer
+  selection logic changes.
+- **`BlockProtocol`** — bump when block, header, vote, commit, or state
+  structures change, or block validity rules change.
+- **`ABCISemVer`** — follows semver; field additions are patch-level, interface
+  changes are minor/major.
 
-Note that, after creating the backport branch, you'll also need to update the
-tags on the development branch so that `go mod` is able to order the branches correctly. You
-should tag the development branch with a "dev" tag that is "greater than" the backport
-branches tags. See [#6072](https://github.com/tendermint/tendermint/pull/6072)
-for more context.
+Example: for v1.5.4 → v1.6.0-dev.1 none of these changed, so all were left
+as-is.
 
-In the following example, we'll assume that we're making a backport branch for
-the 0.35.x line.
+## Prerequisites
 
-1. Start on the development branch (latest `vMAJOR.MINOR-dev`)
+Before running the release script:
 
-2. Create and push the backport branch:
-   ```sh
-   git checkout -b v0.35.x
-   git push origin v0.35.x
-   ```
+1. Be on the `vX.Y-dev` branch (e.g. `git checkout v1.6-dev`).
+2. Working tree must be clean (`git status` shows nothing).
+3. **Local branch must be in sync with origin** — the script now enforces this
+   and will fast-forward your branch automatically, or error if a non-linear
+   sync is needed.
+4. `master` and the previous `vX.Y-dev` must already be merged forward into the
+   current dev branch.
+5. `docker` and `gh` (authenticated via `gh auth login`) must be installed.
 
-3. Create a PR to update the documentation directory for the backport branch.
+## Running a release
 
-   We only maintain RFC and ADR documents on the development branch, to avoid confusion.
-   In addition, we rewrite Markdown URLs pointing to the development branch to point to the
-   backport branch, so that generated documentation will link to the correct
-   versions of files elsewhere in the repository. For context on the latter,
-   see https://github.com/tendermint/tendermint/issues/7675.
+```sh
+# Example prerelease
+git checkout v1.6-dev
+./scripts/release/release.sh --release=1.6.0-dev.1
 
-   To prepare the PR:
-   ```sh
-   # Remove the RFC and ADR documents from the backport.
-   # We only maintain these on the development branch to avoid confusion.
-   git rm -r docs/rfc docs/architecture
+# Example full release
+git checkout v1.6-dev
+./scripts/release/release.sh --release=1.6.0
+```
 
-   # Update absolute links to point to the backport.
-   go run ./scripts/linkpatch -recur -target v0.35.x -skip-path docs/DOCS_README.md,docs/README.md docs
+Add `--sign` to also build and upload signed linux amd64/arm64 tarballs (GPG
+key required; skipped for routine dev prereleases).
 
-   # Create and push the PR.
-   git checkout -b update-docs-v035x
-   git commit -m "Update docs for v0.35.x backport branch." docs
-   git push -u origin update-docs-v035x
-   ```
+### What the script does
 
-   Be sure to merge this PR before making other changes on the newly-created
-   backport branch.
+1. Validates you are on the correct source branch and the working tree is clean.
+2. Fetches origin and fast-forwards local branch to match (errors if diverged).
+3. Generates `CHANGELOG.md` via `docker run orhunp/git-cliff:2.4.0` using
+   `scripts/release/cliff.toml`; range is `v1.0.0-dev.1..HEAD`.
+4. Bumps `TMVersionDefault` in `version/version.go`.
+5. Creates branch `release_<version>`, commits the two files, and pushes.
+6. Creates a GitHub milestone `vX.Y` if it does not already exist.
+7. Opens a PR targeting `vX.Y-dev` (prerelease) or `master` (full release).
+8. Prints the merge strategy and waits for the PR to be merged.
+9. Creates a **draft** GitHub release with auto-generated notes.
 
-After doing these steps, go back to the development branch and do the following:
+After the script exits:
 
-1. Tag the development branch as the dev branch for the _next_ minor version release and push
-   it up to GitHub.
-   For example:
-   ```sh
-   git tag -a v0.36.0-dev -m "Development base for Tenderdash v0.36."
-   git push origin v0.36.0-dev
-   ```
+- **Prerelease PR** — squash-merge into `vX.Y-dev`.
+- **Full release PR** — merge-commit into `master`.
+- Review the draft release on GitHub, then **publish** it. Publishing creates the
+  `vX.Y.Z` tag and triggers any downstream CI that watches tags.
 
-2. Create a new workflow to run e2e nightlies for the new backport branch.
-   (See [e2e.yml](https://github.com/dashpay/tenderdash/blob/HEAD/.github/workflows/e2e.yml) for an example.)
+### Signed binaries (--sign)
 
-3. Add a new section to the Mergify config (`.github/mergify.yml`) to enable the
-   backport bot to work on this branch, and add a corresponding `S:backport-to-v0.35.x`
-   [label](https://github.com/dashpay/tenderdash/labels) so the bot can be triggered.
+When `--sign` is passed, after you publish the draft release the script resumes,
+checks out the released tag, builds linux/amd64 and linux/arm64 binaries via
+Docker, signs them with GPG, creates `.tar.gz` archives with detached `.sig`
+files, and uploads everything to the release. Set `GPG_KEY_ID` to use a
+specific key.
 
-4. Add a new section to the Dependabot config (`.github/dependabot.yml`) to
-   enable automatic update of Go dependencies on this branch. Copy and edit one
-   of the existing branch configurations to set the correct `target-branch`.
+## CI and build tooling
 
-## Release candidates
-
-Before creating an official release, especially a minor release, we may want to create a
-release candidate (RC) for our friends and partners to test out. We use git tags to
-create RCs, and we build them off of backport branches.
-
-Tags for RCs should follow the "standard" release naming conventions, with `-rcX` at the end
-(for example, `v0.35.0-rc0`).
-
-(Note that branches and tags _cannot_ have the same names, so it's important that these branches
-have distinct names from the tags/release names.)
-
-If this is the first RC for a minor release, you'll have to make a new backport branch (see above).
-Otherwise:
-
-1. Start from the backport branch (e.g. `v0.35.x`).
-2. Run the integration tests and the e2e nightlies (which can be triggered from
-   the Github UI).
-3. Prepare the changelog:
-   - Move the changes included in `CHANGELOG_PENDING.md` into `CHANGELOG.md`. Each RC should have
-     it's own changelog section. These will be squashed when the final candidate is released.
-   - Run `python ./scripts/linkify_changelog.py CHANGELOG.md` to add links for
-     all PRs
-   - Ensure that `UPGRADING.md` is up-to-date and includes notes on any breaking changes
-      or other upgrading flows.
-   - Bump TMVersionDefault version in  `version.go`
-   - Bump P2P and block protocol versions in  `version.go`, if necessary.
-     Check the changelog for breaking changes in these components.
-   - Bump ABCI protocol version in `version.go`, if necessary
-4. Open a PR with these changes against the backport branch.
-5. Once these changes have landed on the backport branch, be sure to pull them back down locally.
-6. Once you have the changes locally, create the new tag, specifying a name and a tag "message":
-   `git tag -a v0.35.0-rc0 -m "Release Candidate v0.35.0-rc0`
-7. Push the tag back up to origin:
-   `git push origin v0.35.0-rc0`
-   Now the tag should be available on the repo's releases page.
-8. Future RCs will continue to be built off of this branch.
-
-Note that this process should only be used for "true" RCs--
-release candidates that, if successful, will be the next release.
-For more experimental "RCs," create a new, short-lived branch and tag that instead.
-
-## Minor release
-
-This minor release process assumes that this release was preceded by release candidates.
-If there were no release candidates, begin by creating a backport branch, as described above.
-
-Before performing these steps, be sure the [Minor Release Checklist](#minor-release-checklist) has been completed.
-
-1. Start on the backport branch (e.g. `v0.35.x`)
-2. Run integration tests (`make test_integrations`) and the e2e nightlies.
-3. Prepare the release:
-   - "Squash" changes from the changelog entries for the RCs into a single entry,
-      and add all changes included in `CHANGELOG_PENDING.md`.
-      (Squashing includes both combining all entries, as well as removing or simplifying
-      any intra-RC changes. It may also help to alphabetize the entries by package name.)
-   - Run `python ./scripts/linkify_changelog.py CHANGELOG.md` to add links for
-     all PRs
-   - Ensure that `UPGRADING.md` is up-to-date and includes notes on any breaking changes
-      or other upgrading flows.
-   - Bump TMVersionDefault version in  `version.go`
-   - Bump P2P and block protocol versions in  `version.go`, if necessary
-   - Bump ABCI protocol version in `version.go`, if necessary
-4. Open a PR with these changes against the backport branch.
-5. Once these changes are on the backport branch, push a tag with prepared release details.
-   This will trigger the actual release `v0.35.0`.
-   - `git tag -a v0.35.0 -m 'Release v0.35.0'`
-   - `git push origin v0.35.0`
-6. Make sure that the development branch is updated with the latest
-   `CHANGELOG.md`, `CHANGELOG_PENDING.md`, and `UPGRADING.md`.
-7. Add the release to the documentation site generator config (see
-   [DOCS_README.md](./docs/DOCS_README.md) for more details). In summary:
-   - Start on the development branch.
-   - Add a new line at the bottom of [`docs/versions`](./docs/versions) to
-     ensure the newest release is the default for the landing page.
-   - Add a new entry to `themeConfig.versions` in
-     [`docs/.vuepress/config.js`](./docs/.vuepress/config.js) to include the
-     release in the dropdown versions menu.
-   - Commit these changes to the development branch and backport them into the backport
-     branch for this release.
-
-## Patch release
-
-Patch releases are done differently from minor releases: They are built off of
-long-lived backport branches, rather than from the development branch. As
-non-breaking changes land on the development branch, they should also be
-backported into these backport branches.
-
-Patch releases don't have release candidates by default, although any tricky
-changes may merit a release candidate.
-
-To create a patch release:
-
-1. Checkout the long-lived backport branch: `git checkout v0.35.x`
-2. Run integration tests (`make test_integrations`) and the nightlies.
-3. Check out a new branch and prepare the release:
-   - Copy `CHANGELOG_PENDING.md` to top of `CHANGELOG.md`
-   - Run `python ./scripts/linkify_changelog.py CHANGELOG.md` to add links for all issues
-   - Run `bash ./scripts/authors.sh` to get a list of authors since the latest release, and add the GitHub aliases of external contributors to the top of the CHANGELOG. To lookup an alias from an email, try `bash ./scripts/authors.sh <email>`
-   - Reset the `CHANGELOG_PENDING.md`
-   - Bump the TMDefaultVersion in `version.go`
-   - Bump the ABCI version number, if necessary.
-     (Note that ABCI follows semver, and that ABCI versions are the only versions
-     which can change during patch releases, and only field additions are valid patch changes.)
-4. Open a PR with these changes that will land them back on `v0.35.x`
-5. Once this change has landed on the backport branch, make sure to pull it locally, then push a tag.
-   - `git tag -a v0.35.1 -m 'Release v0.35.1'`
-   - `git push origin v0.35.1`
-6. Create a pull request back to the development branch with the CHANGELOG &
-   version changes from the latest release.
-   - Remove all `R:patch` labels from the pull requests that were included in the release.
-   - Do not merge the backport branch into the development branch.
+`.github/workflows/release.yml` is triggered manually (`workflow_dispatch`) and
+runs `goreleaser` (config: `.goreleaser.yml`). It currently builds a full
+release when `$GITHUB_REF` starts with `refs/tags/`; it runs a validate-only
+build on pull requests. This workflow is separate from the script's own Docker
+cross-compile path used for signed binaries.
 
 ## Minor Release Checklist
 
-The following set of steps are performed on all releases that increment the
-_minor_ version, e.g. v0.25 to v0.26. These steps ensure that Tenderdash is
-well tested, stable, and suitable for adoption by the various diverse projects
-that rely on Tenderdash.
+The following steps are performed on all releases that increment the _minor_
+version (e.g. v1.5 to v1.6). These steps ensure Tenderdash is well tested,
+stable, and suitable for adoption by the projects that rely on it.
 
 ### Feature Freeze
 
-Ahead of any minor version release of Tenderdash, the software enters 'Feature
-Freeze' for at least two weeks. A feature freeze means that _no_ new features
-are added to the code being prepared for release. No code changes should be made
-to the code being released that do not directly improve pressing issues of code
-quality. The following must not be merged during a feature freeze:
+Ahead of any minor version release, the software enters Feature Freeze for at
+least two weeks. No new features are added to the code being prepared for
+release. The following must not be merged during a feature freeze:
 
-* Refactors that are not related to specific bug fixes.
-* Dependency upgrades.
-* New test code that does not test a discovered regression.
-* New features of any kind.
-* Documentation or spec improvements that are not related to the newly developed
-code.
+- Refactors unrelated to specific bug fixes.
+- Dependency upgrades.
+- New test code that does not test a discovered regression.
+- New features of any kind.
+- Documentation or spec improvements unrelated to the newly developed code.
 
-This period directly follows the creation of the [backport
-branch](#creating-a-backport-branch). The Tenderdash team instead directs all
-attention to ensuring that the existing code is stable and reliable. Broken
-tests are fixed, flakey-tests are remedied, end-to-end test failures are
-thoroughly diagnosed and all efforts of the team are aimed at improving the
-quality of the code. During this period, the upgrade harness tests are run
-repeatedly and a variety of in-house testnets are run to ensure Tenderdash
-functions at the scale it will be used by application developers and node
-operators.
+During this period the Tenderdash team focuses on ensuring existing code is
+stable and reliable. Broken tests are fixed, flaky tests are remedied, and all
+efforts are aimed at improving code quality.
 
 ### Nightly End-To-End Tests
 
 The Tenderdash team maintains [a set of end-to-end
-tests](./test/e2e/README.md) for the dashcore and rotating e2e networks; other
-networks are deprecated. These tests run nightly on the latest commit of the
-project. They start a network of containerized Tenderdash processes and run
-automated checks that the network functions as expected in both stable and
-unstable conditions. During the feature freeze, these tests are run nightly and
-must pass consistently for a release of Tenderdash to be considered stable.
+tests](./test/e2e/README.md) for the dashcore and rotating e2e networks. These
+tests run nightly on the latest commit. They start a network of containerized
+Tenderdash processes and run automated checks in both stable and unstable
+conditions. During the feature freeze these tests must pass consistently before
+a release is considered stable.
 
 ### Upgrade Harness
 
@@ -269,76 +139,51 @@ upgrades work in a representative sample of stop conditions.
 ### Large Scale Testnets
 
 The Tenderdash end-to-end tests run a small network (~10s of nodes) to exercise
-basic consensus interactions. Real world deployments of Tenderdash often have over 
-a hundred nodes just in the validator set, with many others acting as full
-nodes and sentry nodes. To gain more assurance before a release, we will also run
-larger-scale test networks to shake out emergent behaviors at scale.
+basic consensus interactions. Real world deployments of Tenderdash often have
+over a hundred nodes just in the validator set. To gain more assurance before a
+release, larger-scale test networks are run to shake out emergent behaviors at
+scale.
 
-Large-scale test networks are run on a set of virtual machines (VMs). Each VM
-is equipped with 4 Gigabytes of RAM and 2 CPU cores. The network runs a very
-simple key-value store application. The application adds artificial delays to
-different ABCI calls to simulate a slow application. Each testnet is briefly
-run with no load being generated to collect a baseline performance. Once
-baseline is captured, a consistent load is applied across the network. This
-load takes the form of 10% of the running nodes all receiving a consistent
-stream of two hundred transactions per minute each.
+Large-scale test networks run on virtual machines (VMs), each with 4 GB of RAM
+and 2 CPU cores. The network runs a simple key-value store application with
+artificial delays on ABCI calls to simulate a slow application. A baseline is
+captured with no load, then a consistent load is applied (10% of nodes receiving
+200 transactions per minute each).
 
-During each test net, the following metrics are monitored and collected on each
-node:
+Metrics monitored on each node:
 
-* Consensus rounds per height
-* Maximum connected peers, Minimum connected peers, Rate of change of peer connections
-* Memory resident set size
-* CPU utilization
-* Blocks produced per minute
-* Seconds for each step of consensus (Propose, Prevote, Precommit, Commit)
-* Latency to receive block proposals
-
-For these tests we intentionally target low-powered host machines (with low core
-counts and limited memory) to ensure we observe similar kinds of resource contention 
-and limitation that real-world  deployments of Tenderdash experience in production. 
+- Consensus rounds per height
+- Maximum/minimum connected peers, rate of peer connection change
+- Memory resident set size
+- CPU utilization
+- Blocks produced per minute
+- Seconds for each consensus step (Propose, Prevote, Precommit, Commit)
+- Latency to receive block proposals
 
 #### 200 Node Testnet
 
-To test the stability and performance of Tenderdash in a real world scenario,
-a 200 node test network is run. The network comprises 5 seed nodes, 100
-validators and 95 non-validating full nodes. All nodes begin by dialing
-a subset of the seed nodes to discover peers. The network is run for several
-days, with metrics being collected continuously. In cases of changes to performance
-critical systems, testnets of larger sizes should be considered.
+A 200-node test network comprising 5 seed nodes, 100 validators, and 95
+non-validating full nodes. All nodes begin by dialing a subset of seed nodes to
+discover peers. The network runs for several days with continuous metric
+collection. In cases of changes to performance-critical systems, larger testnets
+should be considered.
 
 #### Rotating Node Testnet
 
-Real-world deployments of Tenderdash frequently see new nodes arrive and old
-nodes exit the network. The rotating node testnet ensures that Tenderdash is
-able to handle this reliably. In this test, a network with 10 validators and
-3 seed nodes is started. A rolling set of 25 full nodes are started and each
-connects to the network by dialing one of the seed nodes. Once the node is able
-to blocksync to the head of the chain and begins producing blocks using
-Tenderdash consensus it is stopped. Once stopped, a new node is started and
-takes its place. This network is run for several days.
+A network with 10 validators and 3 seed nodes. A rolling set of 25 full nodes
+are started; each connects to the network via a seed node, block-syncs to the
+head of the chain, begins producing blocks, is stopped, and is replaced by a new
+node. This network runs for several days.
 
 #### Network Partition Testnet
 
-Tenderdash is expected to recover from network partitions. A partition where no
-subset of the nodes is left with the super-majority of the stake is expected to
-stop making blocks. Upon alleviation of the partition, the network is expected
-to once again become fully connected and capable of producing blocks. The
-network partition testnet ensures that Tenderdash is able to handle this
-reliably at scale. In this test, a network with 100 validators and 95 full
-nodes is started. All validators have equal stake. Once the network is
-producing blocks, a set of firewall rules is deployed to create a partitioned
-network with 50% of the stake on one side and 50% on the other. Once the
-network stops producing blocks, the firewall rules are removed and the nodes
-are monitored to ensure they reconnect and that the network again begins
-producing blocks.
+A network with 100 validators and 95 full nodes (all validators with equal
+stake). Once producing blocks, firewall rules create a 50/50 stake partition.
+After block production stops, the firewall rules are removed and the network is
+monitored to confirm reconnection and resumed block production.
 
 #### Absent Stake Testnet
 
-Tenderdash networks often run with _some_ portion of the voting power offline.
-The absent stake testnet ensures that large networks are able to handle this
-reliably. A set of 150 validator nodes and three seed nodes is started. The set
-of 150 validators is configured to only possess a cumulative stake of 67% of
-the total stake. The remaining 33% of the stake is configured to belong to
-a validator that is never actually run in the test network. The network is run
-for multiple days, ensuring that it is able to produce blocks without issue.
+A set of 150 validator nodes and 3 seed nodes configured so that 67% of the
+total stake is active and 33% belongs to a validator that is never run. The
+network runs for multiple days to confirm it produces blocks with missing stake.

--- a/scripts/release/pr_description.md
+++ b/scripts/release/pr_description.md
@@ -4,7 +4,7 @@
 ## Issue being fixed or feature implemented
 <!--- Why is this change required? What problem does it solve? -->
 <!--- If it fixes an open issue, please link to the issue here. -->
-Release new Dash Platform version
+Release new Tenderdash version
 
 ## What was done?
 <!--- Describe your changes in detail -->
@@ -27,6 +27,7 @@ None
 - [ ] I have performed a self-review of the generated changelog
 - [ ] I have checked that P2PProtocol in version/version.go is bumped if needed
 - [ ] I have checked that BlockProtocol in version/version.go is bumped if needed
+- [ ] I have checked that ABCISemVer in version/version.go is bumped if needed
 
 **For repository code-owners and collaborators only**
 - [ ] I have assigned this pull request to a milestone

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 
 function success {
     [[ -t 1 ]] && echo -e "\e[32mSUCCESS:\e[0m" "$@" || echo "SUCCESS:" "$@"
@@ -154,7 +154,15 @@ function validate {
 
     # ensure github authentication
     if ! gh auth status &>/dev/null; then
-        gh auth login
+        error "Not authenticated to GitHub; run 'gh auth login' first"
+    fi
+
+    # Ensure local branch is in sync with origin before generating the changelog,
+    # so commits on origin are not silently missed.
+    git fetch origin "${SOURCE_BRANCH}"
+    if [[ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/${SOURCE_BRANCH}")" ]]; then
+        git merge --ff-only "origin/${SOURCE_BRANCH}" ||
+            error "Your ${SOURCE_BRANCH} is out of sync with origin; sync it before releasing"
     fi
 }
 
@@ -167,9 +175,7 @@ function generateChangelog {
         CLIFF_ARGS="--ignore-tags='v[0-9]\.[0-9]+\.[0-9]+-[a-z]+\.[0-9]+'"
     fi
 
-    echo 2>"${REPO_DIR}/CHANGELOG.md"
-
-    docker run --rm -ti \
+    docker run --rm \
         -v "${REPO_DIR}/.git":/app/.git:ro \
         -v "${CLIFF_CONFIG}":/cliff.toml:ro \
         -v "${REPO_DIR}/CHANGELOG.md":/CHANGELOG.md \
@@ -189,7 +195,6 @@ function updateVersionGo {
 
 function createReleasePR {
     debug "Creating release branch ${RELEASE_BRANCH}"
-    git pull -q
     git checkout -q -b "${RELEASE_BRANCH}"
 
     # commit changes
@@ -201,7 +206,8 @@ function createReleasePR {
     git push --force -u origin "${RELEASE_BRANCH}"
 
     debug "Creating milestone ${MILESTONE} if it doesn't exist yet"
-    gh api --silent --method POST 'repos/dashevo/tenderdash/milestones' --field "title=${MILESTONE}" || true
+    # {owner}/{repo} are substituted by gh from the current repo; HTTP 422 means it already exists.
+    gh api --silent --method POST 'repos/{owner}/{repo}/milestones' --field "title=${MILESTONE}" || true
 
     if [[ -n "$(getPrURL)" ]]; then
         debug "PR for branch ${TARGET_BRANCH} already exists, skipping creation"
@@ -273,9 +279,10 @@ function buildAndUploadArtifacts() {
     local platforms=("linux/amd64" "linux/arm64")
 
     waitForRelease
-    # checkout and build binaries from release tag
-    # TODO: uncomment
-    # git fetch --tags && git checkout "v${NEW_PACKAGE_VERSION}"
+
+    # Build signed binaries from the released tag, not the working checkout.
+    git fetch --tags
+    git checkout "v${NEW_PACKAGE_VERSION}"
 
     buildBinaries "${bindir}" "${platforms[@]}"
 

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -12,8 +12,8 @@ function debug {
 
 function error {
     debug Error: "$@"
-    cleanup
     [[ -t 1 ]] && echo -e '\e[91mERROR:\e[0m' "$@" || echo "ERROR:" "$@"
+    cleanup
     exit 1
 }
 function displayHelp {
@@ -170,9 +170,9 @@ function generateChangelog {
     debug Generating CHANGELOG
 
     CLIFF_CONFIG="${REPO_DIR}/scripts/release/cliff.toml"
-    CLIFF_ARGS=
+    CLIFF_ARGS=()
     if [[ "${RELEASE_TYPE}" = "prerelease" ]]; then
-        CLIFF_ARGS="--ignore-tags='v[0-9]\.[0-9]+\.[0-9]+-[a-z]+\.[0-9]+'"
+        CLIFF_ARGS+=(--ignore-tags 'v[0-9]\.[0-9]+\.[0-9]+-[a-z]+\.[0-9]+')
     fi
 
     docker run --rm \
@@ -183,7 +183,7 @@ function generateChangelog {
         --config /cliff.toml \
         --output /CHANGELOG.md \
         --tag "v${NEW_PACKAGE_VERSION}" \
-        ${CLIFF_ARGS} \
+        "${CLIFF_ARGS[@]}" \
         --strip all \
         --verbose \
         'v1.0.0-dev.1..HEAD'
@@ -277,6 +277,10 @@ function buildAndUploadArtifacts() {
 
     bindir="$(mktemp -d)"
     local platforms=("linux/amd64" "linux/arm64")
+
+    # The build checks out the release tag (detached HEAD); restore the branch on
+    # any exit so the developer is never left stranded.
+    trap 'git checkout -q "${SOURCE_BRANCH}" 2>/dev/null || true' EXIT
 
     waitForRelease
 
@@ -381,7 +385,7 @@ function cleanup() {
     # We need to re-detect current branch again
     CURRENT_BRANCH="$(git branch --show-current)"
 
-    make clean
+    make clean || true
 }
 
 configureDefaults


### PR DESCRIPTION
## Issue being fixed or feature implemented

Our release tooling had several bugs that surfaced during a real **v1.6.0-dev.1** release dry-run. This PR fixes them and rewrites the release docs to match what the script actually does.

## What was done?

### `scripts/release/release.sh`
- **Milestone org fixed** — was hitting `repos/dashevo/tenderdash/milestones` (wrong org); now uses the `repos/{owner}/{repo}/milestones` placeholder so `gh` resolves `dashpay/tenderdash` automatically. `|| true` kept so a pre-existing milestone (HTTP 422) is tolerated.
- **No more TTY requirement** — dropped `docker run -ti`; git-cliff needs no stdin, so the changelog step now works in unattended/CI runs.
- **Changelog branch-sync** — `validate` now fetches origin and fast-forwards the local `vX.Y-dev` before generating the changelog, so commits on origin are never silently missed (the dry-run was 19 commits behind). Removed the now-redundant `git pull -q`.
- **Non-interactive auth** — replaced the blocking `gh auth login` fallback with a clear error telling the user to authenticate first.
- **CLIFF_ARGS quoting** — converted to a bash array so `--ignore-tags` reaches git-cliff without literal quote chars; the prerelease changelog now actually filters dev tags. Also clears shellcheck SC2089/SC2090.
- **Sign path: build from the tag + restore HEAD** — `buildAndUploadArtifacts` now checks out the released tag before building signed binaries, and an `EXIT` trap restores the source branch so the developer is never stranded on detached HEAD.
- **Robust `error()`** — the red `ERROR:` line now prints before `cleanup`, and `cleanup`'s `make clean` is tolerant (`|| true`), so the message is never swallowed.
- Added `-o pipefail` alongside the existing `set -e`.

### `RELEASES.md`
- Full rewrite to document the **actual** scripted flow (the old doc was stale Tendermint-inherited content: `v0.Nx` backport branches, `CHANGELOG_PENDING.md`, `linkify_changelog.py`, `linkpatch`, vuepress versions — none of which describe this repo).
- Accurate CI section: `release.yml` is `workflow_dispatch`-only; nothing auto-runs on tag push or PRs.
- Reconciled merge strategy: normal + prerelease PRs squash; full-release PR into `master` uses a merge commit.
- Neutral tag-timing wording: draft-release tags are mutable and only guaranteed on the remote once published.
- Preserved the full **Minor Release Checklist** (Feature Freeze, Nightly E2E, Upgrade Harness, Large-Scale Testnets).

### `scripts/release/pr_description.md`
- "Release new Dash Platform version" → "Release new Tenderdash version".
- Added an `ABCISemVer` bump check to the checklist.

### `CONTRIBUTING.md`
- Fixed script path `scripts/release.sh` → `scripts/release/release.sh`.
- Noted the full-release merge-commit exception to the squash-merge rule.

## How Has This Been Tested?

`bash -n scripts/release/release.sh` passes. `shellcheck` is clean on every touched line (the only remaining item is a pre-existing SC2035 info on an untouched `sha256sum *.tar.gz` line). Findings originate from the v1.6.0-dev.1 dry-run.

## Breaking Changes

None — script behavior outside the listed fixes is preserved; the default (non-sign) path is unaffected.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`RELEASES.md`, `CONTRIBUTING.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated and expanded release process documentation, including semantic versioning format, branch model, and release procedures. Updated contribution guidelines for release notes generation.

* **Chores**
  * Improved release script reliability with enhanced error handling, authentication validation, and artifact build flow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->