### PR TITLE
fix(consensus,autofile): prevent TempDir cleanup race in TestHandshakeReplayNone

### DIFF
--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -860,9 +860,20 @@ func buildAppStateFromChain(
 	blockStore *mockBlockStore,
 ) {
 	t.Helper()
+	// Derive a child context so this helper owns the lifecycle of the service
+	// it starts, regardless of the caller's t.Cleanup ordering. abciclient.Client
+	// only exposes Start/Wait via service.Service — there is no Stop() on the
+	// interface — so a service is stopped by canceling the context passed to
+	// Start(). Canceling here before Wait() makes Wait() return promptly; a bare
+	// t.Cleanup(appClient.Wait) would block until the test timed out if it ran
+	// (LIFO) before the caller's cancel().
+	ctx, cancel := context.WithCancel(ctx)
 	// start a new app without handshake, play nBlocks blocks
 	require.NoError(t, appClient.Start(ctx))
-	t.Cleanup(appClient.Wait)
+	t.Cleanup(func() {
+		cancel()
+		appClient.Wait()
+	})
 
 	state.Version.Consensus.App = kvstore.ProtocolVersion // simulate handshake, receive app version
 	validators := types.TM2PB.ValidatorUpdates(state.Validators)
@@ -923,9 +934,20 @@ func buildTMStateFromChain(
 	// run the whole chain against this client to build up the tendermint state
 	client := abciclient.NewLocalClient(logger, app)
 
+	// Derive a child context so this helper owns the lifecycle of the proxy app
+	// it starts, regardless of the caller's t.Cleanup ordering. proxy.New returns
+	// an abciclient.Client whose only stop mechanism (via service.Service) is
+	// canceling the context passed to Start() — there is no Stop() on the
+	// interface. Canceling here before Wait() makes Wait() return promptly; a
+	// bare t.Cleanup(proxyApp.Wait) would block until the test timed out if it
+	// ran (LIFO) before the caller's cancel().
+	ctx, cancel := context.WithCancel(ctx)
 	proxyApp := proxy.New(client, logger, proxy.NopMetrics())
 	require.NoError(t, proxyApp.Start(ctx))
-	t.Cleanup(proxyApp.Wait)
+	t.Cleanup(func() {
+		cancel()
+		proxyApp.Wait()
+	})
 
 	state.Version.Consensus.App = kvstore.ProtocolVersion // simulate handshake, receive app version
 	validators := types.TM2PB.ValidatorUpdates(state.Validators)

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -708,7 +708,18 @@ func testHandshakeReplay(
 		require.NoError(t, err)
 		err = wal.Start(ctx)
 		require.NoError(t, err)
-		t.Cleanup(func() { cancel(); wal.Wait() })
+		// Explicitly Stop the WAL before Wait so that OnStop (which marks the
+		// AutoFile closed and drains the group) runs synchronously from this
+		// cleanup, rather than relying on the background goroutine to have
+		// called it first.  Without this, BaseWAL.Wait() can return while
+		// processFlushTicks / processTicks goroutines are still mid-execution
+		// and able to re-open the WAL file — causing a race with t.TempDir()
+		// cleanup that manifests as "directory not empty".
+		t.Cleanup(func() {
+			cancel()
+			wal.Stop()
+			wal.Wait()
+		})
 		chain, commits = makeBlockchainFromWAL(t, wal)
 		stateDB, genesisState, store = stateAndStore(t, cfg, kvstore.ProtocolVersion)
 	}
@@ -739,6 +750,7 @@ func testHandshakeReplay(
 
 	eventBus := eventbus.NewDefault(logger)
 	require.NoError(t, eventBus.Start(ctx))
+	t.Cleanup(func() { eventBus.Stop(); eventBus.Wait() })
 
 	client := abciclient.NewLocalClient(logger, newKVStoreFunc(t, opts...)(logger, ""))
 	if nBlocks > 0 {
@@ -850,6 +862,7 @@ func buildAppStateFromChain(
 	t.Helper()
 	// start a new app without handshake, play nBlocks blocks
 	require.NoError(t, appClient.Start(ctx))
+	t.Cleanup(appClient.Wait)
 
 	state.Version.Consensus.App = kvstore.ProtocolVersion // simulate handshake, receive app version
 	validators := types.TM2PB.ValidatorUpdates(state.Validators)
@@ -912,6 +925,7 @@ func buildTMStateFromChain(
 
 	proxyApp := proxy.New(client, logger, proxy.NopMetrics())
 	require.NoError(t, proxyApp.Start(ctx))
+	t.Cleanup(proxyApp.Wait)
 
 	state.Version.Consensus.App = kvstore.ProtocolVersion // simulate handshake, receive app version
 	validators := types.TM2PB.ValidatorUpdates(state.Validators)
@@ -924,6 +938,7 @@ func buildTMStateFromChain(
 
 	eventBus := eventbus.NewDefault(logger)
 	require.NoError(t, eventBus.Start(ctx))
+	t.Cleanup(func() { eventBus.Stop(); eventBus.Wait() })
 
 	blockExec := sm.NewBlockExecutor(
 		stateStore,

--- a/internal/consensus/wal.go
+++ b/internal/consensus/wal.go
@@ -166,7 +166,7 @@ func (wal *BaseWAL) OnStart(ctx context.Context) error {
 	// Derive a child context so that OnStop can cancel the goroutine via
 	// procCancel() independently of the caller ctx. The child inherits
 	// cancellation from ctx so the existing "exit when caller ctx cancels"
-	// behaviour is preserved.
+	// behavior is preserved.
 	procCtx, procCancel := context.WithCancel(ctx)
 	wal.procCancel = procCancel
 	wal.goroutineWg.Add(1)
@@ -201,7 +201,7 @@ func (wal *BaseWAL) FlushAndSync() error {
 // before cleaning up files.
 func (wal *BaseWAL) OnStop() {
 	// Cancel the goroutine's context first so processFlushTicks exits on its
-	// next select iteration without waiting for the caller ctx to be cancelled.
+	// next select iteration without waiting for the caller ctx to be canceled.
 	wal.procCancel()
 	wal.flushTicker.Stop()
 	if err := wal.FlushAndSync(); err != nil {

--- a/internal/consensus/wal.go
+++ b/internal/consensus/wal.go
@@ -104,10 +104,15 @@ type BaseWAL struct {
 	flushTicker   *time.Ticker
 	flushInterval time.Duration
 
+	// procCancel cancels the context supplied to processFlushTicks. It is
+	// derived from the caller ctx in OnStart (context.WithCancel) so the
+	// goroutine exits on either procCancel() or the parent ctx. OnStop calls
+	// procCancel() directly, which makes goroutineWg.Wait() in Wait() safe to
+	// call immediately after Stop() regardless of whether the caller ctx fired.
+	procCancel context.CancelFunc
+
 	// goroutineWg tracks the processFlushTicks goroutine so that Wait() can
-	// block until it has truly exited.  processFlushTicks runs with the
-	// caller-supplied ctx and exits on ctx.Done(), not on the service srvCtx,
-	// so BaseService.Wait() alone is insufficient.
+	// block until it has truly exited.
 	goroutineWg sync.WaitGroup
 }
 
@@ -158,10 +163,16 @@ func (wal *BaseWAL) OnStart(ctx context.Context) error {
 		return err
 	}
 	wal.flushTicker = time.NewTicker(wal.flushInterval)
+	// Derive a child context so that OnStop can cancel the goroutine via
+	// procCancel() independently of the caller ctx. The child inherits
+	// cancellation from ctx so the existing "exit when caller ctx cancels"
+	// behaviour is preserved.
+	procCtx, procCancel := context.WithCancel(ctx)
+	wal.procCancel = procCancel
 	wal.goroutineWg.Add(1)
 	go func() {
 		defer wal.goroutineWg.Done()
-		wal.processFlushTicks(ctx)
+		wal.processFlushTicks(procCtx)
 	}()
 	return nil
 }
@@ -189,6 +200,9 @@ func (wal *BaseWAL) FlushAndSync() error {
 // Use Wait() to ensure it's finished shutting down
 // before cleaning up files.
 func (wal *BaseWAL) OnStop() {
+	// Cancel the goroutine's context first so processFlushTicks exits on its
+	// next select iteration without waiting for the caller ctx to be cancelled.
+	wal.procCancel()
 	wal.flushTicker.Stop()
 	if err := wal.FlushAndSync(); err != nil {
 		wal.logger.Error("error on flush data to disk", "error", err)
@@ -206,12 +220,14 @@ func (wal *BaseWAL) OnStop() {
 //  3. The processFlushTicks goroutine has fully exited.
 //  4. The Group's processTicks goroutine has fully exited.
 //
-// Points 3 and 4 are important: those goroutines run with the caller-supplied
-// context and exit on ctx.Done(), which may happen before or after the
-// BaseService srvCtx is cancelled.  Without waiting for them, a goroutine
-// still executing a flush tick could re-open the WAL file (via AutoFile)
-// after the caller believes the WAL is fully stopped, causing a race with
-// t.TempDir() cleanup ("directory not empty").
+// Points 3 and 4 are important: those goroutines run with a child context
+// derived from the caller ctx. OnStop() cancels that child context via
+// procCancel() so goroutineWg.Wait() / WaitForGoroutines() always unblock
+// promptly after Stop() — regardless of whether the original caller ctx has
+// fired. Without waiting for them, a goroutine still executing a flush tick
+// could re-open the WAL file (via AutoFile) after the caller believes the
+// WAL is fully stopped, causing a race with t.TempDir() cleanup
+// ("directory not empty").
 func (wal *BaseWAL) Wait() {
 	if wal.IsRunning() {
 		wal.BaseService.Wait()

--- a/internal/consensus/wal.go
+++ b/internal/consensus/wal.go
@@ -8,6 +8,7 @@ import (
 	"hash/crc32"
 	"io"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/cosmos/gogoproto/proto"
@@ -102,6 +103,12 @@ type BaseWAL struct {
 
 	flushTicker   *time.Ticker
 	flushInterval time.Duration
+
+	// goroutineWg tracks the processFlushTicks goroutine so that Wait() can
+	// block until it has truly exited.  processFlushTicks runs with the
+	// caller-supplied ctx and exits on ctx.Done(), not on the service srvCtx,
+	// so BaseService.Wait() alone is insufficient.
+	goroutineWg sync.WaitGroup
 }
 
 var _ WAL = &BaseWAL{}
@@ -151,7 +158,11 @@ func (wal *BaseWAL) OnStart(ctx context.Context) error {
 		return err
 	}
 	wal.flushTicker = time.NewTicker(wal.flushInterval)
-	go wal.processFlushTicks(ctx)
+	wal.goroutineWg.Add(1)
+	go func() {
+		defer wal.goroutineWg.Done()
+		wal.processFlushTicks(ctx)
+	}()
 	return nil
 }
 
@@ -188,6 +199,19 @@ func (wal *BaseWAL) OnStop() {
 
 // Wait for the underlying autofile group to finish shutting down
 // so it's safe to cleanup files.
+//
+// This blocks until:
+//  1. The WAL BaseService has stopped (OnStop has returned).
+//  2. The Group BaseService has stopped.
+//  3. The processFlushTicks goroutine has fully exited.
+//  4. The Group's processTicks goroutine has fully exited.
+//
+// Points 3 and 4 are important: those goroutines run with the caller-supplied
+// context and exit on ctx.Done(), which may happen before or after the
+// BaseService srvCtx is cancelled.  Without waiting for them, a goroutine
+// still executing a flush tick could re-open the WAL file (via AutoFile)
+// after the caller believes the WAL is fully stopped, causing a race with
+// t.TempDir() cleanup ("directory not empty").
 func (wal *BaseWAL) Wait() {
 	if wal.IsRunning() {
 		wal.BaseService.Wait()
@@ -195,6 +219,9 @@ func (wal *BaseWAL) Wait() {
 	if wal.group.IsRunning() {
 		wal.group.Wait()
 	}
+	// Wait for context-driven goroutines that are not tracked by BaseService.
+	wal.group.WaitForGoroutines()
+	wal.goroutineWg.Wait()
 }
 
 // Write is called in newStep and for each receive on the

--- a/internal/libs/autofile/group.go
+++ b/internal/libs/autofile/group.go
@@ -71,10 +71,15 @@ type Group struct {
 	minIndex           int // Includes head
 	maxIndex           int // Includes head, where Head will move to
 
+	// procCancel cancels the context supplied to background goroutines
+	// (processTicks). It is derived from the caller ctx in OnStart so that
+	// goroutines also exit when the caller ctx is cancelled. OnStop calls
+	// procCancel() directly, which makes goroutineWg.Wait() safe to call
+	// immediately after Stop() regardless of whether the caller ctx has fired.
+	procCancel context.CancelFunc
+
 	// goroutineWg tracks the processTicks goroutine so that WaitForGoroutines
-	// can block until it has fully exited. This is separate from the
-	// BaseService srvCtx because processTicks runs with the caller-supplied
-	// context and exits on ctx.Done(), not on the service's internal cancel.
+	// can block until it has fully exited.
 	goroutineWg stdsync.WaitGroup
 
 	// TODO: When we start deleting files, we need to start tracking GroupReaders
@@ -143,18 +148,23 @@ func GroupTotalSizeLimit(limit int64) func(*Group) {
 // and group limits.
 func (g *Group) OnStart(ctx context.Context) error {
 	g.ticker = time.NewTicker(g.groupCheckDuration)
+	// Derive a child context so that OnStop can cancel the goroutine by
+	// calling g.procCancel() independently of whether the caller ctx fires.
+	// The child inherits cancellation from ctx, preserving the existing
+	// "also exit when caller ctx cancels" behaviour.
+	procCtx, procCancel := context.WithCancel(ctx)
+	g.procCancel = procCancel
 	g.goroutineWg.Add(1)
 	go func() {
 		defer g.goroutineWg.Done()
-		g.processTicks(ctx)
+		g.processTicks(procCtx)
 	}()
 	return nil
 }
 
 // WaitForGoroutines blocks until the background goroutines started by this
-// Group (e.g. processTicks) have fully exited.  It must be called after
-// Close() / Stop() so that the context used to start those goroutines has
-// already been cancelled.
+// Group (e.g. processTicks) have fully exited.  It is safe to call after
+// Stop() because OnStop() cancels the goroutine's context via procCancel.
 func (g *Group) WaitForGoroutines() {
 	g.goroutineWg.Wait()
 }
@@ -162,6 +172,9 @@ func (g *Group) WaitForGoroutines() {
 // OnStop implements service.Service by stopping the goroutine described above.
 // NOTE: g.Head must be closed separately using Close.
 func (g *Group) OnStop() {
+	// Cancel the goroutine's context first so that processTicks exits on its
+	// next select iteration without waiting for the caller ctx.
+	g.procCancel()
 	g.ticker.Stop()
 	if err := g.FlushAndSync(); err != nil {
 		g.logger.Error("error flushing to disk", "err", err)

--- a/internal/libs/autofile/group.go
+++ b/internal/libs/autofile/group.go
@@ -169,6 +169,21 @@ func (g *Group) WaitForGoroutines() {
 	g.goroutineWg.Wait()
 }
 
+// Wait blocks until the Group service has stopped and its background goroutines
+// have fully exited. It overrides BaseService.Wait — which returns as soon as
+// OnStop() closes the quit channel, before the procCancel-driven processTicks
+// goroutine is joined — so that every direct Group consumer gets the same
+// shutdown guarantee BaseWAL.Wait relies on, not just callers that remember to
+// chain WaitForGoroutines explicitly.
+//
+// It calls g.BaseService.Wait() (the embedded method), not g.Wait(), so there
+// is no recursion. WaitForGoroutines is idempotent, so chaining it here on top
+// of an explicit caller call is harmless.
+func (g *Group) Wait() {
+	g.BaseService.Wait()
+	g.WaitForGoroutines()
+}
+
 // OnStop implements service.Service by stopping the goroutine described above.
 // NOTE: g.Head must be closed separately using Close.
 func (g *Group) OnStop() {

--- a/internal/libs/autofile/group.go
+++ b/internal/libs/autofile/group.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	stdsync "sync"
 	"time"
 
 	sync "github.com/sasha-s/go-deadlock"
@@ -69,6 +70,12 @@ type Group struct {
 	groupCheckDuration time.Duration
 	minIndex           int // Includes head
 	maxIndex           int // Includes head, where Head will move to
+
+	// goroutineWg tracks the processTicks goroutine so that WaitForGoroutines
+	// can block until it has fully exited. This is separate from the
+	// BaseService srvCtx because processTicks runs with the caller-supplied
+	// context and exits on ctx.Done(), not on the service's internal cancel.
+	goroutineWg stdsync.WaitGroup
 
 	// TODO: When we start deleting files, we need to start tracking GroupReaders
 	// and their dependencies.
@@ -136,8 +143,20 @@ func GroupTotalSizeLimit(limit int64) func(*Group) {
 // and group limits.
 func (g *Group) OnStart(ctx context.Context) error {
 	g.ticker = time.NewTicker(g.groupCheckDuration)
-	go g.processTicks(ctx)
+	g.goroutineWg.Add(1)
+	go func() {
+		defer g.goroutineWg.Done()
+		g.processTicks(ctx)
+	}()
 	return nil
+}
+
+// WaitForGoroutines blocks until the background goroutines started by this
+// Group (e.g. processTicks) have fully exited.  It must be called after
+// Close() / Stop() so that the context used to start those goroutines has
+// already been cancelled.
+func (g *Group) WaitForGoroutines() {
+	g.goroutineWg.Wait()
 }
 
 // OnStop implements service.Service by stopping the goroutine described above.

--- a/internal/libs/autofile/group.go
+++ b/internal/libs/autofile/group.go
@@ -73,7 +73,7 @@ type Group struct {
 
 	// procCancel cancels the context supplied to background goroutines
 	// (processTicks). It is derived from the caller ctx in OnStart so that
-	// goroutines also exit when the caller ctx is cancelled. OnStop calls
+	// goroutines also exit when the caller ctx is canceled. OnStop calls
 	// procCancel() directly, which makes goroutineWg.Wait() safe to call
 	// immediately after Stop() regardless of whether the caller ctx has fired.
 	procCancel context.CancelFunc
@@ -151,7 +151,7 @@ func (g *Group) OnStart(ctx context.Context) error {
 	// Derive a child context so that OnStop can cancel the goroutine by
 	// calling g.procCancel() independently of whether the caller ctx fires.
 	// The child inherits cancellation from ctx, preserving the existing
-	// "also exit when caller ctx cancels" behaviour.
+	// "also exit when caller ctx cancels" behavior.
 	procCtx, procCancel := context.WithCancel(ctx)
 	g.procCancel = procCancel
 	g.goroutineWg.Add(1)


### PR DESCRIPTION
## Summary

Two commits fixing a TempDir cleanup race in `TestHandshakeReplayNone` — and a follow-up fixing a deadlock the first commit introduced.

### Commit 1 — root cause fix
- **Root cause**: `BaseWAL.Wait()` / `Group.Wait()` returned while `processFlushTicks` / `processTicks` goroutines were still mid-tick and could re-open the AutoFile (`openFile()` with `O_CREATE`), racing with `t.TempDir()` cleanup → `ENOTEMPTY`.
- Added `goroutineWg sync.WaitGroup` to `BaseWAL` and `autofile.Group` to track those goroutines.
- `BaseWAL.Wait()` now calls `group.WaitForGoroutines()` + `wal.goroutineWg.Wait()` after `BaseService.Wait()`.
- Test: explicit `wal.Stop()` before `wal.Wait()` in cleanup hook; missing `t.Cleanup` added for `eventBus`, `buildTMStateFromChain` proxyApp/eventBus, `buildAppStateFromChain` appClient.

### Commit 2 — deadlock fix (⚠️ addresses QA finding)
The first commit introduced a deadlock: both goroutines exited on the caller-supplied ctx, but `Stop()`/`OnStop()` only cancelled the service-internal srvCtx — not the caller ctx. `Wait()` (blocking on `goroutineWg`) would hang forever if called before the caller ctx was cancelled.

**Failing call sites**:
- `TestWALWriteCommit`: `defer cancel()` registered first (LIFO → runs last), `defer { wal.Stop(); wal.Wait() }` registered second (runs first) → hang.
- `state.go receiveRoutine` `onExit()`: calls `wal.Stop(); wal.Wait()` with no guarantee caller ctx has fired → production regression.

**Fix**: in `OnStart`, derive `procCtx, procCancel := context.WithCancel(ctx)`, store `procCancel` on the struct, run goroutines with `procCtx`. `OnStop` calls `procCancel()` first — goroutine exits on next select, `goroutineWg.Wait()` unblocks promptly. Child ctx still inherits cancellation from parent, so "exit when caller ctx cancels" is preserved.

**After**: `Stop()` → `OnStop()` → `procCancel()` → goroutine exits → `Wait()` returns. Safe at every call site regardless of caller ctx state.

## Test results (post commit 2, -race)
- `TestWALWriteCommit -timeout 60s` → **PASS** (0.046s, no hang)
- `TestHandshakeReplayNone -race -count=2` → **PASS** (6.7s, no "directory not empty")
- `./internal/libs/autofile/... -race -count=1` → **PASS**
- `go vet` → clean

## Reviewer notes
1. `stdsync "sync"` import alias in `group.go` — stdlib `sync` is aliased because `go-deadlock` already occupies the `sync` name in that file. `WaitGroup` comes from stdlib `sync`; `Mutex`/`RWMutex` from `go-deadlock`.
2. `procCancel` is never nil when `goroutineWg.Wait()` is reached: `goroutineWg.Add(1)` only fires from `OnStart`, and `OnStart` always sets `procCancel` before `Add(1)`.
3. `goroutineWg.Wait()` is a no-op if `OnStart` was never called (counter stays 0).
4. Follow-up opportunity: `autofile.AutoFile` has `closeFileRoutine` / SIGHUP goroutines signalled by `af.cancel()` but not waited on. They only close FDs (cannot create files), so they are not part of this race — but a similar WaitGroup treatment would be good for goroutine-leak-test hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)