### PR TITLE
fix(mempool): guard concurrent access to the tx index

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -263,6 +263,8 @@ func (txmp *TxMempool) CheckTx(
 // GetTxByHash returns transaction by key from the mempool. If the transaction
 // does not exist, it returns nil.
 func (txmp *TxMempool) GetTxByHash(txHash types.TxKey) types.Tx {
+	txmp.mtx.RLock()
+	defer txmp.mtx.RUnlock()
 	if elt, ok := txmp.txByKey[txHash]; ok {
 		w := elt.Value.(*WrappedTx)
 		return w.tx

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -834,3 +834,94 @@ func mustKvStore(t *testing.T, opts ...kvstore.OptFunc) *kvstore.Application {
 	require.NoError(t, err)
 	return app
 }
+
+func TestTxMempool_GetTxByHash(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := abciclient.NewLocalClient(log.NewNopLogger(), &application{Application: mustKvStore(t)})
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(client.Wait)
+
+	txmp := setup(t, client, 0)
+	txs := checkTxs(ctx, t, txmp, 5, 0)
+
+	present := txs[0].tx
+	var absent types.Tx = []byte("missing-sender=missing-key=42")
+
+	testCases := []struct {
+		name string
+		tx   types.Tx
+		want types.Tx
+	}{
+		{"present", present, present},
+		{"absent", absent, nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := txmp.GetTxByHash(tc.tx.Key())
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestTxMempool_GetTxByHashConcurrent exercises GetTxByHash against concurrent
+// writers (CheckTx inserts, RemoveTxByKey deletes) to assert the read is
+// synchronized. It is meaningful only under the race detector (go test -race).
+func TestTxMempool_GetTxByHashConcurrent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := abciclient.NewLocalClient(log.NewNopLogger(), &application{Application: mustKvStore(t)})
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(client.Wait)
+
+	txmp := setup(t, client, 0)
+
+	const (
+		writers      = 4
+		readers      = 4
+		txsPerWriter = 50
+	)
+
+	var (
+		writersWG sync.WaitGroup
+		readersWG sync.WaitGroup
+		stop      atomic.Bool
+		keys      sync.Map // types.TxKey -> struct{}: keys that have been inserted
+	)
+
+	for w := 0; w < writers; w++ {
+		writersWG.Add(1)
+		go func(peerID uint16) {
+			defer writersWG.Done()
+			for _, tx := range checkTxs(ctx, t, txmp, txsPerWriter, peerID) {
+				key := tx.tx.Key()
+				keys.Store(key, struct{}{})
+				_ = txmp.RemoveTxByKey(key)
+			}
+		}(uint16(w))
+	}
+
+	for r := 0; r < readers; r++ {
+		readersWG.Add(1)
+		go func() {
+			defer readersWG.Done()
+			for !stop.Load() {
+				keys.Range(func(k, _ any) bool {
+					txmp.GetTxByHash(k.(types.TxKey))
+					return true
+				})
+			}
+		}()
+	}
+
+	writersWG.Wait()
+	stop.Store(true)
+	readersWG.Wait()
+}


### PR DESCRIPTION
## Why this PR exists
- **Problem**: `Mempool.GetTxByHash` reads the `txByKey` map **without holding the mempool mutex (`mtx`)**, while every other accessor of that map is synchronized via `mtx` (see the "Synchronized fields, protected by mtx" struct comment in `mempool.go`).
- **What breaks without it**: A read concurrent with a writer is a data race, and the Go runtime promotes a detected map data race to a **fatal, unrecoverable error** — the process crashes. The unlocked read is reachable from the `UnconfirmedTx` RPC handler, so a client RPC racing normal mempool churn can crash the node (availability / DoS).
- **Blocking relationship**: Independent hardening fix; one of a batch of `v1.5-dev` robustness/security fixes. Not stacked on any other PR.

## What was done
- Take the read lock (`mtx.RLock`) around the `txByKey` lookup in `GetTxByHash`, matching the existing pattern in `allEntriesSorted`.
- The only production caller (`UnconfirmedTx` RPC handler) holds no mempool lock, and the returned `clist.CElement.Value` is immutable, so no nested-lock / lock-ordering path is introduced.

## Testing
- Added a table-driven unit test for `GetTxByHash`.
- Added a concurrent regression test that **fails under the race detector** (`go test -race`) without the fix and passes with it.

## Breaking changes
None.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation (n/a — internal concurrency fix)

## Attribution
<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>