### PR TITLE
fix(light): correctness and robustness in client verification

### DIFF
--- a/light/client.go
+++ b/light/client.go
@@ -834,6 +834,7 @@ func (c *Client) compareFirstHeaderWithWitnesses(ctx context.Context, h *types.S
 	}
 
 	witnessesToRemove := make([]int, 0, len(c.witnesses))
+	conflictingWitnesses := make([]int, 0, len(c.witnesses))
 
 	// handle errors from the header comparisons as they come in
 	for i := 0; i < cap(errc); i++ {
@@ -846,8 +847,9 @@ func (c *Client) compareFirstHeaderWithWitnesses(ctx context.Context, h *types.S
 			c.logger.Error(fmt.Sprintf("witness #%d has a different header. Please check primary is correct and"+
 				" remove witness. Otherwise, use the different primary", e.WitnessIndex), "witness",
 				c.witnesses[e.WitnessIndex])
-			// if attempt to generate conflicting headers failed then remove witness
-			witnessesToRemove = append(witnessesToRemove, e.WitnessIndex)
+			// The primary and a witness disagree; keep the dissenting witness, as
+			// the primary may be the faulty party, and fail the comparison below.
+			conflictingWitnesses = append(conflictingWitnesses, e.WitnessIndex)
 		case errBadWitness:
 			// If witness sent us an invalid header, then remove it
 			c.logger.Info("witness sent an invalid light block, removing...",
@@ -874,8 +876,18 @@ func (c *Client) compareFirstHeaderWithWitnesses(ctx context.Context, h *types.S
 
 	}
 
-	// remove all witnesses that misbehaved
-	return c.removeWitnesses(witnessesToRemove)
+	// remove all witnesses that sent an invalid header
+	if err := c.removeWitnesses(witnessesToRemove); err != nil {
+		return err
+	}
+
+	// A witness presenting a header that conflicts with the primary's means the
+	// primary's header cannot be trusted: fail the comparison.
+	if len(conflictingWitnesses) > 0 {
+		return fmt.Errorf("%w: witnesses %v", ErrConflictingWitnessHeader, conflictingWitnesses)
+	}
+
+	return nil
 }
 
 func (c *Client) Status(_ctx context.Context) *types.LightClientInfo {

--- a/light/client_test.go
+++ b/light/client_test.go
@@ -464,8 +464,8 @@ func TestClient(t *testing.T) {
 		mockBadValSetNode := mockNodeFromHeadersAndVals(
 			map[int64]*types.SignedHeader{
 				1: h1,
-				// 3/3 signed, but validator set at height 2 below is invalid -> witness
-				// should be removed.
+				// 3/3 signed, but the header at height 2 differs from the primary's
+				// (different app hash) -> the witness reports a conflicting header.
 				2: keys.GenSignedHeaderLastBlockID(t, chainID, 2, bTime.Add(30*time.Minute), nil, vals, vals,
 					hash("app_hash2"), hash("cons_hash"), hash("results_hash"),
 					0, len(keys),
@@ -515,10 +515,13 @@ func TestClient(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(c.Witnesses()))
 
+		// A witness reporting a header that conflicts with the primary's fails the
+		// verification; the dissenting witness is kept, since the primary may be
+		// the faulty party.
 		_, err = c.VerifyLightBlockAtHeight(ctx, 2, bTime.Add(2*time.Hour).Add(1*time.Second))
-		assert.NoError(t, err)
-		assert.Equal(t, 1, len(c.Witnesses()))
-		mockBadValSetNode.AssertExpectations(t)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, light.ErrConflictingWitnessHeader)
+		assert.Equal(t, 2, len(c.Witnesses()))
 		mockFullNode.AssertExpectations(t)
 	})
 	t.Run("PrunesHeadersAndValidatorSets", func(t *testing.T) {

--- a/light/detector.go
+++ b/light/detector.go
@@ -116,19 +116,12 @@ func (c *Client) compareNewHeaderWithWitness(ctx context.Context, errc chan erro
 		)
 
 		errc <- errConflictingHeaders{Block: lightBlock, WitnessIndex: witnessIndex}
+		return
 	}
 
 	c.logger.Debug("Matching header received by witness", "height", h.Height, "witness", witnessIndex)
 	errc <- nil
 }
-
-// sendEvidence sends evidence to a provider on a best effort basis.
-// func (c *Client) sendEvidence(ctx context.Context, ev *types.LightClientAttackEvidence, receiver provider.Provider) {
-//	err := receiver.ReportEvidence(ctx, ev)
-//	if err != nil {
-//		c.logger.Error("Failed to report evidence to provider", "ev", ev, "provider", receiver)
-//	}
-// }
 
 // getTargetBlockOrLatest gets the latest height, if it is greater than the target height then it queries
 // the target height else it returns the latest. returns true if it successfully managed to acquire the target

--- a/light/detector_internal_test.go
+++ b/light/detector_internal_test.go
@@ -1,0 +1,165 @@
+package light
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dashpay/tenderdash/libs/log"
+	"github.com/dashpay/tenderdash/light/provider"
+	provider_mocks "github.com/dashpay/tenderdash/light/provider/mocks"
+	"github.com/dashpay/tenderdash/types"
+)
+
+var errTestBadWitness = errors.New("bad witness")
+
+var testBlockTime = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// testLightBlock builds a minimal light block whose hash is determined by the
+// validatorsHash, which is enough to drive the header-comparison logic. The
+// block time is fixed so equal inputs hash equally.
+func testLightBlock(height int64, validatorsHash []byte) *types.LightBlock {
+	return &types.LightBlock{
+		SignedHeader: &types.SignedHeader{
+			Header: &types.Header{
+				Height:         height,
+				Time:           testBlockTime,
+				ValidatorsHash: validatorsHash,
+			},
+		},
+	}
+}
+
+func mockWitness(lb *types.LightBlock, id string) *provider_mocks.Provider {
+	w := &provider_mocks.Provider{}
+	w.On("LightBlock", mock.Anything, mock.Anything).Return(lb, nil).Maybe()
+	w.On("ID").Return(id).Maybe()
+	return w
+}
+
+// TestCompareNewHeaderWithWitness_Conflict is a regression test for the missing
+// return after a conflicting-header send: a witness reporting a different header
+// must produce exactly one message on the channel.
+func TestCompareNewHeaderWithWitness_Conflict(t *testing.T) {
+	primary := testLightBlock(5, []byte("primary-validators-hash"))
+	conflicting := testLightBlock(5, []byte("witness-validators-hash"))
+	require.NotEqual(t, primary.Hash(), conflicting.Hash())
+
+	c := &Client{logger: log.NewNopLogger()}
+	witness := mockWitness(conflicting, "witness-1")
+
+	// Buffer of two so a (buggy) double send would not block; the assertion is
+	// that exactly one message arrives.
+	errc := make(chan error, 2)
+	c.compareNewHeaderWithWitness(context.Background(), errc, primary.SignedHeader, witness, 0)
+	close(errc)
+
+	msgs := make([]error, 0, 2)
+	for err := range errc {
+		msgs = append(msgs, err)
+	}
+
+	require.Len(t, msgs, 1, "exactly one message expected on conflict")
+	require.IsType(t, errConflictingHeaders{}, msgs[0])
+}
+
+// TestCompareNewHeaderWithWitness_Match confirms a matching witness header
+// produces a single nil message.
+func TestCompareNewHeaderWithWitness_Match(t *testing.T) {
+	header := testLightBlock(5, []byte("shared-validators-hash"))
+	matching := testLightBlock(5, []byte("shared-validators-hash"))
+	require.Equal(t, header.Hash(), matching.Hash())
+
+	c := &Client{logger: log.NewNopLogger()}
+	witness := mockWitness(matching, "witness-1")
+
+	errc := make(chan error, 2)
+	c.compareNewHeaderWithWitness(context.Background(), errc, header.SignedHeader, witness, 0)
+	close(errc)
+
+	msgs := make([]error, 0, 2)
+	for err := range errc {
+		msgs = append(msgs, err)
+	}
+
+	require.Len(t, msgs, 1, "exactly one message expected on match")
+	require.NoError(t, msgs[0])
+}
+
+// TestCompareFirstHeaderWithWitnesses covers the witness cross-check flow: a
+// conflicting witness fails verification while being kept, a bad witness is
+// removed, and full agreement succeeds.
+func TestCompareFirstHeaderWithWitnesses(t *testing.T) {
+	primary := testLightBlock(5, []byte("primary-validators-hash"))
+	matching := func() *types.LightBlock { return testLightBlock(5, []byte("primary-validators-hash")) }
+	conflicting := func() *types.LightBlock { return testLightBlock(5, []byte("other-validators-hash")) }
+
+	testCases := []struct {
+		name             string
+		witnesses        func() []provider.Provider
+		wantErr          bool
+		wantConflict     bool
+		wantWitnessCount int
+	}{
+		{
+			name: "all witnesses agree",
+			witnesses: func() []provider.Provider {
+				return []provider.Provider{
+					mockWitness(matching(), "w0"),
+					mockWitness(matching(), "w1"),
+				}
+			},
+			wantErr:          false,
+			wantWitnessCount: 2,
+		},
+		{
+			name: "one conflicting witness fails verification but is kept",
+			witnesses: func() []provider.Provider {
+				return []provider.Provider{
+					mockWitness(matching(), "w0"),
+					mockWitness(conflicting(), "w1"),
+				}
+			},
+			wantErr:          true,
+			wantConflict:     true,
+			wantWitnessCount: 2,
+		},
+		{
+			name: "an erroring witness is removed when others agree",
+			witnesses: func() []provider.Provider {
+				bad := &provider_mocks.Provider{}
+				bad.On("LightBlock", mock.Anything, mock.Anything).
+					Return(nil, provider.ErrUnreliableProvider{Reason: errTestBadWitness}).Maybe()
+				bad.On("ID").Return("bad").Maybe()
+				return []provider.Provider{
+					mockWitness(matching(), "w0"),
+					mockWitness(matching(), "w1"),
+					bad,
+				}
+			},
+			wantErr:          false,
+			wantWitnessCount: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Client{logger: log.NewNopLogger(), witnesses: tc.witnesses()}
+			err := c.compareFirstHeaderWithWitnesses(context.Background(), primary.SignedHeader)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantConflict {
+					require.ErrorIs(t, err, ErrConflictingWitnessHeader)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+			require.Len(t, c.witnesses, tc.wantWitnessCount)
+		})
+	}
+}

--- a/light/errors.go
+++ b/light/errors.go
@@ -82,7 +82,7 @@ var ErrNoWitnesses = errors.New("no witnesses connected. please reset light clie
 // differs from the primary's. The primary's header is not trusted while the
 // conflict is unresolved.
 //
-// By design this favours safety over availability: a single conflicting
+// By design this favors safety over availability: a single conflicting
 // witness fails verification, and there is intentionally no automatic
 // primary swap or recovery. Witness selection is therefore availability-
 // critical — a misbehaving witness can stall verification until an operator

--- a/light/errors.go
+++ b/light/errors.go
@@ -78,6 +78,17 @@ var ErrNoDashCoreClient = errors.New("no dash core client. please reset light cl
 // continue running the light client.
 var ErrNoWitnesses = errors.New("no witnesses connected. please reset light client")
 
+// ErrConflictingWitnessHeader is returned when a witness reports a header that
+// differs from the primary's. The primary's header is not trusted while the
+// conflict is unresolved.
+//
+// By design this favours safety over availability: a single conflicting
+// witness fails verification, and there is intentionally no automatic
+// primary swap or recovery. Witness selection is therefore availability-
+// critical — a misbehaving witness can stall verification until an operator
+// reconfigures the providers.
+var ErrConflictingWitnessHeader = errors.New("witness reported a conflicting header")
+
 // ----------------------------- INTERNAL ERRORS ---------------------------------
 
 // ErrConflictingHeaders is thrown when two conflicting headers are discovered.

--- a/light/provider/http/http.go
+++ b/light/provider/http/http.go
@@ -169,13 +169,14 @@ func (p *http) validatorSet(ctx context.Context, height *int64, proposer types.P
 	const maxPages = 100
 
 	var (
-		perPage         = 100
-		vals            []*types.Validator
-		thresholdPubKey crypto.PubKey
-		quorumType      btcjson.LLMQType
-		quorumHash      crypto.QuorumHash
-		page            = 1
-		total           = -1
+		perPage                 = 100
+		vals                    []*types.Validator
+		thresholdPubKey         crypto.PubKey
+		quorumType              btcjson.LLMQType
+		quorumHash              crypto.QuorumHash
+		page                    = 1
+		total                   = -1
+		thresholdPubKeyReceived bool
 	)
 
 	for len(vals) != total && page <= maxPages {
@@ -183,7 +184,10 @@ func (p *http) validatorSet(ctx context.Context, height *int64, proposer types.P
 		// is negative we will keep repeating.
 		attempt := uint16(0)
 		for {
-			reqThresholdPubKey := attempt == 0
+			// The threshold public key and quorum info are returned only once, with
+			// the first page. Re-request them until received so a timed-out first
+			// attempt is retried rather than silently dropping them.
+			reqThresholdPubKey := !thresholdPubKeyReceived
 			res, err := p.client.Validators(ctx, height, &page, &perPage, &reqThresholdPubKey)
 			switch e := err.(type) {
 			case nil: // success!! Now we validate the response
@@ -226,18 +230,31 @@ func (p *http) validatorSet(ctx context.Context, height *int64, proposer types.P
 				// terminate the connection with the peer.
 				return nil, provider.ErrUnreliableProvider{Reason: e}
 			}
-			// update the total and increment the page index so we can fetch the
-			// next page of validators if need be
-			total = res.Total
-			vals = append(vals, res.Validators...)
 			if reqThresholdPubKey {
+				if res.ThresholdPublicKey == nil || res.QuorumHash == nil {
+					return nil, provider.ErrBadLightBlock{
+						Reason: fmt.Errorf("validator response missing threshold public key or quorum hash (height: %d, page: %d)",
+							height, page),
+					}
+				}
 				thresholdPubKey = *res.ThresholdPublicKey
 				quorumHash = *res.QuorumHash
 				quorumType = res.QuorumType
+				thresholdPubKeyReceived = true
 			}
+			// update the total and advance to the next page so we can fetch the
+			// remaining validators if need be
+			total = res.Total
+			vals = append(vals, res.Validators...)
+			page++
 			break
 		}
 	}
+
+	if !thresholdPubKeyReceived {
+		return nil, provider.ErrBadLightBlock{Reason: fmt.Errorf("validator response did not provide a threshold public key")}
+	}
+
 	valSet := types.NewValidatorSet(vals, thresholdPubKey, quorumType, quorumHash, false, nil)
 
 	if valSet == nil || valSet.IsNilOrEmpty() {

--- a/light/provider/http/validator_set_internal_test.go
+++ b/light/provider/http/validator_set_internal_test.go
@@ -1,0 +1,144 @@
+package http
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dashpay/tenderdash/light/provider"
+	rpcmock "github.com/dashpay/tenderdash/rpc/client/mocks"
+	"github.com/dashpay/tenderdash/rpc/coretypes"
+	"github.com/dashpay/tenderdash/types"
+)
+
+// timeoutErr is a *url.Error reporting a timeout, matching the type the
+// validatorSet retry path inspects.
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+func urlTimeout() error {
+	return &url.Error{Op: "Get", URL: "http://example", Err: net.Error(timeoutErr{})}
+}
+
+// validatorSetProvider exposes the unexported validatorSet method for tests.
+func validatorSetProvider(t *testing.T, c *rpcmock.RemoteClient) *http {
+	t.Helper()
+	p := NewWithClientAndOptions("chain-test", c, Options{MaxRetryAttempts: 3}).(*http)
+	return p
+}
+
+// page returns a single page of the validator set as a ResultValidators,
+// optionally including the threshold/quorum info.
+func page(vs *types.ValidatorSet, vals []*types.Validator, withQuorumInfo bool) *coretypes.ResultValidators {
+	res := &coretypes.ResultValidators{
+		Validators: vals,
+		Count:      len(vals),
+		Total:      len(vs.Validators),
+		QuorumType: vs.QuorumType,
+	}
+	if withQuorumInfo {
+		tpk := vs.ThresholdPublicKey
+		qh := vs.QuorumHash
+		res.ThresholdPublicKey = &tpk
+		res.QuorumHash = &qh
+	}
+	return res
+}
+
+func TestValidatorSetThresholdKey(t *testing.T) {
+	const height = int64(5)
+
+	// A real validator set provides a valid threshold key, quorum hash and
+	// validators that pass ValidateBasic.
+	vs, _ := types.RandValidatorSet(2)
+	proposer := vs.Validators[0].ProTxHash
+
+	t.Run("missing threshold public key returns bad light block", func(t *testing.T) {
+		c := &rpcmock.RemoteClient{}
+		res := page(vs, vs.Validators, true)
+		res.ThresholdPublicKey = nil // provider omitted the threshold key
+		c.On("Validators", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(res, nil)
+
+		p := validatorSetProvider(t, c)
+		vset, err := p.validatorSet(context.Background(), heightPtr(height), proposer)
+		require.Nil(t, vset)
+		require.Error(t, err)
+		require.IsType(t, provider.ErrBadLightBlock{}, err)
+	})
+
+	t.Run("missing quorum hash returns bad light block", func(t *testing.T) {
+		c := &rpcmock.RemoteClient{}
+		res := page(vs, vs.Validators, true)
+		res.QuorumHash = nil // provider omitted the quorum hash
+		c.On("Validators", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(res, nil)
+
+		p := validatorSetProvider(t, c)
+		vset, err := p.validatorSet(context.Background(), heightPtr(height), proposer)
+		require.Nil(t, vset)
+		require.Error(t, err)
+		require.IsType(t, provider.ErrBadLightBlock{}, err)
+	})
+
+	t.Run("timeout on first attempt then retry succeeds populates threshold key", func(t *testing.T) {
+		c := &rpcmock.RemoteClient{}
+		var calls int
+		c.On("Validators", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(func(_ context.Context, _ *int64, _ *int, _ *int, requestQuorumInfo *bool) (*coretypes.ResultValidators, error) {
+				calls++
+				// The first attempt requests the quorum info and times out; the
+				// retry must request it again so the threshold key is populated.
+				require.True(t, *requestQuorumInfo, "threshold key must be re-requested after a timeout")
+				if calls == 1 {
+					return nil, urlTimeout()
+				}
+				return page(vs, vs.Validators, true), nil
+			})
+
+		p := validatorSetProvider(t, c)
+		vset, err := p.validatorSet(context.Background(), heightPtr(height), proposer)
+		require.NoError(t, err)
+		require.NotNil(t, vset)
+		require.True(t, vset.ThresholdPublicKey.Equals(vs.ThresholdPublicKey))
+	})
+
+	t.Run("multi-page happy path advances pages and terminates", func(t *testing.T) {
+		// total=2 with perPage>=2 fits on one page, so to exercise the page
+		// increment we report a total larger than each page and serve the set
+		// across two pages.
+		c := &rpcmock.RemoteClient{}
+		firstPage := []*types.Validator{vs.Validators[0]}
+		secondPage := []*types.Validator{vs.Validators[1]}
+		c.On("Validators", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(func(_ context.Context, _ *int64, pg *int, _ *int, requestQuorumInfo *bool) (*coretypes.ResultValidators, error) {
+				switch *pg {
+				case 1:
+					require.True(t, *requestQuorumInfo, "quorum info requested on first page")
+					return page(vs, firstPage, true), nil
+				case 2:
+					require.False(t, *requestQuorumInfo, "quorum info not re-requested after receipt")
+					return page(vs, secondPage, false), nil
+				default:
+					t.Fatalf("validatorSet requested unexpected page %d (page increment missing?)", *pg)
+					return nil, nil
+				}
+			})
+
+		p := validatorSetProvider(t, c)
+		vset, err := p.validatorSet(context.Background(), heightPtr(height), proposer)
+		require.NoError(t, err)
+		require.NotNil(t, vset)
+		require.Len(t, vset.Validators, 2)
+		require.True(t, vset.ThresholdPublicKey.Equals(vs.ThresholdPublicKey))
+	})
+}
+
+func heightPtr(h int64) *int64 { return &h }

--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -185,9 +185,10 @@ func (c *Client) ABCIQueryWithOptions(ctx context.Context, path string, data tmb
 	}
 
 	// Update the light client if we're behind.
-	// NOTE: AppHash for height H is in header H+1.
-	nextHeight := resp.Height + 1
-	l, err := c.updateLightClientIfNeededTo(ctx, &nextHeight)
+	// AppHash for height H is committed in the header at height H (same-block
+	// execution), so the value proof is verified against the header at resp.Height.
+	queryHeight := resp.Height
+	l, err := c.updateLightClientIfNeededTo(ctx, &queryHeight)
 	if err != nil {
 		return nil, err
 	}
@@ -449,8 +450,9 @@ func (c *Client) BlockResults(ctx context.Context, height *int64) (*coretypes.Re
 	}
 
 	// Update the light client if we're behind.
-	nextHeight := h + 1
-	trustedBlock, err := c.updateLightClientIfNeededTo(ctx, &nextHeight)
+	// ResultsHash for height h is committed in the header at height h (same-block
+	// execution), so the results are verified against the header at h.
+	trustedBlock, err := c.updateLightClientIfNeededTo(ctx, &h)
 	if err != nil {
 		return nil, err
 	}

--- a/light/rpc/client_test.go
+++ b/light/rpc/client_test.go
@@ -1,130 +1,155 @@
 package rpc
 
-//
-// // TestABCIQuery tests ABCIQuery requests and verifies proofs. HAPPY PATH 😀
-// func TestABCIQuery(t *testing.T) {
-//	tree, err := iavl.NewMutableTree(dbm.NewMemDB(), 100)
-//	require.NoError(t, err)
-//
-//	var (
-//		key   = []byte("foo")
-//		value = []byte("bar")
-//	)
-//	tree.Set(key, value)
-//
-//	commitmentProof, err := tree.GetMembershipProof(key)
-//	require.NoError(t, err)
-//
-//	op := &testOp{
-//		Spec:  ics23.IavlSpec,
-//		Key:   key,
-//		Proof: commitmentProof,
-//	}
-//
-//	next := &rpcmock.Client{}
-//	next.On(
-//		"ABCIQueryWithOptions",
-//		context.Background(),
-//		mock.AnythingOfType("string"),
-//		bytes.HexBytes(key),
-//		mock.AnythingOfType("client.ABCIQueryOptions"),
-//	).Return(&ctypes.ResultABCIQuery{
-//		Response: abci.ResponseQuery{
-//			Code:   0,
-//			Key:    key,
-//			Value:  value,
-//			Height: 1,
-//			ProofOps: &tmcrypto.ProofOps{
-//				Ops: []tmcrypto.ProofOp{op.ProofOp()},
-//			},
-//		},
-//	}, nil)
-//
-//	lc := &lcmock.LightClient{}
-//	appHash, _ := hex.DecodeString("5EFD44055350B5CC34DBD26085347A9DBBE44EA192B9286A9FC107F40EA1FAC5")
-//	lc.On("VerifyLightBlockAtHeight", context.Background(), int64(2), mock.AnythingOfType("time.Time")).Return(
-//		&types.LightBlock{
-//			SignedHeader: &types.SignedHeader{
-//				Header: &types.Header{AppHash: appHash},
-//			},
-//		},
-//		nil,
-//	)
-//
-//	c := NewClient(next, lc,
-//		KeyPathFn(func(_ string, key []byte) (merkle.KeyPath, error) {
-//			kp := merkle.KeyPath{}
-//			kp = kp.AppendKey(key, merkle.KeyEncodingURL)
-//			return kp, nil
-//		}))
-//	c.RegisterOpDecoder("ics23:iavl", testOpDecoder)
-//	res, err := c.ABCIQuery(context.Background(), "/store/accounts/key", key)
-//	require.NoError(t, err)
-//
-//	assert.NotNil(t, res)
-// }
-//
-// type testOp struct {
-//	Spec  *ics23.ProofSpec
-//	Key   []byte
-//	Proof *ics23.CommitmentProof
-// }
-//
-// var _ merkle.ProofOperator = testOp{}
-//
-// func (op testOp) GetKey() []byte {
-//	return op.Key
-// }
-//
-// func (op testOp) ProofOp() tmcrypto.ProofOp {
-//	bz, err := op.Proof.Marshal()
-//	if err != nil {
-//		panic(err.Error())
-//	}
-//	return tmcrypto.ProofOp{
-//		Type: "ics23:iavl",
-//		Key:  op.Key,
-//		Data: bz,
-//	}
-// }
-//
-// func (op testOp) Run(args [][]byte) ([][]byte, error) {
-//	// calculate root from proof
-//	root, err := op.Proof.Calculate()
-//	if err != nil {
-//		return nil, fmt.Errorf("could not calculate root for proof: %v", err)
-//	}
-//	// Only support an existence proof or nonexistence proof (batch proofs currently unsupported)
-//	switch len(args) {
-//	case 0:
-//		// Args are nil, so we verify the absence of the key.
-//		absent := ics23.VerifyNonMembership(op.Spec, root, op.Proof, op.Key)
-//		if !absent {
-//			return nil, fmt.Errorf("proof did not verify absence of key: %s", string(op.Key))
-//		}
-//	case 1:
-//		// Args is length 1, verify existence of key with value args[0]
-//		if !ics23.VerifyMembership(op.Spec, root, op.Proof, op.Key, args[0]) {
-//			return nil, fmt.Errorf("proof did not verify existence of key %s with given value %x", op.Key, args[0])
-//		}
-//	default:
-//		return nil, fmt.Errorf("args must be length 0 or 1, got: %d", len(args))
-//	}
-//
-//	return [][]byte{root}, nil
-// }
-//
-// func testOpDecoder(pop tmcrypto.ProofOp) (merkle.ProofOperator, error) {
-//	proof := &ics23.CommitmentProof{}
-//	err := proof.Unmarshal(pop.Data)
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	op := testOp{
-//		Key:   pop.Key,
-//		Spec:  ics23.IavlSpec,
-//		Proof: proof,
-//	}
-//	return op, nil
-// }
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	abci "github.com/dashpay/tenderdash/abci/types"
+	"github.com/dashpay/tenderdash/crypto/merkle"
+	tmbytes "github.com/dashpay/tenderdash/libs/bytes"
+	"github.com/dashpay/tenderdash/libs/log"
+	lcmock "github.com/dashpay/tenderdash/light/rpc/mocks"
+	tmcrypto "github.com/dashpay/tenderdash/proto/tendermint/crypto"
+	rpcclient "github.com/dashpay/tenderdash/rpc/client"
+	rpcmock "github.com/dashpay/tenderdash/rpc/client/mocks"
+	"github.com/dashpay/tenderdash/rpc/coretypes"
+	"github.com/dashpay/tenderdash/types"
+)
+
+var errUnexpectedHeight = errors.New("light block not verified at this height")
+
+// txResults builds a deterministic set of transaction results and its hash.
+func txResults(t *testing.T) ([]*abci.ExecTxResult, tmbytes.HexBytes) {
+	t.Helper()
+	results := []*abci.ExecTxResult{
+		{Code: 0, Data: []byte("first")},
+		{Code: 1, Data: []byte("second")},
+	}
+	h, err := abci.TxResultsHash(results)
+	require.NoError(t, err)
+	return results, h
+}
+
+func headerLightBlock(height int64, appHash, resultsHash tmbytes.HexBytes) *types.LightBlock {
+	return &types.LightBlock{
+		SignedHeader: &types.SignedHeader{
+			Header: &types.Header{Height: height, AppHash: appHash, ResultsHash: resultsHash},
+		},
+	}
+}
+
+// TestBlockResultsVerificationHeight verifies that BlockResults anchors the
+// results hash to the trusted header at the same height (same-block execution),
+// not the header at height+1.
+func TestBlockResultsVerificationHeight(t *testing.T) {
+	const height = int64(10)
+	results, resultsHash := txResults(t)
+	differentHash := tmbytes.HexBytes("a-different-results-hash")
+
+	testCases := []struct {
+		name string
+		// answerHeight is the height the light client is configured to answer
+		// for; if BlockResults queries any other height the mock returns an
+		// error, so a successful run proves it anchored to answerHeight.
+		answerHeight int64
+		headerHash   tmbytes.HexBytes
+		wantErr      bool
+	}{
+		{
+			name:         "results verified against same-height header",
+			answerHeight: height,
+			headerHash:   resultsHash,
+			wantErr:      false,
+		},
+		{
+			name:         "results hash mismatch fails verification",
+			answerHeight: height,
+			headerHash:   differentHash,
+			wantErr:      true,
+		},
+		{
+			name:         "anchoring to height+1 header is not used",
+			answerHeight: height + 1,
+			headerHash:   resultsHash,
+			wantErr:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			next := &rpcmock.Client{}
+			next.On("BlockResults", mock.Anything, mock.Anything).
+				Return(&coretypes.ResultBlockResults{Height: height, TxsResults: results}, nil)
+
+			lc := &lcmock.LightClient{}
+			lc.On("VerifyLightBlockAtHeight", mock.Anything, tc.answerHeight, mock.Anything).
+				Return(headerLightBlock(tc.answerHeight, nil, tc.headerHash), nil)
+			// Any other height is treated as "block not verified".
+			lc.On("VerifyLightBlockAtHeight", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil, errUnexpectedHeight)
+
+			c := NewClient(log.NewNopLogger(), next, lc)
+			h := height
+			_, err := c.BlockResults(ctx, &h)
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				lc.AssertCalled(t, "VerifyLightBlockAtHeight", mock.Anything, height, mock.Anything)
+			}
+		})
+	}
+}
+
+// TestABCIQueryVerificationHeight verifies that ABCIQueryWithOptions anchors the
+// value proof to the trusted header at the response height (same-block
+// execution), not the header at height+1.
+func TestABCIQueryVerificationHeight(t *testing.T) {
+	const respHeight = int64(7)
+	appHash := tmbytes.HexBytes("app-hash-for-height-7")
+
+	ctx := context.Background()
+
+	next := &rpcmock.Client{}
+	next.On("ABCIQueryWithOptions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(&coretypes.ResultABCIQuery{
+			Response: abci.ResponseQuery{
+				Code:   0,
+				Key:    []byte("key"),
+				Value:  []byte("value"),
+				Height: respHeight,
+				ProofOps: &tmcrypto.ProofOps{
+					Ops: []tmcrypto.ProofOp{{Type: "noop", Key: []byte("key")}},
+				},
+			},
+		}, nil)
+
+	var queriedHeight int64
+	lc := &lcmock.LightClient{}
+	lc.On("VerifyLightBlockAtHeight", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			queriedHeight = args.Get(1).(int64)
+		}).
+		Return(headerLightBlock(respHeight, appHash, nil), nil)
+
+	c := NewClient(log.NewNopLogger(), next, lc,
+		KeyPathFn(func(_ string, key []byte) (merkle.KeyPath, error) {
+			return merkle.KeyPath{}.AppendKey(key, merkle.KeyEncodingURL), nil
+		}))
+
+	// The stub proof will not verify, but by then the light client has already
+	// been asked for the trusted header at a specific height, which is the
+	// behavior under test.
+	_, _ = c.ABCIQueryWithOptions(ctx, "/store/x/key", []byte("key"),
+		rpcclient.ABCIQueryOptions{Height: respHeight, Prove: true})
+
+	require.Equal(t, respHeight, queriedHeight,
+		"value proof must be anchored to the header at the response height, not height+1")
+}


### PR DESCRIPTION
## Summary

Hardens the light client's verification path against several correctness and robustness issues.

## Changes

- **Same-block proof anchoring** — anchor same-block proofs at the block's own height, removing an incorrect `H+1` offset in `light/rpc/client.go` that verified proofs against the wrong header.
- **Provider pagination** — fix the `provider/http` page increment so result sets whose total isn't a multiple of the page size no longer cause an infinite request loop.
- **Witness-conflict handling** — in the detector, keep the dissenting witness, fail the comparison, and return after sending the conflicting-evidence report, so witness conflicts are surfaced rather than silently dropped.
- **Defensive nil-checks** — guard `ThresholdPublicKey` / `quorumHash` against nil before use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
