### PR TITLE
chore: disable CodeRabbit automatic reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit configuration.
+# Automatic pull-request reviews are disabled: CodeRabbit will only review a
+# pull request when explicitly requested via the "@coderabbitai review"
+# comment command.
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
## Why this PR exists
- **Problem**: CodeRabbit currently reviews every pull request automatically. We want it to run only on demand.
- **What this does**: Adds a root `.coderabbit.yaml` that disables automatic reviews (`reviews.auto_review.enabled: false`). CodeRabbit will then review a PR only when explicitly requested with the `@coderabbitai review` comment command.
- **Note on taking effect**: CodeRabbit reads the configuration from the repository's default branch (`v1.6-dev`), so this needs to be **merged** to take effect repo-wide.

## What was done
- Added `.coderabbit.yaml` at the repo root with `reviews.auto_review.enabled: false` and a comment explaining the on-demand workflow.

## Testing
- N/A — configuration-only change. YAML validates against the CodeRabbit v2 schema reference.

## Breaking changes
None.

## Checklist
- [x] Self-review performed
- [x] Comment explaining the setting included
- [ ] Milestone (maintainer)

## Attribution
<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
