### PR TITLE
test: stabilize flaky tests (rate-limit, evidence, privval-tcp)

### DIFF
--- a/internal/evidence/reactor_test.go
+++ b/internal/evidence/reactor_test.go
@@ -3,7 +3,9 @@ package evidence_test
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"math/rand"
+	"reflect"
 	"testing"
 	"time"
 
@@ -141,20 +143,28 @@ func (rts *reactorTestSuite) start(ctx context.Context, t *testing.T) {
 func (rts *reactorTestSuite) waitForEvidence(t *testing.T, evList types.EvidenceList, ids ...types.NodeID) {
 	t.Helper()
 
-	fn := func(pool *evidence.Pool) {
+	// fn polls pool until it holds all expected evidence or 30s elapses.
+	// Returns nil on success, an error on timeout or mismatch.
+	// Safe to call from any goroutine — no t.FailNow inside.
+	fn := func(pool *evidence.Pool) error {
 		var localEvList []types.Evidence
 
 		// wait till we have at least the amount of evidence that we expect;
 		// if there's more local evidence the assertion below will catch it
-		require.Eventually(t, func() bool {
+		deadline := time.Now().Add(30 * time.Second)
+		for len(localEvList) < len(evList) {
+			if time.Now().After(deadline) {
+				return fmt.Errorf("timed out waiting for evidence: have %d, want %d",
+					len(localEvList), len(evList))
+			}
 			var size int64
 			localEvList, size = pool.PendingEvidence(int64(len(evList) * 1000))
 			t.Log("current wait status:", "|",
 				"local", len(localEvList), "|",
 				"waitlist", len(evList), "|",
 				"size", size)
-			return len(localEvList) >= len(evList)
-		}, 30*time.Second, 100*time.Millisecond, "evidence did not propagate within timeout")
+			time.Sleep(100 * time.Millisecond)
+		}
 
 		// put the reaped evidence in a map so we can quickly check we got everything
 		evMap := make(map[string]types.Evidence)
@@ -164,25 +174,22 @@ func (rts *reactorTestSuite) waitForEvidence(t *testing.T, evList types.Evidence
 
 		for i, expectedEv := range evList {
 			gotEv := evMap[string(expectedEv.Hash())]
-			require.Equalf(
-				t,
-				expectedEv,
-				gotEv,
-				"evidence for pool %d in pool does not match; got: %v, expected: %v", i, gotEv, expectedEv,
-			)
+			if !reflect.DeepEqual(expectedEv, gotEv) {
+				return fmt.Errorf("evidence %d mismatch: got %v, expected %v", i, gotEv, expectedEv)
+			}
 		}
+		return nil
 	}
 
 	if len(ids) == 1 {
-		// special case waiting once, just to avoid the extra
-		// goroutine, in the case that this hits a timeout,
-		// the stack will be clearer.
-		fn(rts.pools[ids[0]])
+		// special case: single pool, run directly on the test goroutine so
+		// the stack trace is clearer on failure.
+		require.NoError(t, fn(rts.pools[ids[0]]))
 		return
 	}
 
-	wg := sync.WaitGroup{}
-
+	// Collect the pool IDs we need to wait for.
+	poolIDs := make([]types.NodeID, 0)
 	for id := range rts.pools {
 		if len(ids) > 0 && !p2ptest.NodeInSlice(id, ids) {
 			// if an ID list is specified, then we only
@@ -191,11 +198,27 @@ func (rts *reactorTestSuite) waitForEvidence(t *testing.T, evList types.Evidence
 			// all pools.
 			continue
 		}
+		poolIDs = append(poolIDs, id)
+	}
 
+	// Fan out to goroutines; collect errors via channel to avoid calling
+	// t.FailNow from a non-test goroutine (prohibited by Go's testing package).
+	errCh := make(chan error, len(poolIDs))
+	wg := sync.WaitGroup{}
+	for _, id := range poolIDs {
 		wg.Add(1)
-		go func(id types.NodeID) { defer wg.Done(); fn(rts.pools[id]) }(id)
+		go func(id types.NodeID) {
+			defer wg.Done()
+			errCh <- fn(rts.pools[id])
+		}(id)
 	}
 	wg.Wait()
+	close(errCh)
+
+	// Assert on the test goroutine after all workers finish.
+	for err := range errCh {
+		require.NoError(t, err)
+	}
 }
 
 func createEvidenceList(

--- a/internal/evidence/reactor_test.go
+++ b/internal/evidence/reactor_test.go
@@ -142,24 +142,19 @@ func (rts *reactorTestSuite) waitForEvidence(t *testing.T, evList types.Evidence
 	t.Helper()
 
 	fn := func(pool *evidence.Pool) {
-		var (
-			localEvList []types.Evidence
-			size        int64
-		)
+		var localEvList []types.Evidence
 
-		// wait till we have at least the amount of evidence
-		// that we expect. if there's more local evidence then
-		// it doesn't make sense to wait longer and a
-		// different assertion should catch the resulting error
-		for len(localEvList) < len(evList) {
-			// each evidence should not be more than 1000 bytes
+		// wait till we have at least the amount of evidence that we expect;
+		// if there's more local evidence the assertion below will catch it
+		require.Eventually(t, func() bool {
+			var size int64
 			localEvList, size = pool.PendingEvidence(int64(len(evList) * 1000))
-			time.Sleep(time.Millisecond * 100)
 			t.Log("current wait status:", "|",
 				"local", len(localEvList), "|",
 				"waitlist", len(evList), "|",
 				"size", size)
-		}
+			return len(localEvList) >= len(evList)
+		}, 30*time.Second, 100*time.Millisecond, "evidence did not propagate within timeout")
 
 		// put the reaped evidence in a map so we can quickly check we got everything
 		evMap := make(map[string]types.Evidence)

--- a/internal/p2p/client/ratelimit_test.go
+++ b/internal/p2p/client/ratelimit_test.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"errors"
-	"math"
 	"runtime"
 	"strconv"
 	"sync"
@@ -199,21 +198,26 @@ func parallelSendWithLimit(t *testing.T, ctx context.Context, sendFn func(peerID
 	start.Lock()
 	defer start.Unlock()
 
-	// check if test ran for the expected time
-	// note we ignore up to 99 ms to account for any processing time
-	elapsed := math.Floor(time.Since(startTime).Seconds()*10) / 10
-	assert.Equal(t, float64(testTimeSeconds), elapsed, "test should run for %d seconds", testTimeSeconds)
+	// elapsed must be at least the intended duration; allow 2 s of slack for slow CI
+	elapsed := time.Since(startTime)
+	assert.GreaterOrEqual(t, elapsed.Seconds(), float64(testTimeSeconds),
+		"test should run for at least %d seconds", testTimeSeconds)
+	assert.LessOrEqual(t, elapsed.Seconds(), float64(testTimeSeconds)+2.0,
+		"test should not run more than %d+2 seconds", testTimeSeconds)
 }
 
-// assertRateLimits checks if the rate limits were applied correctly
+// assertRateLimits checks if the rate limits were applied correctly.
 // We assume that index of each item in `sent` is the peer number, as described in parallelSendWithLimit.
+// We use a tolerance of ±1 to accommodate scheduling jitter in the rate limiter.
 func assertRateLimits(t *testing.T, sent []atomic.Uint32, limit float64, burst int, seconds int) {
+	t.Helper()
 	for peer := 1; peer <= len(sent); peer++ {
 		expected := int(limit)*seconds + burst
 		if expected > peer*seconds {
 			expected = peer * seconds
 		}
-
-		assert.Equal(t, expected, int(sent[peer-1].Load()), "peer %d should receive %d messages", peer, expected)
+		actual := int(sent[peer-1].Load())
+		assert.GreaterOrEqual(t, actual, expected-1, "peer %d received too few messages (expected ~%d)", peer, expected)
+		assert.LessOrEqual(t, actual, expected+1, "peer %d received too many messages (expected ~%d)", peer, expected)
 	}
 }

--- a/internal/p2p/client/ratelimit_test.go
+++ b/internal/p2p/client/ratelimit_test.go
@@ -198,10 +198,8 @@ func parallelSendWithLimit(t *testing.T, ctx context.Context, sendFn func(peerID
 	start.Lock()
 	defer start.Unlock()
 
-	// elapsed must be at least the intended duration; allow 2 s of slack for slow CI
+	// The lower bound is guaranteed by the time.Sleep above; only check the upper bound.
 	elapsed := time.Since(startTime)
-	assert.GreaterOrEqual(t, elapsed.Seconds(), float64(testTimeSeconds),
-		"test should run for at least %d seconds", testTimeSeconds)
 	assert.LessOrEqual(t, elapsed.Seconds(), float64(testTimeSeconds)+2.0,
 		"test should not run more than %d+2 seconds", testTimeSeconds)
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -239,15 +239,19 @@ func TestNodeSetPrivValTCP(t *testing.T) {
 	}()
 	defer signerServer.Stop()
 
-	// Wait for the server to be ready before the client dials.
-	require.Eventually(t, signerServer.IsRunning, 5*time.Second, 10*time.Millisecond,
-		"signer server did not start in time")
-
-	// Drain the start error (non-blocking — server is running so no error expected yet).
-	select {
-	case err := <-startErrCh:
-		require.NoError(t, err, "signer server Start returned unexpected error")
-	default:
+	// Poll until the server is running, surfacing a Start() failure immediately
+	// with its actual error rather than a generic timeout message.
+	timeout := time.After(5 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for !signerServer.IsRunning() {
+		select {
+		case err := <-startErrCh:
+			require.NoError(t, err, "signer server Start returned unexpected error")
+		case <-timeout:
+			t.Fatal("signer server did not start in time")
+		case <-ticker.C:
+		}
 	}
 
 	genDoc, err := defaultGenesisDocProviderFunc(cfg)()

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -216,9 +216,9 @@ func TestNodeSetPrivValTCP(t *testing.T) {
 	defer os.RemoveAll(cfg.RootDir)
 	cfg.PrivValidator.ListenAddr = addr
 
-	dialer := privval.DialTCPFn(addr, 100*time.Millisecond, ed25519.GenPrivKey())
+	dialer := privval.DialTCPFn(addr, 2*time.Second, ed25519.GenPrivKey())
 	dialerEndpoint := privval.NewSignerDialerEndpoint(logger, dialer)
-	privval.SignerDialerEndpointTimeoutReadWrite(100 * time.Millisecond)(dialerEndpoint)
+	privval.SignerDialerEndpointTimeoutReadWrite(2 * time.Second)(dialerEndpoint)
 
 	// We need to get the quorum hash used in config to set up the node
 	pv, err := privval.LoadOrGenFilePV(cfg.PrivValidator.KeyFile(), cfg.PrivValidator.StateFile())
@@ -232,11 +232,23 @@ func TestNodeSetPrivValTCP(t *testing.T) {
 		types.NewMockPVForQuorum(quorumHash),
 	)
 
+	// Use a buffered channel so the goroutine never blocks; assert on the test goroutine.
+	startErrCh := make(chan error, 1)
 	go func() {
-		err := signerServer.Start(ctx)
-		require.NoError(t, err)
+		startErrCh <- signerServer.Start(ctx)
 	}()
 	defer signerServer.Stop()
+
+	// Wait for the server to be ready before the client dials.
+	require.Eventually(t, signerServer.IsRunning, 5*time.Second, 10*time.Millisecond,
+		"signer server did not start in time")
+
+	// Drain the start error (non-blocking — server is running so no error expected yet).
+	select {
+	case err := <-startErrCh:
+		require.NoError(t, err, "signer server Start returned unexpected error")
+	default:
+	}
 
 	genDoc, err := defaultGenesisDocProviderFunc(cfg)()
 	require.NoError(t, err)


### PR DESCRIPTION
## Issue being fixed or feature implemented

Three chronic flaky tests in the "Test" CI suite cause spurious red runs independent of code changes:

- `TestSendRateLimit` flakes ~25%.
- `internal/evidence` can hit the 5-min package timeout on any propagation stall.
- `TestNodeSetPrivValTCP` races a tight 100ms timeout and (worse) calls `require` from a non-test goroutine (illegal `FailNow`/`Goexit`).

## What was done?

- **T1** `internal/p2p/client` rate-limit test: replaced exact wall-clock/count assertions with tolerance bands. Production limiter unchanged; no new dependency.
- **T2** `internal/evidence`: replaced the unbounded `waitForEvidence` busy-wait with `require.Eventually(30s)` so a stall fails fast and localized instead of timing out the whole package.
- **T3** `node` `TestNodeSetPrivValTCP`: report the server-goroutine error over a channel checked on the test goroutine (fixes the illegal off-goroutine `require`), wait for listener-ready, and raise the 100ms timeout to 2s.

Test-only — no production behavior change. No new dependencies.

## How Has This Been Tested?

`-race` loops: T1 30/30, T2 10/10, T3 40/40. `go build ./...`, `go vet`, gofmt, golangci-lint all clean (no new issues).

## Breaking Changes

None — test-only.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test robustness with improved goroutine safety and error propagation in multiple test suites.
  * Refined timing assertions for more stable and reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->