### PR TITLE
chore(deps): bump Go to 1.26.6

### DIFF
--- a/.github/actions/bls/action.yml
+++ b/.github/actions/bls/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v6
       with:
         submodules: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6
         with:
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6
         with:
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - uses: actions/checkout@v7
 
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - uses: actions/checkout@v7
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.2.0

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - uses: actions/checkout@v7
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-go@v7.0.0
         if: env.GIT_DIFF
         with:
-          go-version: "^1.26.5"
+          go-version: "^1.26.6"
 
       - name: Install dependencies
         if: env.GIT_DIFF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Build
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-go@v7.0.0
         if: env.GIT_DIFF
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Install libpcap
         if: env.GIT_DIFF

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -5,7 +5,7 @@
 # * image - creates final image of minimal size
 
 ARG ALPINE_VERSION=3.23
-ARG GOLANG_VERSION=1.26.5
+ARG GOLANG_VERSION=1.26.6
 #################################
 # STAGE 1: install dependencies #
 #################################

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ requirements if installing from source.
 
 | Requirement | Notes              |
 | ----------- | ------------------ |
-| Go version  | Go1.26.5 or higher |
+| Go version  | Go1.26.6 or higher |
 
 ## Versioning
 

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -596,7 +596,7 @@ This will populate the `go.mod` with a release number followed by a hash for Ten
 ```go
 module github.com/<username>/kvstore
 
-go 1.26.5
+go 1.26.6
 
 require (
  github.com/dgraph-io/badger/v3 v3.2103.2

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -447,7 +447,7 @@ This will populate the `go.mod` with a release number followed by a hash for Ten
 ```go
 module github.com/<username>/kvstore
 
-go 1.26.5
+go 1.26.6
 
 require (
  github.com/dgraph-io/badger/v3 v3.2103.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dashpay/tenderdash
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5
+FROM golang:1.26.6
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,6 +1,6 @@
 ## Stage 1 and 2 is copied from /DOCKER/Dockerfile
 ARG ALIPNE_VERSION=3.23
-ARG GOLANG_VERSION=1.26.5
+ARG GOLANG_VERSION=1.26.6
 #################################
 # STAGE 1: install dependencies #
 #################################

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -1,7 +1,7 @@
 # fuzz
 
 Fuzzing for various packages in Tendermint using the fuzzing infrastructure included in
-Go 1.26.5.
+Go 1.26.6.
 
 Inputs:
 


### PR DESCRIPTION
**TL;DR:** Bumps the pinned Go toolchain from 1.26.5 to 1.26.6 across the repo (go.mod, CI workflows, Dockerfiles, docs) to clear six pre-existing Go standard-library vulnerability findings that `govulncheck` currently reports on `v1.7-dev` and on every open dependency-bump PR.

## Detailed discussion

This is a pure internal/CI change with no user-observable behavior — no `User story` / `Scenario` sections.

### Issue being fixed or feature implemented
`govulncheck` fails identically on `v1.7-dev` and on every open PR branch (#1412, #1411, #1410), independent of what each PR actually changes:

```
Fixed in: net/url@go1.26.6
Fixed in: html/template@go1.26.6
Fixed in: crypto/tls@go1.26.6
Fixed in: net/http@go1.26.6 (x2)
Fixed in: encoding/asn1@go1.26.6
```

All six are Go **standard-library** vulnerabilities (GO-2026-6218, 6091, 6090, 6089 x2, 5972), found at `go1.26.5` and fixed at `go1.26.6`. None live in any third-party module, so no dependency bump can fix them. They're reachable from our TLS/RPC/HTTP server and Dash Core client paths — the same call sites documented in #1395, which fixed the previous instance of this exact pattern (1.26.4 → 1.26.5).

Confirmed via three independent dependency-review passes this session that the same six IDs, in the same order, are already present on a plain `v1.7-dev` push with no dependabot involvement — this is blocking unrelated PRs, not something any of them introduced.

### What was done?
Bumped Go from 1.26.5 to 1.26.6 at every pin, mirroring #1395's file list exactly:

- `go.mod`
- `DOCKER/Dockerfile`, `test/docker/Dockerfile`, `test/e2e/docker/Dockerfile`
- `go-version` in the `build`, `check-generated`, `e2e`, `govulncheck`, `lint`, `release` and `tests` workflows, and `.github/actions/bls/action.yml`
- `README.md`, `docs/tutorials/go.md`, `docs/tutorials/go-built-in.md`, `test/fuzz/README.md`

Patch release only — no language or API changes.

### How Has This Been Tested?
Locally, with the Go 1.26.6 toolchain:

```
go build ./...            # succeeds
govulncheck ./...          # 0 vulnerabilities (down from 6)
```

CI on this PR exercises the full build, lint, unit and e2e suites on the new toolchain — that's the authoritative signal for anything this local run couldn't reach.

### Breaking Changes
None. Go patch release; no language or standard library API changes.

### Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

### Prior work
- #1395 — the previous instance of this exact pattern (Go 1.26.4 → 1.26.5), same rationale and same file set.
- #1412, #1411, #1410 — open dependabot PRs currently blocked by this same pre-existing govulncheck failure; this PR unblocks all three.

### Attribution

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
