### PR TITLE
chore: bump Go to 1.26.5

### DIFF
--- a/.github/actions/bls/action.yml
+++ b/.github/actions/bls/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.26.4"
+        go-version: "1.26.5"
     - uses: actions/checkout@v6
       with:
         submodules: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6.5.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6
         with:
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6.5.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6
         with:
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6.5.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6.5.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - uses: actions/checkout@v7
 
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6.5.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - uses: actions/checkout@v7
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6.5.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6.5.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - uses: actions/checkout@v7
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-go@v6.5.0
         if: env.GIT_DIFF
         with:
-          go-version: "^1.26.4"
+          go-version: "^1.26.5"
 
       - name: Install dependencies
         if: env.GIT_DIFF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v6.5.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Build
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-go@v6.5.0
         if: env.GIT_DIFF
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Install libpcap
         if: env.GIT_DIFF

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -5,7 +5,7 @@
 # * image - creates final image of minimal size
 
 ARG ALPINE_VERSION=3.23
-ARG GOLANG_VERSION=1.26.4
+ARG GOLANG_VERSION=1.26.5
 #################################
 # STAGE 1: install dependencies #
 #################################

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ requirements if installing from source.
 
 | Requirement | Notes              |
 | ----------- | ------------------ |
-| Go version  | Go1.26.4 or higher |
+| Go version  | Go1.26.5 or higher |
 
 ## Versioning
 

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -596,7 +596,7 @@ This will populate the `go.mod` with a release number followed by a hash for Ten
 ```go
 module github.com/<username>/kvstore
 
-go 1.26.4
+go 1.26.5
 
 require (
  github.com/dgraph-io/badger/v3 v3.2103.2

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -447,7 +447,7 @@ This will populate the `go.mod` with a release number followed by a hash for Ten
 ```go
 module github.com/<username>/kvstore
 
-go 1.26.4
+go 1.26.5
 
 require (
  github.com/dgraph-io/badger/v3 v3.2103.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dashpay/tenderdash
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4
+FROM golang:1.26.5
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,6 +1,6 @@
 ## Stage 1 and 2 is copied from /DOCKER/Dockerfile
 ARG ALIPNE_VERSION=3.23
-ARG GOLANG_VERSION=1.26.4
+ARG GOLANG_VERSION=1.26.5
 #################################
 # STAGE 1: install dependencies #
 #################################

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -1,7 +1,7 @@
 # fuzz
 
 Fuzzing for various packages in Tendermint using the fuzzing infrastructure included in
-Go 1.26.4.
+Go 1.26.5.
 
 Inputs:
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

`govulncheck` fails on `v1.6-dev` and consequently on every PR branch:

```
Vulnerability #1: GO-2026-5856
    Found in: crypto/tls@go1.26.4
    Fixed in: crypto/tls@go1.26.5
```

It is a Go **standard library** vulnerability, reached from:

- `dash/core/client.go:89` → `rpcclient.New` → `tls.Conn.Handshake`
- `rpc/jsonrpc/server/http_server.go:81` → `http.Server.Serve` → `tls.Conn.HandshakeContext`
- `rpc/jsonrpc/client/http_json_client.go:209` → `http.Client.Do` → `tls.Dialer.DialContext`
- `internal/libs/autofile/group.go:255,544` → `bufio` → `tls.Conn.Read`/`Write`

It is unrelated to any application code, so it blocks unrelated PRs (#1393 and
#1394 are both green apart from this check).

## What was done?

Bumped Go from 1.26.4 to 1.26.5 at every pin:

- `go.mod`
- `DOCKER/Dockerfile`, `test/docker/Dockerfile`, `test/e2e/docker/Dockerfile`
- `go-version` in the `build`, `check-generated`, `e2e`, `govulncheck`, `lint`,
  `release` and `tests` workflows

Patch release only — no language or API changes.

## How Has This Been Tested?

Built `DOCKER/Dockerfile`'s `deps` stage against `golang:1.26.5-alpine3.23` and
ran the same scanner the CI job runs:

```
go version go1.26.5 linux/arm64
go build ./internal/... ./types/... ./node/... ./cmd/...   # OK

=== Symbol Results ===
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
```

The two remaining advisories it reports are in imported packages/required
modules that the code does not call, which is the same state as before and does
not fail the check.

CI on this PR exercises the full build, unit and e2e suites on the new toolchain.

## Breaking Changes

None. Go patch release; no language or standard library API changes.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
