### PR TITLE
fix(state): propagate tx indexer database errors

### DIFF
--- a/internal/state/indexer/tx/kv/kv.go
+++ b/internal/state/indexer/tx/kv/kv.go
@@ -308,7 +308,7 @@ func (txi *TxIndex) match(
 			}
 		}
 		if err := it.Error(); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("prefix iterator failed during scan: %w", err)
 		}
 
 	case syntax.TExists:
@@ -332,7 +332,7 @@ func (txi *TxIndex) match(
 			}
 		}
 		if err := it.Error(); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("prefix iterator failed during scan: %w", err)
 		}
 
 	case syntax.TContains:
@@ -363,7 +363,7 @@ func (txi *TxIndex) match(
 			}
 		}
 		if err := it.Error(); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("prefix iterator failed during scan: %w", err)
 		}
 	default:
 		panic("other operators should be handled already")
@@ -467,7 +467,7 @@ iter:
 		}
 	}
 	if err := it.Error(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("prefix iterator failed during scan: %w", err)
 	}
 
 	if len(tmpHashes) == 0 || firstRun {

--- a/internal/state/indexer/tx/kv/kv.go
+++ b/internal/state/indexer/tx/kv/kv.go
@@ -44,7 +44,7 @@ func (txi *TxIndex) Get(hash []byte) (*abci.TxResult, error) {
 
 	rawBytes, err := txi.store.Get(primaryKey(hash))
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to read tx result: %w", err)
 	}
 	if rawBytes == nil {
 		return nil, nil
@@ -179,7 +179,10 @@ func (txi *TxIndex) Search(ctx context.Context, q *query.Query) ([]*abci.TxResul
 
 		for _, qr := range ranges {
 			if !hashesInitialized {
-				filteredHashes = txi.matchRange(ctx, qr, prefixFromCompositeKey(qr.Key), filteredHashes, true)
+				filteredHashes, err = txi.matchRange(ctx, qr, prefixFromCompositeKey(qr.Key), filteredHashes, true)
+				if err != nil {
+					return nil, err
+				}
 				hashesInitialized = true
 
 				// Ignore any remaining conditions if the first condition resulted
@@ -188,7 +191,10 @@ func (txi *TxIndex) Search(ctx context.Context, q *query.Query) ([]*abci.TxResul
 					break
 				}
 			} else {
-				filteredHashes = txi.matchRange(ctx, qr, prefixFromCompositeKey(qr.Key), filteredHashes, false)
+				filteredHashes, err = txi.matchRange(ctx, qr, prefixFromCompositeKey(qr.Key), filteredHashes, false)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
@@ -203,7 +209,10 @@ func (txi *TxIndex) Search(ctx context.Context, q *query.Query) ([]*abci.TxResul
 		}
 
 		if !hashesInitialized {
-			filteredHashes = txi.match(ctx, c, prefixForCondition(c, height), filteredHashes, true)
+			filteredHashes, err = txi.match(ctx, c, prefixForCondition(c, height), filteredHashes, true)
+			if err != nil {
+				return nil, err
+			}
 			hashesInitialized = true
 
 			// Ignore any remaining conditions if the first condition resulted
@@ -212,7 +221,10 @@ func (txi *TxIndex) Search(ctx context.Context, q *query.Query) ([]*abci.TxResul
 				break
 			}
 		} else {
-			filteredHashes = txi.match(ctx, c, prefixForCondition(c, height), filteredHashes, false)
+			filteredHashes, err = txi.match(ctx, c, prefixForCondition(c, height), filteredHashes, false)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -267,20 +279,20 @@ func (txi *TxIndex) match(
 	startKeyBz []byte,
 	filteredHashes map[string][]byte,
 	firstRun bool,
-) map[string][]byte {
+) (map[string][]byte, error) {
 	// A previous match was attempted but resulted in no matches, so we return
 	// no matches (assuming AND operand).
 	if !firstRun && len(filteredHashes) == 0 {
-		return filteredHashes
+		return filteredHashes, nil
 	}
 
 	tmpHashes := make(map[string][]byte)
 
-	switch {
-	case c.Op == syntax.TEq:
+	switch c.Op {
+	case syntax.TEq:
 		it, err := dbm.IteratePrefix(txi.store, startKeyBz)
 		if err != nil {
-			panic(err)
+			return nil, fmt.Errorf("failed to create prefix iterator: %w", err)
 		}
 		defer it.Close()
 
@@ -296,15 +308,15 @@ func (txi *TxIndex) match(
 			}
 		}
 		if err := it.Error(); err != nil {
-			panic(err)
+			return nil, err
 		}
 
-	case c.Op == syntax.TExists:
+	case syntax.TExists:
 		// XXX: can't use startKeyBz here because c.Operand is nil
 		// (e.g. "account.owner/<nil>/" won't match w/ a single row)
 		it, err := dbm.IteratePrefix(txi.store, prefixFromCompositeKey(c.Tag))
 		if err != nil {
-			panic(err)
+			return nil, fmt.Errorf("failed to create prefix iterator: %w", err)
 		}
 		defer it.Close()
 
@@ -320,16 +332,16 @@ func (txi *TxIndex) match(
 			}
 		}
 		if err := it.Error(); err != nil {
-			panic(err)
+			return nil, err
 		}
 
-	case c.Op == syntax.TContains:
+	case syntax.TContains:
 		// XXX: startKey does not apply here.
 		// For example, if startKey = "account.owner/an/" and search query = "account.owner CONTAINS an"
 		// we can't iterate with prefix "account.owner/an/" because we might miss keys like "account.owner/Ulan/"
 		it, err := dbm.IteratePrefix(txi.store, prefixFromCompositeKey(c.Tag))
 		if err != nil {
-			panic(err)
+			return nil, fmt.Errorf("failed to create prefix iterator: %w", err)
 		}
 		defer it.Close()
 
@@ -351,7 +363,7 @@ func (txi *TxIndex) match(
 			}
 		}
 		if err := it.Error(); err != nil {
-			panic(err)
+			return nil, err
 		}
 	default:
 		panic("other operators should be handled already")
@@ -365,7 +377,7 @@ func (txi *TxIndex) match(
 		// return no matches (assuming AND operand).
 		//
 		// 2. A previous match was not attempted, so we return all results.
-		return tmpHashes
+		return tmpHashes, nil
 	}
 
 	// Remove/reduce matches in filteredHashes that were not found in this
@@ -383,7 +395,7 @@ func (txi *TxIndex) match(
 		}
 	}
 
-	return filteredHashes
+	return filteredHashes, nil
 }
 
 // matchRange returns all matching txs by hash that meet a given queryRange and
@@ -397,11 +409,11 @@ func (txi *TxIndex) matchRange(
 	startKey []byte,
 	filteredHashes map[string][]byte,
 	firstRun bool,
-) map[string][]byte {
+) (map[string][]byte, error) {
 	// A previous match was attempted but resulted in no matches, so we return
 	// no matches (assuming AND operand).
 	if !firstRun && len(filteredHashes) == 0 {
-		return filteredHashes
+		return filteredHashes, nil
 	}
 
 	tmpHashes := make(map[string][]byte)
@@ -410,7 +422,7 @@ func (txi *TxIndex) matchRange(
 
 	it, err := dbm.IteratePrefix(txi.store, startKey)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to create prefix iterator: %w", err)
 	}
 	defer it.Close()
 
@@ -455,7 +467,7 @@ iter:
 		}
 	}
 	if err := it.Error(); err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	if len(tmpHashes) == 0 || firstRun {
@@ -466,7 +478,7 @@ iter:
 		// return no matches (assuming AND operand).
 		//
 		// 2. A previous match was not attempted, so we return all results.
-		return tmpHashes
+		return tmpHashes, nil
 	}
 
 	// Remove/reduce matches in filteredHashes that were not found in this
@@ -484,7 +496,7 @@ iter:
 		}
 	}
 
-	return filteredHashes
+	return filteredHashes, nil
 }
 
 // ##########################  Keys  #############################

--- a/internal/state/indexer/tx/kv/kv_errors_test.go
+++ b/internal/state/indexer/tx/kv/kv_errors_test.go
@@ -1,0 +1,149 @@
+package kv
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	dbm "github.com/cometbft/cometbft-db"
+	"github.com/stretchr/testify/require"
+
+	abci "github.com/dashpay/tenderdash/abci/types"
+	"github.com/dashpay/tenderdash/internal/pubsub/query"
+	"github.com/dashpay/tenderdash/types"
+)
+
+var errInjected = errors.New("injected database error")
+
+// errorDB wraps a dbm.DB and lets a test inject failures into Get and into the
+// iterators it hands out, including failures that only surface after iteration
+// via Iterator.Error().
+type errorDB struct {
+	dbm.DB
+
+	failGet           bool
+	failIteratorOpen  bool
+	failIteratorError bool
+}
+
+func (d *errorDB) Get(key []byte) ([]byte, error) {
+	if d.failGet {
+		return nil, errInjected
+	}
+	return d.DB.Get(key)
+}
+
+func (d *errorDB) Iterator(start, end []byte) (dbm.Iterator, error) {
+	if d.failIteratorOpen {
+		return nil, errInjected
+	}
+	it, err := d.DB.Iterator(start, end)
+	if err != nil {
+		return nil, err
+	}
+	if d.failIteratorError {
+		return &errorIterator{Iterator: it}, nil
+	}
+	return it, nil
+}
+
+// errorIterator wraps a dbm.Iterator and reports an error from Error() after
+// iteration completes, mimicking a storage failure observed mid-scan.
+type errorIterator struct {
+	dbm.Iterator
+}
+
+func (it *errorIterator) Error() error {
+	return errInjected
+}
+
+func indexedTxResult(events []abci.Event) *abci.TxResult {
+	tx := types.Tx("HELLO WORLD")
+	return &abci.TxResult{
+		Height: 1,
+		Index:  0,
+		Tx:     tx,
+		Result: abci.ExecTxResult{
+			Data:   []byte{0},
+			Code:   abci.CodeTypeOK,
+			Log:    "",
+			Events: events,
+		},
+	}
+}
+
+// newPopulatedStore returns a MemDB already holding one indexed tx so that the
+// match/matchRange iterators have at least one row to scan.
+func newPopulatedStore(t *testing.T) dbm.DB {
+	t.Helper()
+
+	store := dbm.NewMemDB()
+	idx := NewTxIndex(store)
+	txResult := indexedTxResult([]abci.Event{
+		{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
+		{Type: "account", Attributes: []abci.EventAttribute{{Key: "owner", Value: "Ivan", Index: true}}},
+	})
+	require.NoError(t, idx.Index([]*abci.TxResult{txResult}))
+	return store
+}
+
+// TestTxIndexGetStorageError asserts Get surfaces a storage read failure as an
+// error instead of panicking.
+func TestTxIndexGetStorageError(t *testing.T) {
+	store := newPopulatedStore(t)
+	idx := NewTxIndex(&errorDB{DB: store, failGet: true})
+
+	hash := types.Tx("HELLO WORLD").Hash()
+
+	require.NotPanics(t, func() {
+		_, err := idx.Get(hash)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errInjected)
+	})
+}
+
+// TestTxIndexSearchStorageErrors drives Search through match, matchRange, and
+// the hash-lookup Get path, asserting that both iterator-creation failures and
+// post-iteration Iterator.Error() failures are returned, never panicked.
+func TestTxIndexSearchStorageErrors(t *testing.T) {
+	hash := types.Tx("HELLO WORLD").Hash()
+
+	testCases := []struct {
+		name string
+		// q is the search query exercised against the decorated store.
+		q string
+		// mutate configures which failure the decorated store injects.
+		mutate func(*errorDB)
+	}{
+		// match: c.Op == TEq
+		{"match_equal_open", "account.number = 1", func(d *errorDB) { d.failIteratorOpen = true }},
+		{"match_equal_iter_error", "account.number = 1", func(d *errorDB) { d.failIteratorError = true }},
+		// match: c.Op == TExists
+		{"match_exists_open", "account.number EXISTS", func(d *errorDB) { d.failIteratorOpen = true }},
+		{"match_exists_iter_error", "account.number EXISTS", func(d *errorDB) { d.failIteratorError = true }},
+		// match: c.Op == TContains
+		{"match_contains_open", "account.owner CONTAINS 'an'", func(d *errorDB) { d.failIteratorOpen = true }},
+		{"match_contains_iter_error", "account.owner CONTAINS 'an'", func(d *errorDB) { d.failIteratorError = true }},
+		// matchRange
+		{"match_range_open", "account.number >= 1 AND account.number <= 5", func(d *errorDB) { d.failIteratorOpen = true }},
+		{"match_range_iter_error", "account.number >= 1 AND account.number <= 5", func(d *errorDB) { d.failIteratorError = true }},
+		// Search hash-lookup path delegates to Get.
+		{"search_hash_get_error", fmt.Sprintf("tx.hash = '%X'", hash), func(d *errorDB) { d.failGet = true }},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newPopulatedStore(t)
+			decorated := &errorDB{DB: store}
+			tc.mutate(decorated)
+			idx := NewTxIndex(decorated)
+
+			require.NotPanics(t, func() {
+				_, err := idx.Search(context.Background(), query.MustCompile(tc.q))
+				require.Error(t, err)
+				require.ErrorIs(t, err, errInjected)
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary

On the synchronous tx-search RPC path, the tx KV indexer panicked on DB read errors instead of returning them — a transient store error would crash the query path.

## Changes

- In `internal/state/indexer/tx/kv/kv.go`, `Get`, `match`, and `matchRange` now propagate DB read/iteration errors as returned `error`s instead of `panic`, so a transient store failure fails the tx-search query gracefully. (Key-encoding helpers keep their encode-cannot-fail panics; those are not on the DB-read path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
