### PR TITLE
fix(light,statesync): format light-provider height errors and document chunk-ID integrity

### DIFF
--- a/internal/statesync/chunks.go
+++ b/internal/statesync/chunks.go
@@ -152,6 +152,11 @@ func (q *chunkQueue) dequeue() (bytes.HexBytes, error) {
 }
 
 // Add adds a chunk to the queue. It ignores chunks that already exist, returning false.
+//
+// SEC-016 (accept-risk): individual chunk IDs and content are NOT cryptographically
+// verified at this layer. Chunk integrity is delegated to (a) the ABCI application
+// that reassembles and applies the snapshot, and (b) the post-restore app-hash
+// comparison against the trusted light block, which provides the end-to-end guarantee.
 func (q *chunkQueue) Add(chunk *chunk) (bool, error) {
 	if chunk == nil {
 		return false, errChunkNil

--- a/light/provider/http/http.go
+++ b/light/provider/http/http.go
@@ -193,14 +193,14 @@ func (p *http) validatorSet(ctx context.Context, height *int64, proposer types.P
 			case nil: // success!! Now we validate the response
 				if len(res.Validators) == 0 {
 					return nil, provider.ErrBadLightBlock{
-						Reason: fmt.Errorf("validator set is empty (height: %d, page: %d, per_page: %d)",
-							height, page, perPage),
+						Reason: fmt.Errorf("validator set is empty (height: %s, page: %d, per_page: %d)",
+							fmtHeight(height), page, perPage),
 					}
 				}
 				if res.Total <= 0 {
 					return nil, provider.ErrBadLightBlock{
-						Reason: fmt.Errorf("total number of vals is <= 0: %d (height: %d, page: %d, per_page: %d)",
-							res.Total, height, page, perPage),
+						Reason: fmt.Errorf("total number of vals is <= 0: %d (height: %s, page: %d, per_page: %d)",
+							res.Total, fmtHeight(height), page, perPage),
 					}
 				}
 			case *url.Error:
@@ -233,8 +233,8 @@ func (p *http) validatorSet(ctx context.Context, height *int64, proposer types.P
 			if reqThresholdPubKey {
 				if res.ThresholdPublicKey == nil || res.QuorumHash == nil {
 					return nil, provider.ErrBadLightBlock{
-						Reason: fmt.Errorf("validator response missing threshold public key or quorum hash (height: %d, page: %d)",
-							height, page),
+						Reason: fmt.Errorf("validator response missing threshold public key or quorum hash (height: %s, page: %d)",
+							fmtHeight(height), page),
 					}
 				}
 				thresholdPubKey = *res.ThresholdPublicKey
@@ -355,6 +355,15 @@ func (p *http) parseRPCError(e *rpctypes.RPCError) error {
 	default:
 		return provider.ErrBadLightBlock{Reason: e}
 	}
+}
+
+// fmtHeight formats a nullable height pointer for use in error messages.
+// A nil pointer means "latest" (height was not specified by the caller).
+func fmtHeight(h *int64) string {
+	if h == nil {
+		return "latest"
+	}
+	return fmt.Sprintf("%d", *h)
 }
 
 func validateHeight(height int64) (*int64, error) {


### PR DESCRIPTION
## Summary

Two low-severity production fixes, no logic changes:

- **Fix 1 (LOW)** — `light/provider/http`: `validatorSet()` formatted `height` (a `*int64`) with `%d`, which printed the pointer's decimal memory address (e.g. `824636669952`) instead of the actual block height. Added a `fmtHeight(*int64) string` helper and replaced `%d` + `height` with `%s` + `fmtHeight(height)` in all three `ErrBadLightBlock` error messages ('validator set is empty', 'total number of vals is <= 0', 'missing threshold public key or quorum hash').

- **Fix 2 (LOW / SEC-016 accept-risk)** — `internal/statesync/chunks.go`: added a concise doc comment on `chunkQueue.Add` recording that individual chunk IDs and content are **not** cryptographically verified at this layer — integrity is delegated to (a) the ABCI application that reassembles/applies the snapshot, and (b) the post-restore app-hash comparison against the trusted light block. Documentation-only; zero logic change.

## Test plan

- [x] `go build ./light/... ./internal/statesync/...` — clean
- [x] `gofmt -w -s` — no formatting changes needed
- [x] `golangci-lint run` on both packages — all findings are pre-existing in untouched files
- [ ] Unit tests: `go test ./light/provider/http/... ./internal/statesync/...` fails to link in this environment due to missing native BLS library (`-lmimalloc-secure`); unrelated to these changes — same failure on base branch

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)