### PR TITLE
fix(blocksync): validate peer block and status responses

### DIFF
--- a/internal/blocksync/block_fetch_job.go
+++ b/internal/blocksync/block_fetch_job.go
@@ -2,6 +2,7 @@ package blocksync
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	sync "github.com/sasha-s/go-deadlock"
@@ -43,6 +44,10 @@ func blockFetchJobHandler(client client.BlockClient, peer PeerData, height int64
 		err = resp.Validate()
 		if err != nil {
 			return errorResult(peer.peerID, height, err)
+		}
+		if resp.Block.Height != height {
+			return errorResult(peer.peerID, height,
+				fmt.Errorf("peer sent block at height %d, requested height %d", resp.Block.Height, height))
 		}
 		return workerpool.Result{Value: resp}
 	}

--- a/internal/blocksync/block_fetch_job_test.go
+++ b/internal/blocksync/block_fetch_job_test.go
@@ -89,6 +89,64 @@ func (suite *BlockFetchJobTestSuite) TestExecute() {
 	}
 }
 
+func (suite *BlockFetchJobTestSuite) TestExecuteHeightMismatch() {
+	ctx := context.Background()
+	const requested = int64(5)
+	// The peer answers a request for height 5 with a valid block+commit at height 6.
+	mismatched := suite.responses[6-1]
+	suite.client.
+		On("GetBlock", mock.Anything, requested, suite.peer.peerID).
+		Once().
+		Return(suite.getBlockReturnFunc(suite.promiseResolveResponse(mismatched)), nil)
+	handler := blockFetchJobHandler(suite.client, suite.peer, requested)
+	res := handler(ctx)
+	suite.requireError("peer sent block at height 6, requested height 5", res.Err)
+}
+
+func TestBlockResponseValidate(t *testing.T) {
+	block := func(h int64) *types.Block {
+		return &types.Block{Header: types.Header{Height: h}}
+	}
+	commit := func(h int64) *types.Commit {
+		return &types.Commit{Height: h}
+	}
+	testCases := []struct {
+		name    string
+		resp    BlockResponse
+		wantErr string
+	}{
+		{
+			name:    "nil block, nil commit",
+			resp:    BlockResponse{},
+			wantErr: "block response without a block",
+		},
+		{
+			name:    "nil block, non-nil commit",
+			resp:    BlockResponse{Commit: commit(10)},
+			wantErr: "block response without a block",
+		},
+		{
+			name:    "block, nil commit",
+			resp:    BlockResponse{Block: block(10)},
+			wantErr: "a block without a commit at height 10",
+		},
+		{
+			name:    "height mismatch",
+			resp:    BlockResponse{Block: block(10), Commit: commit(11)},
+			wantErr: "heights don't match",
+		},
+		{
+			name: "valid",
+			resp: BlockResponse{Block: block(10), Commit: commit(10)},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmrequire.Error(t, tc.wantErr, tc.resp.Validate())
+		})
+	}
+}
+
 func (suite *BlockFetchJobTestSuite) requireError(wantErr string, err error) {
 	tmrequire.Error(suite.T(), wantErr, err)
 	bfErr := &errBlockFetch{}
@@ -168,8 +226,12 @@ func (suite *BlockFetchJobTestSuite) promiseReject(err error) *promise.Promise[*
 }
 
 func (suite *BlockFetchJobTestSuite) promiseResolve(height int64) *promise.Promise[*bcproto.BlockResponse] {
+	return suite.promiseResolveResponse(suite.responses[height-1])
+}
+
+func (suite *BlockFetchJobTestSuite) promiseResolveResponse(resp *bcproto.BlockResponse) *promise.Promise[*bcproto.BlockResponse] {
 	return promise.New(func(resolve func(data *bcproto.BlockResponse), _ func(err error)) {
-		resolve(suite.responses[height-1])
+		resolve(resp)
 	})
 }
 

--- a/internal/blocksync/p2p_msg_handler.go
+++ b/internal/blocksync/p2p_msg_handler.go
@@ -13,6 +13,10 @@ import (
 	bcproto "github.com/dashpay/tenderdash/proto/tendermint/blocksync"
 )
 
+// maxPlausiblePeerHeight bounds a peer-reported height so that downstream
+// height arithmetic (MaxHeight()+1, target counts) cannot overflow.
+const maxPlausiblePeerHeight = int64(1) << 60
+
 type (
 	response               func(ctx context.Context, msg proto.Message) error
 	blockP2PMessageHandler struct {
@@ -50,6 +54,13 @@ func (h *blockP2PMessageHandler) Handle(ctx context.Context, p2pClient *client.C
 			Base:   h.store.Base(),
 		})
 	case *bcproto.StatusResponse:
+		if msg.Base < 0 || msg.Height < msg.Base || msg.Height > maxPlausiblePeerHeight {
+			h.logger.Error("ignoring implausible peer status",
+				"peer", envelope.From,
+				"base", msg.Base,
+				"height", msg.Height)
+			return nil
+		}
 		h.peerAdder.AddPeer(newPeerData(envelope.From, msg.Base, msg.Height))
 	case *bcproto.NoBlockResponse:
 		h.logger.Debug("peer does not have the requested block",

--- a/internal/blocksync/p2p_msg_handler_test.go
+++ b/internal/blocksync/p2p_msg_handler_test.go
@@ -134,27 +134,50 @@ func (suite *BlockP2PMessageHandlerTestSuite) TestHandleStatusResponse() {
 	ctx := context.Background()
 	peerID := types.NodeID("peer")
 	testCases := []struct {
-		mockFn func()
-		msg    *bcproto.StatusResponse
+		name       string
+		msg        *bcproto.StatusResponse
+		wantAdded  bool
+		wantBase   int64
+		wantHeight int64
 	}{
 		{
-			mockFn: func() {
-				suite.fakePeerAdder.
-					On("AddPeer", mock.MatchedBy(func(peerData PeerData) bool {
-						return peerData.height == 1001 && peerData.base == 1000
-					})).
-					Once()
-			},
-			msg: &bcproto.StatusResponse{
-				Height: 1001,
-				Base:   1000,
-			},
+			name:       "valid base below height",
+			msg:        &bcproto.StatusResponse{Height: 1001, Base: 1000},
+			wantAdded:  true,
+			wantBase:   1000,
+			wantHeight: 1001,
+		},
+		{
+			name:       "fresh node reports zero",
+			msg:        &bcproto.StatusResponse{Height: 0, Base: 0},
+			wantAdded:  true,
+			wantBase:   0,
+			wantHeight: 0,
+		},
+		{
+			name:      "negative base",
+			msg:       &bcproto.StatusResponse{Height: 5, Base: -1},
+			wantAdded: false,
+		},
+		{
+			name:      "base above height",
+			msg:       &bcproto.StatusResponse{Height: 4, Base: 5},
+			wantAdded: false,
+		},
+		{
+			name:      "height above plausible bound",
+			msg:       &bcproto.StatusResponse{Height: maxPlausiblePeerHeight + 1, Base: 0},
+			wantAdded: false,
 		},
 	}
-	for i, tc := range testCases {
-		suite.Run(fmt.Sprintf("%d", i), func() {
-			if tc.mockFn != nil {
-				tc.mockFn()
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			if tc.wantAdded {
+				suite.fakePeerAdder.
+					On("AddPeer", mock.MatchedBy(func(peerData PeerData) bool {
+						return peerData.height == tc.wantHeight && peerData.base == tc.wantBase
+					})).
+					Once()
 			}
 			err := suite.handleMessage(ctx, tc.msg, peerID)
 			suite.Require().NoError(err)

--- a/internal/blocksync/synchronizer.go
+++ b/internal/blocksync/synchronizer.go
@@ -469,14 +469,17 @@ type BlockResponse struct {
 }
 
 func (r *BlockResponse) Validate() error {
-	if r.Commit != nil && r.Block.Height != r.Commit.Height {
+	if r.Block == nil {
+		return errors.New("block response without a block")
+	}
+	if r.Commit == nil {
+		// See https://github.com/tendermint/tendermint/pull/8433#discussion_r866790631
+		return fmt.Errorf("a block without a commit at height %d - possible node store corruption", r.Block.Height)
+	}
+	if r.Block.Height != r.Commit.Height {
 		return fmt.Errorf("heights don't match, not adding block (block height: %d, commit height: %d)",
 			r.Block.Height,
 			r.Commit.Height)
-	}
-	if r.Block != nil && r.Commit == nil {
-		// See https://github.com/tendermint/tendermint/pull/8433#discussion_r866790631
-		return fmt.Errorf("a block without a commit at height %d - possible node store corruption", r.Block.Height)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Hardens the block-sync path against malformed responses from unauthenticated P2P peers.

## Changes

- Nil-check before field access in `BlockResponse.Validate`.
- Reject a block whose height does not match the requested height.
- Bound peer-reported `StatusResponse` Base/Height (log + ignore implausible values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
