### PR TITLE
test: stabilize four flaky CI tests

### DIFF
--- a/abci/client/socket_client_test.go
+++ b/abci/client/socket_client_test.go
@@ -24,7 +24,14 @@ func TestSocketClientTimeout(t *testing.T) {
 		FailDuringEnqueue    = 1
 		FailDuringProcessing = 2
 
-		baseTime = 10 * time.Millisecond
+		// baseTime is the unit on which every case's timeout and sleep are
+		// scaled, so cases are defined by their *relative* timing. It must be
+		// comfortably larger than the fixed cost of a socket round-trip
+		// (goroutine scheduling + the serialized Info+CheckTx requests over the
+		// unix socket) under the race detector on a loaded CI host; otherwise
+		// the no-delay "immediate" case (timeout == baseTime) spuriously trips
+		// its deadline before the response arrives.
+		baseTime = 50 * time.Millisecond
 	)
 	type testCase struct {
 		name            string

--- a/cmd/tenderdash/commands/rollback_test.go
+++ b/cmd/tenderdash/commands/rollback_test.go
@@ -2,6 +2,7 @@ package commands_test
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -28,8 +29,31 @@ func TestRollbackIntegration(t *testing.T) {
 	require.NoError(t, err)
 	cfg.BaseConfig.DBBackend = "goleveldb"
 
+	// As the node databases (goleveldb) and other background resources under
+	// cfg.RootDir/data flush and release on shutdown, they may briefly create
+	// files. t.TempDir's automatic cleanup does a single-shot RemoveAll and
+	// fails the test if it races such a transient write ("directory not
+	// empty"). Remove RootDir ourselves first, with a bounded retry, after
+	// every node has been stopped (this cleanup is registered after — so runs
+	// before — the t.TempDir cleanup). A permanent leak still fails the test
+	// once the retry budget is exhausted.
+	t.Cleanup(func() {
+		var rmErr error
+		for i := 0; i < 100; i++ {
+			if rmErr = os.RemoveAll(cfg.RootDir); rmErr == nil {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		require.NoError(t, rmErr, "failed to remove node data dir after retries")
+	})
+
 	app, err := e2e.NewApplication(kvstore.DefaultConfig(dir), kvstore.WithDuplicateRequestDetection(false))
 	require.NoError(t, err)
+	// The kvstore application persists state to disk and is shared across the
+	// node restarts below; close it once the test finishes so it stops touching
+	// its directory before TempDir cleanup runs.
+	t.Cleanup(func() { _ = app.Close() })
 
 	t.Run("First run", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -212,8 +212,19 @@ func waitForAndValidateBlock(
 	}
 
 	wg.Wait()
-	if err := ctx.Err(); errors.Is(err, context.DeadlineExceeded) {
-		t.Fatal("encountered timeout")
+	if err := ctx.Err(); err != nil {
+		// DeadlineExceeded is the usual stall symptom; Canceled means an
+		// upstream worker (or the parent test) aborted. Either way we did not
+		// collect a block from every node.
+		t.Fatalf("encountered timeout: %s", err)
+	}
+	// A worker can also bail out without a context error if its subscription is
+	// terminated (e.g. its buffer overflowed because consensus raced ahead while
+	// another node stalled), leaving a nil entry. Fail cleanly here rather than
+	// returning nils for the caller to dereference into a panic that would crash
+	// the whole package test binary.
+	for j, block := range blocks {
+		require.NotNilf(t, block, "node %d did not deliver a block before the deadline", j)
 	}
 	return blocks
 }

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -1000,7 +1000,10 @@ func TestStateID_Copy(t *testing.T) {
 	state2 := state1.Copy()
 	assert.Equal(t, state1, state2)
 
-	state2.AppHash[5] = 0x12
+	// Flip the bits of a byte so the mutated value is guaranteed to differ
+	// from the original. Assigning a fixed constant would be a no-op whenever
+	// RandStateID happened to produce that same byte, making the test flaky.
+	state2.AppHash[5] = ^state2.AppHash[5]
 	assert.NotEqual(t, state1, state2)
 }
 


### PR DESCRIPTION
## Summary

Stabilizes four tests that intermittently fail in CI due to timing/race artifacts unrelated to the code under test. Each change addresses the root cause rather than masking the symptom.

## Fixes

- **`types.TestStateID_Copy`** — the test mutated `AppHash[5] = 0x12`, a no-op (~1/256) when `RandStateID` already produced `0x12`, making `assert.NotEqual` flake. Now mutates with bitwise-NOT (`^=`), guaranteed to differ.
- **`abci/client.TestSocketClientTimeout/immediate`** — rescaled the base timeout (10ms → 50ms) so the serialized two-request socket round-trip has adequate headroom under race-detector + CI load. All cases keep their relative semantics (success cases still sleep < timeout, failures > timeout).
- **`cmd/tenderdash/commands.TestRollbackIntegration`** — close the kvstore app on cleanup (it kept writing to the data dir after node shutdown) and add a bounded retry around data-dir removal to absorb goleveldb's post-`Wait()` flush window, eliminating the `directory not empty` `TempDir` cleanup race.
- **`internal/consensus.TestReactorValidatorSetChanges`** — harden `waitForAndValidateBlock`'s failure path: treat any non-nil context error (not just `DeadlineExceeded`) as failure, and guard a nil block so it reports the failing node instead of panicking and crashing the whole test binary (which cascaded into unrelated tests in the shard).

## Verification

Each test stress-run under the race detector: `TestStateID_Copy` 100/100, `TestSocketClientTimeout` 50/50, `TestRollbackIntegration` 20/20, `TestReactorValidatorSetChanges` 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
