### PR TITLE
fix(consensus): bound catch-up block-part resends and restore round timeouts in reactor test

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1116,8 +1116,11 @@ type ConsensusConfig struct {
 	// Reactor sleep duration parameters. PeerGossipSleepDuration also sets the
 	// gossip tick a lagging peer's catch-up part-set replay is metered against
 	// (internal/consensus/gossiper.go's catchupResendInterval, currently a fixed
-	// 500ms): raising this past that value disables that throttle, and lowering
-	// it scales the throttle's effective suppression window down proportionally.
+	// 500ms quiet gap between passes that does NOT scale with this value):
+	// raising this past that value disables the throttle entirely, since every
+	// tick then already exceeds the gap it is meant to enforce. Lowering it
+	// does not shrink the gap — it only fits more ticks (and so more sends of
+	// a multi-part block) into that same fixed window before it applies.
 	PeerGossipSleepDuration     time.Duration `mapstructure:"peer-gossip-sleep-duration"`
 	PeerQueryMaj23SleepDuration time.Duration `mapstructure:"peer-query-maj23-sleep-duration"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -1113,7 +1113,11 @@ type ConsensusConfig struct {
 	// has to be manual (useful for tests)
 	DontAutoPropose bool `mapstructure:"dont-auto-propose'"`
 
-	// Reactor sleep duration parameters
+	// Reactor sleep duration parameters. PeerGossipSleepDuration also sets the
+	// gossip tick a lagging peer's catch-up part-set replay is metered against
+	// (internal/consensus/gossiper.go's catchupResendInterval, currently a fixed
+	// 500ms): raising this past that value disables that throttle, and lowering
+	// it scales the throttle's effective suppression window down proportionally.
 	PeerGossipSleepDuration     time.Duration `mapstructure:"peer-gossip-sleep-duration"`
 	PeerQueryMaj23SleepDuration time.Duration `mapstructure:"peer-query-maj23-sleep-duration"`
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -546,7 +546,10 @@ double-sign-check-height = {{ .Consensus.DoubleSignCheckHeight }}
 create-empty-blocks = {{ .Consensus.CreateEmptyBlocks }}
 create-empty-blocks-interval = "{{ .Consensus.CreateEmptyBlocksInterval }}"
 
-# Reactor sleep duration parameters
+# Reactor sleep duration parameters. peer-gossip-sleep-duration also sets the
+# tick rate a lagging peer's catch-up block-part replay is metered against
+# (a fixed 500ms internal throttle): raising this above 500ms disables that
+# throttle.
 peer-gossip-sleep-duration = "{{ .Consensus.PeerGossipSleepDuration }}"
 peer-query-maj23-sleep-duration = "{{ .Consensus.PeerQueryMaj23SleepDuration }}"
 

--- a/internal/consensus/gossip_handlers.go
+++ b/internal/consensus/gossip_handlers.go
@@ -73,7 +73,9 @@ func dataGossipHandler(ps *PeerState, logger log.Logger, blockStore sm.BlockStor
 		if shouldPeerBeCaughtUp(rs, prs, blockStoreBase) {
 			if prs.ProposalBlockParts != nil {
 				gossiper.GossipBlockPartsForCatchup(ctx, rs, prs)
-				// block parts already delivered -  send commits?
+				// GossipBlockPartsForCatchup is rate-limited and returns without
+				// sending on most ticks; GossipCommit runs regardless, so the peer
+				// still gets its missing commit while a part-set pass is inactive.
 				gossiper.GossipCommit(ctx, rs, prs)
 				return
 			}

--- a/internal/consensus/gossip_handlers.go
+++ b/internal/consensus/gossip_handlers.go
@@ -73,9 +73,10 @@ func dataGossipHandler(ps *PeerState, logger log.Logger, blockStore sm.BlockStor
 		if shouldPeerBeCaughtUp(rs, prs, blockStoreBase) {
 			if prs.ProposalBlockParts != nil {
 				gossiper.GossipBlockPartsForCatchup(ctx, rs, prs)
-				// GossipBlockPartsForCatchup is rate-limited and returns without
-				// sending on most ticks; GossipCommit runs regardless, so the peer
-				// still gets its missing commit while a part-set pass is inactive.
+				// GossipBlockPartsForCatchup is rate-limited between passes, not
+				// per tick (see catchupResendInterval); GossipCommit runs
+				// regardless, so the peer still gets its missing commit while a
+				// part-set pass is between replays.
 				gossiper.GossipCommit(ctx, rs, prs)
 				return
 			}

--- a/internal/consensus/gossip_peer_worker.go
+++ b/internal/consensus/gossip_peer_worker.go
@@ -48,6 +48,7 @@ func newPeerGossipWorker(
 		msgSender:  msgSender,
 		logger:     logger,
 		optimistic: true,
+		clock:      clockwork.NewRealClock(),
 	}
 	return &peerGossipWorker{
 		clock:          clockwork.NewRealClock(),

--- a/internal/consensus/gossip_peer_worker.go
+++ b/internal/consensus/gossip_peer_worker.go
@@ -42,16 +42,17 @@ func newPeerGossipWorker(
 	state *State,
 	msgSender *p2pMsgSender,
 ) *peerGossipWorker {
+	clock := clockwork.NewRealClock()
 	gossiper := msgGossiper{
 		ps:         ps,
 		blockStore: &blockRepository{BlockStore: state.blockStore, logger: logger},
 		msgSender:  msgSender,
 		logger:     logger,
 		optimistic: true,
-		clock:      clockwork.NewRealClock(),
+		clock:      clock,
 	}
 	return &peerGossipWorker{
-		clock:          clockwork.NewRealClock(),
+		clock:          clock,
 		logger:         logger,
 		stopCh:         make(chan struct{}),
 		stateDataStore: state.stateDataStore,

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -4,8 +4,8 @@ package consensus
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/cosmos/gogoproto/proto"
@@ -24,6 +24,10 @@ import (
 type Gossiper interface {
 	GossipProposal(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 	GossipProposalBlockParts(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
+	// GossipBlockPartsForCatchup is rate-limited (catchupResendInterval) and
+	// returns immediately on most calls. The limit is per gossip worker, not per
+	// peer: a peer that reconnects gets a fresh worker and a fresh pass. Must be
+	// called from a single goroutine per Gossiper instance.
 	GossipBlockPartsForCatchup(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 	GossipVote(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 	GossipVoteSetMaj23(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
@@ -33,7 +37,9 @@ type Gossiper interface {
 // catchupResendInterval bounds how often the catch-up path replays a block's
 // part set to the same lagging peer. Catch-up deliberately never marks parts as
 // delivered, so without this bound a peer we believe is behind is served on
-// every gossip tick.
+// every gossip tick. A pass suppresses roughly catchupResendInterval /
+// PeerGossipSleepDuration ticks — five at their production defaults — and does
+// nothing at all if the gossip cadence is configured slower than this interval.
 const catchupResendInterval = 500 * time.Millisecond
 
 type msgGossiper struct {
@@ -44,9 +50,12 @@ type msgGossiper struct {
 	optimistic bool
 	clock      clockwork.Clock
 
-	// Catch-up pass accounting for the one peer this gossiper serves. Unguarded:
-	// only dataGossipHandler reaches GossipBlockPartsForCatchup, and its handler
-	// runs on a single goroutine.
+	// Catch-up pass accounting for the one peer this gossiper serves. Guarded by
+	// catchupMu rather than relying on dataGossipHandler being the only caller
+	// today: the same *msgGossiper is shared across three concurrent handler
+	// goroutines (see reactor.go), and nothing stops a future one from also
+	// calling GossipBlockPartsForCatchup.
+	catchupMu        sync.Mutex
 	catchupHeight    int64
 	catchupRemaining int
 	catchupRetryAt   time.Time
@@ -183,7 +192,8 @@ func (g *msgGossiper) GossipProposal(ctx context.Context, rs cstypes.RoundState,
 	}
 }
 
-// GossipBlockPartsForCatchup sends a block part for catch up
+// GossipBlockPartsForCatchup sends a block part for catch up; see the doc on
+// the Gossiper interface for its rate limit and goroutine-affinity contract.
 func (g *msgGossiper) GossipBlockPartsForCatchup(
 	ctx context.Context,
 	_ cstypes.RoundState,
@@ -192,7 +202,7 @@ func (g *msgGossiper) GossipBlockPartsForCatchup(
 	if !g.beginCatchupAttempt(prs) {
 		return
 	}
-	if err := g.sendCatchupBlockPart(ctx, prs); err != nil {
+	if !g.sendCatchupBlockPart(ctx, prs) {
 		// The peer controls both the budget a pass opens with and the inputs that
 		// fail here, so a pass that cannot produce a send is abandoned rather than
 		// charged one slot per tick.
@@ -201,32 +211,35 @@ func (g *msgGossiper) GossipBlockPartsForCatchup(
 }
 
 // sendCatchupBlockPart sends the peer one part of its incomplete block, drawn at
-// random from the parts it reports missing. A non-nil error reports only that no
-// part reached the peer; the caller is not expected to inspect it.
-func (g *msgGossiper) sendCatchupBlockPart(ctx context.Context, prs *cstypes.PeerRoundState) error {
+// random from the parts it reports missing, and reports whether the part
+// reached the peer.
+func (g *msgGossiper) sendCatchupBlockPart(ctx context.Context, prs *cstypes.PeerRoundState) bool {
 	logger := g.logger.With([]any{
 		"height", prs.Height,
 		"round", prs.Round,
 	})
 	index, ok := prs.ProposalBlockParts.Not().PickRandom()
 	if !ok {
-		// The peer replaced its bit-array since the pass drew a budget from it.
-		return errors.New("peer reports no missing block part")
+		// Defensive only: prs is a fresh deep copy for this tick
+		// (PeerState.GetRoundState), so nothing can mutate ProposalBlockParts
+		// between beginCatchupAttempt's missing-count check and this draw. Kept
+		// in case a future caller passes a stale snapshot.
+		return false
 	}
 	meta, err := g.blockStore.loadMeta(prs.Height)
 	if err != nil {
 		logger.Error("couldn't find a block meta", "error", err)
-		return err
+		return false
 	}
 	err = g.ensurePeerPartSetHeader(meta.BlockID.PartSetHeader, prs.ProposalBlockPartSetHeader)
 	if err != nil {
 		logger.Error("block and peer part-set headers do not match", "error", err)
-		return err
+		return false
 	}
 	part, err := g.blockStore.loadPart(prs.Height, index)
 	if err != nil {
 		logger.Error("couldn't find a block part", "part_index", index, "error", err)
-		return err
+		return false
 	}
 	// Catch-up gossip: do NOT optimistically record the part as delivered.
 	//
@@ -238,12 +251,11 @@ func (g *msgGossiper) sendCatchupBlockPart(ctx context.Context, prs *cstypes.Pee
 	// learns the part-set header only once the catch-up commit arrives). The part
 	// is instead replayed once per catchupResendInterval until the peer applies
 	// the block and advances its height.
-	err = g.syncProposalBlockPart(ctx, part, prs.Height, meta.Round, false)
-	if err != nil {
+	if err := g.syncProposalBlockPart(ctx, part, prs.Height, meta.Round, false); err != nil {
 		logger.Error("failed to sync proposal block part to the peer", "error", err)
-		return err
+		return false
 	}
-	return nil
+	return true
 }
 
 // beginCatchupAttempt draws a send from the current catch-up pass, reporting
@@ -264,13 +276,16 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 	if missing == 0 {
 		return false
 	}
+	g.catchupMu.Lock()
+	defer g.catchupMu.Unlock()
 	now := g.clock.Now()
-	// A peer only ever reports a higher height, so advancing cannot be replayed
-	// to reopen a pass, and serving a peer that just advanced is the point.
 	if prs.Height != g.catchupHeight {
+		// A peer only ever reports a higher height, so this cannot be replayed to
+		// reopen a pass. catchupRetryAt is intentionally left untouched: an
+		// advancing peer still waits out any pass already in flight rather than
+		// getting a free bypass of the interval on every height step.
 		g.catchupHeight = prs.Height
 		g.catchupRemaining = 0
-		g.catchupRetryAt = time.Time{}
 	}
 	if g.catchupRemaining <= 0 {
 		if now.Before(g.catchupRetryAt) {
@@ -309,6 +324,8 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 // an error log on every gossip tick until its budget runs out, by which point
 // the deadline armed when it opened has long expired.
 func (g *msgGossiper) endCatchupPass() {
+	g.catchupMu.Lock()
+	defer g.catchupMu.Unlock()
 	g.catchupRemaining = 0
 	g.catchupRetryAt = g.clock.Now().Add(catchupResendInterval)
 }

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -281,12 +281,6 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 	if prs.ProposalBlockParts == nil {
 		return false
 	}
-	// Equivalent to Not().CountTrueBits() (the parts the peer reports missing)
-	// without allocating a flipped copy of a peer-controlled bit-array to count it.
-	missing := prs.ProposalBlockParts.Size() - prs.ProposalBlockParts.CountTrueBits()
-	if missing == 0 {
-		return false
-	}
 	g.catchupMu.Lock()
 	defer g.catchupMu.Unlock()
 	now := g.clock.Now()
@@ -302,14 +296,38 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 		g.catchupHeight = prs.Height
 		g.catchupRemaining = 0
 	}
-	if g.catchupRemaining <= 0 {
-		if now.Before(g.catchupRetryAt) {
-			return false
-		}
+	noOpenPass := g.catchupRemaining <= 0
+	if noOpenPass && now.Before(g.catchupRetryAt) {
+		// Still backed off: this tick cannot send regardless of what the peer
+		// currently reports missing, so skip the bit-array scan below entirely.
+		// Most ticks land here at the production defaults (one pass's worth of
+		// backoff spans roughly catchupResendInterval / PeerGossipSleepDuration
+		// ticks), and the peer-controlled bit-array can be up to
+		// MaxBlockPartsCount bits.
+		return false
+	}
+	// PickRandom draws from the parts the peer reports missing, so the pass is
+	// worth that many sends rather than one per entry in the bit-array. Derived
+	// as size minus set bits rather than via Not().CountTrueBits(), which would
+	// allocate and copy the whole bit-array just to count it.
+	missing := prs.ProposalBlockParts.Size() - prs.ProposalBlockParts.CountTrueBits()
+	if missing == 0 {
+		return false
+	}
+	if noOpenPass {
+		// The budget is fixed here, for the whole pass. The peer owns the
+		// bit-array behind missing and may replace it between ticks, so
+		// re-deriving it to raise the budget mid-pass would let it widen the
+		// pass.
 		g.catchupRemaining = missing
 	} else {
-		// The peer's reported missing count can only shrink honestly (parts
-		// delivered elsewhere); never let it raise the budget mid-pass.
+		// The peer's reported missing count can only shrink honestly as parts
+		// are actually delivered elsewhere (e.g. via non-catch-up gossip), so
+		// clamp the remaining budget down to match; never let it raise the
+		// budget mid-pass. Without this, a peer that swaps in a bit-array with
+		// fewer unset bits mid-pass keeps the larger budget the pass opened
+		// with, and every remaining attempt draws from the now-small missing
+		// set - funding repeated duplicate sends of the few parts still unset.
 		g.catchupRemaining = min(g.catchupRemaining, missing)
 	}
 	g.catchupRemaining--

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -225,12 +225,20 @@ func (g *msgGossiper) GossipBlockPartsForCatchup(
 	_ cstypes.RoundState,
 	prs *cstypes.PeerRoundState,
 ) {
-	if !g.beginCatchupAttempt(prs) {
+	draw, lastSlot := g.beginCatchupAttempt(prs)
+	if !draw {
 		return
 	}
 	sent := false
 	defer func() {
-		if !sent {
+		switch {
+		case sent && lastSlot:
+			// A spent pass settles here, not in beginCatchupAttempt, so its
+			// quiet gap runs from the moment the send returned: the p2p channel
+			// applies backpressure on this very goroutine, and time spent
+			// blocked inside a send is not quiet time.
+			g.completeCatchupPass()
+		case !sent:
 			// The peer controls both the budget a pass opens with and the
 			// inputs that fail here, so a pass that cannot produce a send is
 			// abandoned rather than charged one slot per tick. A defer, not a
@@ -296,13 +304,18 @@ func (g *msgGossiper) sendCatchupBlockPart(ctx context.Context, prs *cstypes.Pee
 }
 
 // beginCatchupAttempt draws a send from the current catch-up pass, reporting
-// false once the pass is spent and until its retry interval elapses. A pass is
-// worth at most one send per part the peer reported missing when it opened, so a
-// peer that dropped those parts is served again every interval while it stays
-// behind. Any attempt that fails ends the pass early, via endCatchupPass.
-func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
+// draw=false once the pass is spent and until its retry interval elapses. A
+// pass is worth at most one send per part the peer reported missing when it
+// opened, so a peer that dropped those parts is served again every interval
+// while it stays behind. Any attempt that fails ends the pass early, via
+// endCatchupPass.
+//
+// lastSlot reports that this draw was the pass's final one, which obliges the
+// caller to settle the pass - via completeCatchupPass on a successful send,
+// endCatchupPass otherwise - once the send has returned.
+func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) (draw, lastSlot bool) {
 	if prs.ProposalBlockParts == nil {
-		return false
+		return false, false
 	}
 	g.catchupMu.Lock()
 	defer g.catchupMu.Unlock()
@@ -369,7 +382,7 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 		// backoff spans roughly catchupResendInterval / PeerGossipSleepDuration
 		// ticks), and the peer-controlled bit-array can be up to
 		// MaxBlockPartsCount bits.
-		return false
+		return false, false
 	}
 	// PickRandom draws from the parts the peer reports missing, so the pass is
 	// worth that many sends rather than one per entry in the bit-array. Derived
@@ -401,7 +414,7 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 			// left to do" case the height-change branch grants amnesty for.
 			g.catchupRetrySticky = false
 		}
-		return false
+		return false, false
 	}
 	if noOpenPass {
 		// The budget is fixed here, for the whole pass. The peer owns the
@@ -421,15 +434,17 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 	}
 	g.catchupRemaining--
 	if g.catchupRemaining <= 0 {
-		// Arm the deadline as the pass closes, not as it opens: a multi-part
-		// pass spans more ticks than the interval, so a deadline set at open
-		// would already have elapsed by the time the budget runs out. Spending
-		// the budget down to zero this way is genuine completion (every part
-		// the peer reported missing at open got a send), so non-sticky.
-		g.catchupRetryAt = now.Add(catchupResendInterval)
-		g.catchupRetrySticky = false
+		// The pass is spent, but its deadline is left to the caller to arm once
+		// the send returns, so the quiet gap excludes the send's own duration.
+		// Until then the pass is closed with a stale deadline, which the
+		// governing invariant allows (it only forbids a future deadline while
+		// catchupRemaining > 0) and no other code can observe: the single
+		// caller is inside that send for the whole window, so no further
+		// attempt - and no height change, which is only ever read from a
+		// per-tick prs here - can run before it settles.
+		return true, true
 	}
-	return true
+	return true, false
 }
 
 // endCatchupPass abandons the rest of the current pass and starts its retry
@@ -440,11 +455,32 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 // must survive a height change - a peer cannot dodge it by claiming a new
 // height right after triggering the failure.
 func (g *msgGossiper) endCatchupPass() {
+	g.settleCatchupPass(true)
+}
+
+// completeCatchupPass closes a pass whose last slot was just spent on a
+// successful send and starts its retry interval now: at the pass's end rather
+// than its start (a multi-part pass outlasts the interval, so a deadline armed
+// at open has elapsed before the budget runs out) and after that send returned
+// rather than before it (a send blocked on channel backpressure must not spend
+// the quiet gap it is supposed to precede). Non-sticky: every part the peer
+// reported missing when the pass opened got a send, so a peer that then
+// reports a new height owes nothing carried over.
+func (g *msgGossiper) completeCatchupPass() {
+	g.settleCatchupPass(false)
+}
+
+// settleCatchupPass closes the current pass and arms its retry deadline an
+// interval from now; sticky marks a pass that ended without rendering the
+// service it opened for. Called only once an attempt has finished, so the
+// deadline it arms is measured from the moment the pass really stopped
+// working.
+func (g *msgGossiper) settleCatchupPass(sticky bool) {
 	g.catchupMu.Lock()
 	defer g.catchupMu.Unlock()
 	g.catchupRemaining = 0
 	g.catchupRetryAt = g.clock.Now().Add(catchupResendInterval)
-	g.catchupRetrySticky = true
+	g.catchupRetrySticky = sticky
 }
 
 // GossipCommit sends a commit message to the peer

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -70,10 +70,21 @@ type msgGossiper struct {
 	// which means catchupRetryAt is already in the past; catchupRetryAt is only
 	// ever in the future while catchupRemaining <= 0. Every write to either
 	// field must preserve this together.
-	catchupMu        sync.Mutex
-	catchupHeight    int64
-	catchupRemaining int
-	catchupRetryAt   time.Time
+	//
+	// catchupRetrySticky distinguishes why catchupRetryAt is currently armed,
+	// for the height-change branch: true means the pass that armed it did NOT
+	// finish rendering service (interrupted before exhausting its own budget,
+	// or ended by endCatchupPass) and the deadline must survive a height
+	// change - including a chain of several in a row, none of which get a
+	// chance to open a pass while it's still pending. false means the pass
+	// closed because it had genuinely nothing left to do (spent its own
+	// budget in full, or the peer reported complete) and a peer that then
+	// reports a new height owes nothing carried over from it.
+	catchupMu          sync.Mutex
+	catchupHeight      int64
+	catchupRemaining   int
+	catchupRetryAt     time.Time
+	catchupRetrySticky bool
 }
 
 func newVoteSetMaj23(height int64, round int32, msgType tmproto.SignedMsgType, maj23 types.BlockID) *tmcons.VoteSetMaj23 {
@@ -298,12 +309,54 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 	now := g.clock.Now()
 	if prs.Height != g.catchupHeight {
 		// A peer only ever reports a higher height, so this cannot be replayed
-		// to reopen a pass — but it can interrupt one before it exhausts its own
-		// budget, which (per the invariant above) means catchupRetryAt was never
-		// armed for it. Arm it here too, or a peer advancing its height every
-		// tick gets a fresh full-budget pass every tick forever.
-		if g.catchupRemaining > 0 {
+		// to reopen a pass.
+		switch {
+		case g.catchupRemaining > 0:
+			// It can, though, interrupt a pass before that pass exhausts its own
+			// budget, which (per the invariant above) means catchupRetryAt was
+			// never armed for it. Arm it here too, or a peer advancing its height
+			// every tick gets a fresh full-budget pass every tick forever. Marked
+			// sticky: unrendered service, must survive further height changes too.
 			g.catchupRetryAt = now.Add(catchupResendInterval)
+			g.catchupRetrySticky = true
+		case g.catchupRetrySticky && now.Before(g.catchupRetryAt):
+			// No pass is open, but the currently-armed deadline is sticky and
+			// hasn't elapsed - it may belong to THIS height change (a pass just
+			// interrupted above), or it may be inherited from an earlier one in
+			// a rapid chain that got no chance to open a pass at all before
+			// advancing again. Leave it untouched either way: a peer hopping
+			// through several heights before the deadline elapses must not be
+			// able to shorten or clear it by hopping through one more.
+		default:
+			// No pass is open, and any armed deadline is either non-sticky
+			// (the previous height's pass closed because it genuinely had
+			// nothing left to do: spent its own budget in full, or the peer
+			// reported complete) or has already elapsed. Clear it: a peer that
+			// isn't replaying anything and owes nothing from before is served
+			// immediately at the new height, matching how catch-up behaves
+			// everywhere upstream of this PR (no per-height throttle at all).
+			//
+			// This does reopen a bounded gap for the non-sticky case: a peer
+			// can open a pass, let it close cleanly (one real send, e.g. by
+			// reporting a single missing part), then immediately claim a new
+			// height and repeat, getting one send per gossip tick indefinitely
+			// instead of one pass per interval. Bounded to that - at most 1
+			// send/PeerGossipSleepDuration tick (10/s, ~640KB/s of block parts
+			// at production defaults) - because CompareHRS enforces monotonic
+			// height only (no replay or ping-ponging) and
+			// ensurePeerPartSetHeader requires the real, currently-stored
+			// PartSetHeader for each claimed height (a mismatch ends the pass
+			// via endCatchupPass, which is sticky, costing the peer a full
+			// interval rather than a send). So sustaining this requires
+			// marching forward through genuine, still-retained history, capped
+			// by blockStoreBase - no worse than the pre-#1365 catch-up rate
+			// this codebase already tolerated in production. Accepted as
+			// strictly cheaper than taxing every honestly-advancing lagging
+			// peer by up to 500ms per height; closing it for real needs a
+			// verified-progress-gated redesign, tracked as follow-up rather
+			// than done here.
+			g.catchupRetryAt = time.Time{}
+			g.catchupRetrySticky = false
 		}
 		g.catchupHeight = prs.Height
 		g.catchupRemaining = 0
@@ -344,6 +397,9 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 			// negligible against block time.
 			g.catchupRemaining = 0
 			g.catchupRetryAt = now.Add(catchupResendInterval)
+			// Non-sticky: the peer reporting complete is exactly the "nothing
+			// left to do" case the height-change branch grants amnesty for.
+			g.catchupRetrySticky = false
 		}
 		return false
 	}
@@ -367,20 +423,28 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 	if g.catchupRemaining <= 0 {
 		// Arm the deadline as the pass closes, not as it opens: a multi-part
 		// pass spans more ticks than the interval, so a deadline set at open
-		// would already have elapsed by the time the budget runs out.
+		// would already have elapsed by the time the budget runs out. Spending
+		// the budget down to zero this way is genuine completion (every part
+		// the peer reported missing at open got a send), so non-sticky.
 		g.catchupRetryAt = now.Add(catchupResendInterval)
+		g.catchupRetrySticky = false
 	}
 	return true
 }
 
 // endCatchupPass abandons the rest of the current pass and starts its retry
 // interval now. Without it a pass that cannot send costs a block-store read
-// and an error log on every gossip tick until its budget runs out.
+// and an error log on every gossip tick until its budget runs out. Marked
+// sticky: ending here means an attempt failed to render service (as opposed
+// to a pass that closed because it had nothing left to do), so the deadline
+// must survive a height change - a peer cannot dodge it by claiming a new
+// height right after triggering the failure.
 func (g *msgGossiper) endCatchupPass() {
 	g.catchupMu.Lock()
 	defer g.catchupMu.Unlock()
 	g.catchupRemaining = 0
 	g.catchupRetryAt = g.clock.Now().Add(catchupResendInterval)
+	g.catchupRetrySticky = true
 }
 
 // GossipCommit sends a commit message to the peer

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -312,6 +312,17 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 	// allocate and copy the whole bit-array just to count it.
 	missing := prs.ProposalBlockParts.Size() - prs.ProposalBlockParts.CountTrueBits()
 	if missing == 0 {
+		if !noOpenPass {
+			// The peer now reports a complete part set while a pass was still
+			// open (budget not yet exhausted). Close it here instead of leaving
+			// catchupRemaining pinned above zero: left open, noOpenPass stays
+			// false on every later tick regardless of how much time passes, so
+			// a peer that later reports parts missing again would resume
+			// sending immediately - the backoff check above only ever runs
+			// when no pass is open.
+			g.catchupRemaining = 0
+			g.catchupRetryAt = now.Add(catchupResendInterval)
+		}
 		return false
 	}
 	if noOpenPass {

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -24,22 +24,31 @@ import (
 type Gossiper interface {
 	GossipProposal(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 	GossipProposalBlockParts(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
-	// GossipBlockPartsForCatchup is rate-limited (catchupResendInterval) and
-	// returns immediately on most calls. The limit is per gossip worker, not per
-	// peer: a peer that reconnects gets a fresh worker and a fresh pass. Must be
-	// called from a single goroutine per Gossiper instance.
+	// GossipBlockPartsForCatchup sends at most one part per call and enforces a
+	// quiet gap of catchupResendInterval between full-part-set replays — it does
+	// NOT bound the send rate to one per interval for a multi-part block, which
+	// spends several ticks before that gap applies (see catchupResendInterval).
+	// The limit is per gossip worker, not per peer: a peer that reconnects gets a
+	// fresh worker and a fresh pass. Must be called from a single goroutine per
+	// Gossiper instance — its internal locking guards field visibility only, not
+	// the check-then-send sequence a second caller would race.
 	GossipBlockPartsForCatchup(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 	GossipVote(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 	GossipVoteSetMaj23(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 	GossipCommit(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 }
 
-// catchupResendInterval bounds how often the catch-up path replays a block's
-// part set to the same lagging peer. Catch-up deliberately never marks parts as
-// delivered, so without this bound a peer we believe is behind is served on
-// every gossip tick. A pass suppresses roughly catchupResendInterval /
-// PeerGossipSleepDuration ticks — five at their production defaults — and does
-// nothing at all if the gossip cadence is configured slower than this interval.
+// catchupResendInterval is the quiet gap enforced once a catch-up pass ends —
+// by exhausting its budget, failing a send, or being interrupted by a height
+// change — before a fresh pass may open. Catch-up deliberately never marks
+// parts as delivered, so without this gap a peer we believe is behind would be
+// served on every gossip tick. The gap is between passes, not between sends
+// within one: a pass spends one send per gossip tick for as many ticks as the
+// peer reports parts missing, so it bounds full-part-set replays to roughly
+// one per (missing_parts * PeerGossipSleepDuration + catchupResendInterval),
+// not to a flat one per catchupResendInterval — see peer-gossip-sleep-duration
+// in config/config.go for the cadence this scales with. It also does nothing
+// at all if that cadence is configured slower than this interval.
 const catchupResendInterval = 500 * time.Millisecond
 
 type msgGossiper struct {
@@ -50,11 +59,17 @@ type msgGossiper struct {
 	optimistic bool
 	clock      clockwork.Clock
 
-	// Catch-up pass accounting for the one peer this gossiper serves. Guarded by
-	// catchupMu rather than relying on dataGossipHandler being the only caller
-	// today: the same *msgGossiper is shared across three concurrent handler
-	// goroutines (see reactor.go), and nothing stops a future one from also
-	// calling GossipBlockPartsForCatchup.
+	// Catch-up pass accounting for the one peer this gossiper serves, touched
+	// only from GossipBlockPartsForCatchup (see its single-goroutine-caller
+	// requirement on the Gossiper interface). catchupMu guards the fields
+	// themselves against a hypothetical second caller, but not the
+	// draw-then-send-then-settle sequence across them — that still requires the
+	// single-caller invariant to hold.
+	//
+	// Governing invariant: catchupRemaining > 0 means a pass is currently open,
+	// which means catchupRetryAt is already in the past; catchupRetryAt is only
+	// ever in the future while catchupRemaining <= 0. Every write to either
+	// field must preserve this together.
 	catchupMu        sync.Mutex
 	catchupHeight    int64
 	catchupRemaining int
@@ -210,9 +225,12 @@ func (g *msgGossiper) GossipBlockPartsForCatchup(
 	}
 }
 
-// sendCatchupBlockPart sends the peer one part of its incomplete block, drawn at
-// random from the parts it reports missing, and reports whether the part
-// reached the peer.
+// sendCatchupBlockPart sends the peer one part of its incomplete block, drawn
+// at random from the parts it reports missing, and reports whether the part
+// was handed to the p2p channel. A false result means either the send could
+// not be enqueued (in practice, only on reactor shutdown — see
+// internal/p2p/channel.go) or the block-store inputs were unusable; it is not
+// a delivery acknowledgement from the peer.
 func (g *msgGossiper) sendCatchupBlockPart(ctx context.Context, prs *cstypes.PeerRoundState) bool {
 	logger := g.logger.With([]any{
 		"height", prs.Height,
@@ -220,15 +238,12 @@ func (g *msgGossiper) sendCatchupBlockPart(ctx context.Context, prs *cstypes.Pee
 	})
 	index, ok := prs.ProposalBlockParts.Not().PickRandom()
 	if !ok {
-		// Defensive only: prs is a fresh deep copy for this tick
-		// (PeerState.GetRoundState), so nothing can mutate ProposalBlockParts
-		// between beginCatchupAttempt's missing-count check and this draw. Kept
-		// in case a future caller passes a stale snapshot.
+		// Defensive: prs is a per-tick deep copy, so the draw cannot come up empty.
 		return false
 	}
+	logger = logger.With("part_index", index)
 	meta, err := g.blockStore.loadMeta(prs.Height)
 	if err != nil {
-		logger.Error("couldn't find a block meta", "error", err)
 		return false
 	}
 	err = g.ensurePeerPartSetHeader(meta.BlockID.PartSetHeader, prs.ProposalBlockPartSetHeader)
@@ -238,7 +253,6 @@ func (g *msgGossiper) sendCatchupBlockPart(ctx context.Context, prs *cstypes.Pee
 	}
 	part, err := g.blockStore.loadPart(prs.Height, index)
 	if err != nil {
-		logger.Error("couldn't find a block part", "part_index", index, "error", err)
 		return false
 	}
 	// Catch-up gossip: do NOT optimistically record the part as delivered.
@@ -248,11 +262,11 @@ func (g *msgGossiper) sendCatchupBlockPart(ctx context.Context, prs *cstypes.Pee
 	// silently drop the part. If we optimistically marked it delivered, our view
 	// of the peer would show the full part set and we would never resend it,
 	// leaving the peer wedged with a stored commit but an incomplete block (it
-	// learns the part-set header only once the catch-up commit arrives). The part
-	// is instead replayed once per catchupResendInterval until the peer applies
-	// the block and advances its height.
+	// learns the part-set header only once the catch-up commit arrives). The
+	// part is instead replayed every pass until the peer applies the block and
+	// advances its height.
 	if err := g.syncProposalBlockPart(ctx, part, prs.Height, meta.Round, false); err != nil {
-		logger.Error("failed to sync proposal block part to the peer", "error", err)
+		logger.Error("failed to send catch-up block part to the peer", "error", err)
 		return false
 	}
 	return true
@@ -267,11 +281,8 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 	if prs.ProposalBlockParts == nil {
 		return false
 	}
-	// PickRandom draws from the parts the peer reports missing, so the pass is
-	// worth that many sends rather than one per entry in the bit-array. Derived
-	// as size minus set bits rather than via Not().CountTrueBits(), which would
-	// allocate and copy the whole (peer-controlled, up to MaxBlockPartsCount)
-	// bit-array on every gossip tick just to count it.
+	// Equivalent to Not().CountTrueBits() (the parts the peer reports missing)
+	// without allocating a flipped copy of a peer-controlled bit-array to count it.
 	missing := prs.ProposalBlockParts.Size() - prs.ProposalBlockParts.CountTrueBits()
 	if missing == 0 {
 		return false
@@ -280,10 +291,14 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 	defer g.catchupMu.Unlock()
 	now := g.clock.Now()
 	if prs.Height != g.catchupHeight {
-		// A peer only ever reports a higher height, so this cannot be replayed to
-		// reopen a pass. catchupRetryAt is intentionally left untouched: an
-		// advancing peer still waits out any pass already in flight rather than
-		// getting a free bypass of the interval on every height step.
+		// A peer only ever reports a higher height, so this cannot be replayed
+		// to reopen a pass — but it can interrupt one before it exhausts its own
+		// budget, which (per the invariant above) means catchupRetryAt was never
+		// armed for it. Arm it here too, or a peer advancing its height every
+		// tick gets a fresh full-budget pass every tick forever.
+		if g.catchupRemaining > 0 {
+			g.catchupRetryAt = now.Add(catchupResendInterval)
+		}
 		g.catchupHeight = prs.Height
 		g.catchupRemaining = 0
 	}
@@ -291,38 +306,25 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 		if now.Before(g.catchupRetryAt) {
 			return false
 		}
-		// The budget is fixed here, for the whole pass. The peer owns the
-		// bit-array behind missing and may replace it between ticks, so
-		// re-deriving it to raise the budget mid-pass would let it widen the
-		// pass.
 		g.catchupRemaining = missing
-	} else if missing < g.catchupRemaining {
-		// The peer's reported missing count can only shrink honestly as parts
-		// are actually delivered elsewhere (e.g. via non-catch-up gossip), so
-		// clamp the remaining budget down to match. Without this, a peer that
-		// swaps in a bit-array with fewer unset bits mid-pass keeps the larger
-		// budget the pass opened with, and every remaining attempt draws from
-		// the now-small missing set - funding repeated duplicate sends of the
-		// few parts still unset.
-		g.catchupRemaining = missing
+	} else {
+		// The peer's reported missing count can only shrink honestly (parts
+		// delivered elsewhere); never let it raise the budget mid-pass.
+		g.catchupRemaining = min(g.catchupRemaining, missing)
 	}
 	g.catchupRemaining--
 	if g.catchupRemaining <= 0 {
-		// Arm the retry deadline when the pass's last attempt is spent, not
-		// when it opened. A pass with enough missing parts to span multiple
-		// gossip ticks takes longer than catchupResendInterval to exhaust, so
-		// a deadline set at open time has already passed by the time the
-		// budget runs out - the next tick reopens immediately, leaving no
-		// quiet gap between passes.
+		// Arm the deadline as the pass closes, not as it opens: a multi-part
+		// pass spans more ticks than the interval, so a deadline set at open
+		// would already have elapsed by the time the budget runs out.
 		g.catchupRetryAt = now.Add(catchupResendInterval)
 	}
 	return true
 }
 
 // endCatchupPass abandons the rest of the current pass and starts its retry
-// interval now. Without it a pass that cannot send costs a block-store read and
-// an error log on every gossip tick until its budget runs out, by which point
-// the deadline armed when it opened has long expired.
+// interval now. Without it a pass that cannot send costs a block-store read
+// and an error log on every gossip tick until its budget runs out.
 func (g *msgGossiper) endCatchupPass() {
 	g.catchupMu.Lock()
 	defer g.catchupMu.Unlock()

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -256,8 +256,11 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 		return false
 	}
 	// PickRandom draws from the parts the peer reports missing, so the pass is
-	// worth that many sends rather than one per entry in the bit-array.
-	missing := prs.ProposalBlockParts.Not().CountTrueBits()
+	// worth that many sends rather than one per entry in the bit-array. Derived
+	// as size minus set bits rather than via Not().CountTrueBits(), which would
+	// allocate and copy the whole (peer-controlled, up to MaxBlockPartsCount)
+	// bit-array on every gossip tick just to count it.
+	missing := prs.ProposalBlockParts.Size() - prs.ProposalBlockParts.CountTrueBits()
 	if missing == 0 {
 		return false
 	}

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -46,9 +46,9 @@ type msgGossiper struct {
 	// Catch-up pass accounting for the one peer this gossiper serves. Unguarded:
 	// only dataGossipHandler reaches GossipBlockPartsForCatchup, and its handler
 	// runs on a single goroutine.
-	catchupHeight   int64
-	catchupAttempts int
-	catchupRetryAt  time.Time
+	catchupHeight    int64
+	catchupRemaining int
+	catchupRetryAt   time.Time
 }
 
 func newVoteSetMaj23(height int64, round int32, msgType tmproto.SignedMsgType, maj23 types.BlockID) *tmcons.VoteSetMaj23 {
@@ -230,37 +230,40 @@ func (g *msgGossiper) GossipBlockPartsForCatchup(
 	}
 }
 
-// beginCatchupAttempt reserves a slot in the current catch-up pass, reporting
-// false while a completed pass waits out its retry interval. A pass spends one
-// send per missing part, so a peer that dropped them is served again every
-// interval for as long as it stays behind.
+// beginCatchupAttempt draws a send from the current catch-up pass, reporting
+// false once the pass is spent and until its retry interval elapses. A pass is
+// worth one send per part the peer reported missing when it opened, so a peer
+// that dropped those parts is served again every interval while it stays behind.
 func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
-	if prs.Height != g.catchupHeight {
-		g.catchupHeight = prs.Height
-		g.catchupAttempts = 0
-		g.catchupRetryAt = time.Time{}
-	}
 	if prs.ProposalBlockParts == nil {
 		return false
 	}
-	// The peer sends this bit-array and only its length is validated, so budget
-	// the pass on the parts it reports missing: those are what PickRandom draws
-	// from, and sizing by the whole array would buy one resend of a single
-	// missing part per entry in it.
+	// PickRandom draws from the parts the peer reports missing, so the pass is
+	// worth that many sends rather than one per entry in the bit-array.
 	missing := prs.ProposalBlockParts.Not().CountTrueBits()
 	if missing == 0 {
 		return false
 	}
-	if g.catchupAttempts >= missing {
-		if g.clock.Now().Before(g.catchupRetryAt) {
+	now := g.clock.Now()
+	// A peer only ever reports a higher height, so advancing cannot be replayed
+	// to reopen a pass, and serving a peer that just advanced is the point.
+	if prs.Height != g.catchupHeight {
+		g.catchupHeight = prs.Height
+		g.catchupRemaining = 0
+		g.catchupRetryAt = time.Time{}
+	}
+	if g.catchupRemaining <= 0 {
+		if now.Before(g.catchupRetryAt) {
 			return false
 		}
-		g.catchupAttempts = 0
+		// Budget and deadline are both fixed here, for the whole pass. The peer
+		// owns the bit-array behind missing and may replace it between ticks, so
+		// re-deriving either one mid-pass would let it reopen the pass early or
+		// widen it.
+		g.catchupRemaining = missing
+		g.catchupRetryAt = now.Add(catchupResendInterval)
 	}
-	g.catchupAttempts++
-	if g.catchupAttempts >= missing {
-		g.catchupRetryAt = g.clock.Now().Add(catchupResendInterval)
-	}
+	g.catchupRemaining--
 	return true
 }
 

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -4,6 +4,7 @@ package consensus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -191,28 +192,41 @@ func (g *msgGossiper) GossipBlockPartsForCatchup(
 	if !g.beginCatchupAttempt(prs) {
 		return
 	}
-	index, ok := prs.ProposalBlockParts.Not().PickRandom()
-	if !ok {
-		return
+	if err := g.sendCatchupBlockPart(ctx, prs); err != nil {
+		// The peer controls both the budget a pass opens with and the inputs that
+		// fail here, so a pass that cannot produce a send is abandoned rather than
+		// charged one slot per tick.
+		g.endCatchupPass()
 	}
+}
+
+// sendCatchupBlockPart sends the peer one part of its incomplete block, drawn at
+// random from the parts it reports missing. A non-nil error reports only that no
+// part reached the peer; the caller is not expected to inspect it.
+func (g *msgGossiper) sendCatchupBlockPart(ctx context.Context, prs *cstypes.PeerRoundState) error {
 	logger := g.logger.With([]any{
 		"height", prs.Height,
 		"round", prs.Round,
 	})
+	index, ok := prs.ProposalBlockParts.Not().PickRandom()
+	if !ok {
+		// The peer replaced its bit-array since the pass drew a budget from it.
+		return errors.New("peer reports no missing block part")
+	}
 	meta, err := g.blockStore.loadMeta(prs.Height)
 	if err != nil {
 		logger.Error("couldn't find a block meta", "error", err)
-		return
+		return err
 	}
 	err = g.ensurePeerPartSetHeader(meta.BlockID.PartSetHeader, prs.ProposalBlockPartSetHeader)
 	if err != nil {
 		logger.Error("block and peer part-set headers do not match", "error", err)
-		return
+		return err
 	}
 	part, err := g.blockStore.loadPart(prs.Height, index)
 	if err != nil {
 		logger.Error("couldn't find a block part", "part_index", index, "error", err)
-		return
+		return err
 	}
 	// Catch-up gossip: do NOT optimistically record the part as delivered.
 	//
@@ -227,13 +241,16 @@ func (g *msgGossiper) GossipBlockPartsForCatchup(
 	err = g.syncProposalBlockPart(ctx, part, prs.Height, meta.Round, false)
 	if err != nil {
 		logger.Error("failed to sync proposal block part to the peer", "error", err)
+		return err
 	}
+	return nil
 }
 
 // beginCatchupAttempt draws a send from the current catch-up pass, reporting
 // false once the pass is spent and until its retry interval elapses. A pass is
-// worth one send per part the peer reported missing when it opened, so a peer
-// that dropped those parts is served again every interval while it stays behind.
+// worth at most one send per part the peer reported missing when it opened, so a
+// peer that dropped those parts is served again every interval while it stays
+// behind. Any attempt that fails ends the pass early, via endCatchupPass.
 func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 	if prs.ProposalBlockParts == nil {
 		return false
@@ -265,6 +282,15 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 	}
 	g.catchupRemaining--
 	return true
+}
+
+// endCatchupPass abandons the rest of the current pass and starts its retry
+// interval now. Without it a pass that cannot send costs a block-store read and
+// an error log on every gossip tick until its budget runs out, by which point
+// the deadline armed when it opened has long expired.
+func (g *msgGossiper) endCatchupPass() {
+	g.catchupRemaining = 0
+	g.catchupRetryAt = g.clock.Now().Add(catchupResendInterval)
 }
 
 // GossipCommit sends a commit message to the peer

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -5,9 +5,11 @@ package consensus
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/hashicorp/go-multierror"
+	"github.com/jonboulle/clockwork"
 
 	cstypes "github.com/dashpay/tenderdash/internal/consensus/types"
 	sm "github.com/dashpay/tenderdash/internal/state"
@@ -27,12 +29,26 @@ type Gossiper interface {
 	GossipCommit(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 }
 
+// catchupResendInterval bounds how often the catch-up path replays a block's
+// part set to the same lagging peer. Catch-up deliberately never marks parts as
+// delivered, so without this bound a peer we believe is behind is served on
+// every gossip tick.
+const catchupResendInterval = 500 * time.Millisecond
+
 type msgGossiper struct {
 	logger     log.Logger
 	ps         *PeerState
 	msgSender  *p2pMsgSender
 	blockStore *blockRepository
 	optimistic bool
+	clock      clockwork.Clock
+
+	// Catch-up pass accounting for the one peer this gossiper serves. Unguarded:
+	// only dataGossipHandler reaches GossipBlockPartsForCatchup, and its handler
+	// runs on a single goroutine.
+	catchupHeight   int64
+	catchupAttempts int
+	catchupRetryAt  time.Time
 }
 
 func newVoteSetMaj23(height int64, round int32, msgType tmproto.SignedMsgType, maj23 types.BlockID) *tmcons.VoteSetMaj23 {
@@ -172,6 +188,9 @@ func (g *msgGossiper) GossipBlockPartsForCatchup(
 	_ cstypes.RoundState,
 	prs *cstypes.PeerRoundState,
 ) {
+	if !g.beginCatchupAttempt(prs) {
+		return
+	}
 	index, ok := prs.ProposalBlockParts.Not().PickRandom()
 	if !ok {
 		return
@@ -202,13 +221,37 @@ func (g *msgGossiper) GossipBlockPartsForCatchup(
 	// silently drop the part. If we optimistically marked it delivered, our view
 	// of the peer would show the full part set and we would never resend it,
 	// leaving the peer wedged with a stored commit but an incomplete block (it
-	// learns the part-set header only once the catch-up commit arrives). By not
-	// marking it, we keep resending the missing part each gossip tick until the
-	// peer actually applies the block and advances its height.
+	// learns the part-set header only once the catch-up commit arrives). The part
+	// is instead replayed once per catchupResendInterval until the peer applies
+	// the block and advances its height.
 	err = g.syncProposalBlockPart(ctx, part, prs.Height, meta.Round, false)
 	if err != nil {
 		logger.Error("failed to sync proposal block part to the peer", "error", err)
 	}
+}
+
+// beginCatchupAttempt reserves a slot in the current catch-up pass, reporting
+// false while a completed pass waits out its retry interval. A pass spends one
+// send per part, so a peer that dropped them is served again every interval for
+// as long as it stays behind.
+func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
+	if prs.Height != g.catchupHeight {
+		g.catchupHeight = prs.Height
+		g.catchupAttempts = 0
+		g.catchupRetryAt = time.Time{}
+	}
+	parts := prs.ProposalBlockParts.Size()
+	if g.catchupAttempts >= parts {
+		if g.clock.Now().Before(g.catchupRetryAt) {
+			return false
+		}
+		g.catchupAttempts = 0
+	}
+	g.catchupAttempts++
+	if g.catchupAttempts >= parts {
+		g.catchupRetryAt = g.clock.Now().Add(catchupResendInterval)
+	}
+	return true
 }
 
 // GossipCommit sends a commit message to the peer

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -408,11 +408,7 @@ func (g *msgGossiper) syncProposalBlockPart(ctx context.Context, part *types.Par
 		syncFunc = updatePeerProposalBlockPart(g.ps, height, round, int(part.Index))
 	}
 	logger.Debug("syncing proposal block part")
-	err = g.sync(ctx, protoBlockPart, syncFunc)
-	if err != nil {
-		logger.Error("failed to sync proposal block part to the peer", "error", err)
-	}
-	return nil
+	return g.sync(ctx, protoBlockPart, syncFunc)
 }
 
 func (g *msgGossiper) sync(ctx context.Context, protoMsg proto.Message, syncFunc func() error) error {

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -273,14 +273,31 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 		if now.Before(g.catchupRetryAt) {
 			return false
 		}
-		// Budget and deadline are both fixed here, for the whole pass. The peer
-		// owns the bit-array behind missing and may replace it between ticks, so
-		// re-deriving either one mid-pass would let it reopen the pass early or
-		// widen it.
+		// The budget is fixed here, for the whole pass. The peer owns the
+		// bit-array behind missing and may replace it between ticks, so
+		// re-deriving it to raise the budget mid-pass would let it widen the
+		// pass.
 		g.catchupRemaining = missing
-		g.catchupRetryAt = now.Add(catchupResendInterval)
+	} else if missing < g.catchupRemaining {
+		// The peer's reported missing count can only shrink honestly as parts
+		// are actually delivered elsewhere (e.g. via non-catch-up gossip), so
+		// clamp the remaining budget down to match. Without this, a peer that
+		// swaps in a bit-array with fewer unset bits mid-pass keeps the larger
+		// budget the pass opened with, and every remaining attempt draws from
+		// the now-small missing set - funding repeated duplicate sends of the
+		// few parts still unset.
+		g.catchupRemaining = missing
 	}
 	g.catchupRemaining--
+	if g.catchupRemaining <= 0 {
+		// Arm the retry deadline when the pass's last attempt is spent, not
+		// when it opened. A pass with enough missing parts to span multiple
+		// gossip ticks takes longer than catchupResendInterval to exhaust, so
+		// a deadline set at open time has already passed by the time the
+		// budget runs out - the next tick reopens immediately, leaving no
+		// quiet gap between passes.
+		g.catchupRetryAt = now.Add(catchupResendInterval)
+	}
 	return true
 }
 

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -217,12 +217,24 @@ func (g *msgGossiper) GossipBlockPartsForCatchup(
 	if !g.beginCatchupAttempt(prs) {
 		return
 	}
-	if !g.sendCatchupBlockPart(ctx, prs) {
-		// The peer controls both the budget a pass opens with and the inputs that
-		// fail here, so a pass that cannot produce a send is abandoned rather than
-		// charged one slot per tick.
-		g.endCatchupPass()
-	}
+	sent := false
+	defer func() {
+		if !sent {
+			// The peer controls both the budget a pass opens with and the
+			// inputs that fail here, so a pass that cannot produce a send is
+			// abandoned rather than charged one slot per tick. A defer, not a
+			// plain if-check on sendCatchupBlockPart's return: its block-store
+			// reads deliberately panic on a decode or read failure (see
+			// blockRepository.loadMeta/loadPart), and runGossipHandler recovers
+			// that panic per tick and keeps ticking - a defer is the only way
+			// this still runs on that path, so a peer that can trigger such a
+			// panic doesn't get a full-stack log and a wasted budget slot on
+			// every tick for the rest of the pass, but exactly one before the
+			// pass ends like any other failed attempt.
+			g.endCatchupPass()
+		}
+	}()
+	sent = g.sendCatchupBlockPart(ctx, prs)
 }
 
 // sendCatchupBlockPart sends the peer one part of its incomplete block, drawn

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -232,23 +232,33 @@ func (g *msgGossiper) GossipBlockPartsForCatchup(
 
 // beginCatchupAttempt reserves a slot in the current catch-up pass, reporting
 // false while a completed pass waits out its retry interval. A pass spends one
-// send per part, so a peer that dropped them is served again every interval for
-// as long as it stays behind.
+// send per missing part, so a peer that dropped them is served again every
+// interval for as long as it stays behind.
 func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 	if prs.Height != g.catchupHeight {
 		g.catchupHeight = prs.Height
 		g.catchupAttempts = 0
 		g.catchupRetryAt = time.Time{}
 	}
-	parts := prs.ProposalBlockParts.Size()
-	if g.catchupAttempts >= parts {
+	if prs.ProposalBlockParts == nil {
+		return false
+	}
+	// The peer sends this bit-array and only its length is validated, so budget
+	// the pass on the parts it reports missing: those are what PickRandom draws
+	// from, and sizing by the whole array would buy one resend of a single
+	// missing part per entry in it.
+	missing := prs.ProposalBlockParts.Not().CountTrueBits()
+	if missing == 0 {
+		return false
+	}
+	if g.catchupAttempts >= missing {
 		if g.clock.Now().Before(g.catchupRetryAt) {
 			return false
 		}
 		g.catchupAttempts = 0
 	}
 	g.catchupAttempts++
-	if g.catchupAttempts >= parts {
+	if g.catchupAttempts >= missing {
 		g.catchupRetryAt = g.clock.Now().Add(catchupResendInterval)
 	}
 	return true

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -314,12 +314,22 @@ func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) bool {
 	if missing == 0 {
 		if !noOpenPass {
 			// The peer now reports a complete part set while a pass was still
-			// open (budget not yet exhausted). Close it here instead of leaving
-			// catchupRemaining pinned above zero: left open, noOpenPass stays
-			// false on every later tick regardless of how much time passes, so
-			// a peer that later reports parts missing again would resume
-			// sending immediately - the backoff check above only ever runs
-			// when no pass is open.
+			// open (budget not yet exhausted). This does NOT let the peer send
+			// more than the budget fixed at pass open — catchupRemaining only
+			// ever counts down, never up, so total sends per pass are unaffected
+			// either way. Left open regardless, though, noOpenPass stays false on
+			// every later tick no matter how much time passes, which costs two
+			// things: the backoff-skip check above never re-engages, so the
+			// bit-array scan above runs on every tick for as long as the peer
+			// holds the pass open this way (the CPU cost the backoff-skip check
+			// exists to bound); and the next report of missing parts resumes
+			// sending on that same tick rather than after a fresh
+			// catchupResendInterval. Close the pass here to bound both. This
+			// does mean a peer that legitimately completes its part set and
+			// later falls behind again waits out one interval before catch-up
+			// resumes - accepted deliberately: a peer that just reported a
+			// complete set is by definition not starving, and the wait is
+			// negligible against block time.
 			g.catchupRemaining = 0
 			g.catchupRetryAt = now.Add(catchupResendInterval)
 		}

--- a/internal/consensus/gossiper_test.go
+++ b/internal/consensus/gossiper_test.go
@@ -889,6 +889,52 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupMismatchedHeaderEn
 	suite.Require().Equal(2, metaReads, "each elapsed interval allows exactly one further attempt")
 }
 
+// TestGossipBlockPartsForCatchupSendFailureEndsPass is a regression test for a
+// defect where syncProposalBlockPart unconditionally returned nil regardless of
+// the underlying send's real result, so sendCatchupBlockPart always reported
+// success: a send that never reached the peer was indistinguishable from one
+// that did, and the pass kept spending its budget one failed attempt per tick
+// instead of ending on the first one -- exactly the spin endCatchupPass exists
+// to prevent. Uses a multi-part block so the budget itself (rather than
+// endCatchupPass) is never the thing limiting attempts.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupSendFailureEndsPass() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*5), partSize)
+	suite.Require().Equal(uint32(5), partSet.Total(), "need multiple missing parts so the budget isn't the limiting factor")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         partSet.BitArray().Not(), // peer has none
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	partReads := 0
+	suite.blockStore.On("LoadBlockPart", int64(999), mock.Anything).
+		Run(func(_ mock.Arguments) { partReads++ }).
+		Return(partSet.GetPart(0))
+
+	// Every send fails to reach the peer.
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).Return(fmt.Errorf("simulated send failure"))
+
+	for range 50 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(1, partReads,
+		"a send that never reaches the peer must end the pass on the first attempt, not spend the whole budget")
+
+	suite.clock.Advance(catchupResendInterval)
+	for range 50 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(2, partReads, "each elapsed interval allows exactly one further attempt")
+}
+
 // TestGossipBlockPartsForCatchupMalformedHeaderDoesNotFundSends pins the budget
 // to a pass that got as far as sending. A pass is deliberately not re-derived
 // from the peer's bit-array once open, so a budget opened against an unusable

--- a/internal/consensus/gossiper_test.go
+++ b/internal/consensus/gossiper_test.go
@@ -782,6 +782,16 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupRetryIntervalArmsW
 // advanced across the first block of ticks below: a working throttle must
 // still bound the send rate even though the peer supplies a "new" pass at
 // every step.
+//
+// Also pins a narrower defect the fix for the above introduced and this test
+// caught directly: naively granting a new height amnesty from the previous
+// height's deadline whenever catchupRemaining == 0 is wrong when that 0 came
+// from an INTERMEDIATE height that never got a chance to open a pass at all
+// (still serving an earlier interruption's penalty) rather than from a pass
+// that genuinely finished. Every height below except the first is exactly
+// that intermediate case, so a version of the fix that doesn't track WHY
+// catchupRetryAt is armed (see catchupRetrySticky) turns this test's 1 send
+// into a fresh send roughly every other height.
 func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupHeightAdvanceInterruptingPassIsThrottled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -833,6 +843,72 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupHeightAdvanceInter
 	suite.clock.Advance(catchupResendInterval)
 	tick(numHeights + 1)
 	suite.Require().Equal(2, sends, "a fresh pass opens once the interval has elapsed since the interrupted pass")
+}
+
+// TestGossipBlockPartsForCatchupCleanHeightAdvanceIsNotThrottled is a
+// regression test for a defect where a pass that closed CLEANLY (its own
+// budget exhausted, catchupRemaining == 0) at the old height left
+// catchupRetryAt armed against that old height, and a peer that then
+// genuinely advanced past it inherited that leftover deadline: the new
+// height's first pass would wait out up to catchupResendInterval for no
+// reason, even though the peer isn't replaying anything and holds no
+// interrupted budget. Catch-up is the only path offered to a peer at a
+// different height than ours, so this taxes every honestly-advancing lagging
+// peer, once per height. Contrast with
+// TestGossipBlockPartsForCatchupHeightAdvanceInterruptingPassIsThrottled,
+// which pins that an height change interrupting an UNEXHAUSTED pass must
+// still throttle - that case is intentionally unchanged here.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupCleanHeightAdvanceIsNotThrottled() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	// Height 999: a single-part block, so one tick both opens AND fully
+	// exhausts the pass's budget - it closes cleanly, not by interruption.
+	onePart := types.NewPartSetFromData(tmrand.Bytes(100), 100)
+	suite.Require().Equal(uint32(1), onePart.Total())
+	onePartMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: onePart.Header()}}
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&onePartMeta)
+	suite.blockStore.On("LoadBlockPart", int64(999), 0).Return(onePart.GetPart(0))
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         onePart.BitArray().Not(),
+		ProposalBlockPartSetHeader: onePart.Header(),
+	}
+	suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	suite.Require().Equal(1, sends, "the single-part pass must close on its own budget, not by interruption")
+
+	// The peer genuinely advances to height 1000, on the very same simulated
+	// instant - no time has passed since the height-999 pass closed.
+	threeParts := types.NewPartSetFromData(tmrand.Bytes(300), 100)
+	suite.Require().Equal(uint32(3), threeParts.Total())
+	threePartsMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: threeParts.Header()}}
+	suite.blockStore.On("LoadBlockMeta", int64(1000)).Return(&threePartsMeta)
+	for i := uint32(0); i < threeParts.Total(); i++ {
+		suite.blockStore.On("LoadBlockPart", int64(1000), int(i)).Return(threeParts.GetPart(int(i)))
+	}
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     1000,
+		Round:                      0,
+		ProposalBlockParts:         threeParts.BitArray().Not(),
+		ProposalBlockPartSetHeader: threeParts.Header(),
+	}
+	suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	suite.Require().Equal(2, sends,
+		"a cleanly-closed pass at the old height must not throttle the new height's first pass")
 }
 
 // TestGossipBlockPartsForCatchupBudgetShrinksWithReportedMissing verifies the

--- a/internal/consensus/gossiper_test.go
+++ b/internal/consensus/gossiper_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cosmos/gogoproto/proto"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
@@ -29,6 +30,7 @@ type GossiperSuiteTest struct {
 
 	ps         *PeerState
 	gossiper   *msgGossiper
+	clock      *clockwork.FakeClock
 	sender     *p2pMsgSender
 	blockStore *mocks.BlockStore
 	stateCh    *p2pmocks.Channel
@@ -68,6 +70,7 @@ func (suite *GossiperSuiteTest) SetupTest() {
 		},
 	}
 	suite.blockStore = &mocks.BlockStore{}
+	suite.clock = clockwork.NewFakeClock()
 	suite.gossiper = &msgGossiper{
 		logger:    suite.logger,
 		ps:        suite.ps,
@@ -77,6 +80,7 @@ func (suite *GossiperSuiteTest) SetupTest() {
 			logger:     suite.logger,
 		},
 		optimistic: true,
+		clock:      suite.clock,
 	}
 }
 
@@ -390,6 +394,9 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchup() {
 			if tc.mockFn != nil {
 				tc.mockFn()
 			}
+			// The cases are independent occasions at the same height; without this
+			// they share one catch-up retry interval and only the first one acts.
+			suite.clock.Advance(catchupResendInterval)
 			suite.ps.PRS = tc.prs
 			if tc.wantMsg != nil {
 				suite.dataCh.
@@ -405,12 +412,11 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchup() {
 	}
 }
 
-// TestGossipBlockPartsForCatchupResends verifies that catch-up block-part
-// gossip does NOT optimistically record the part as delivered. A lagging peer
-// may be at a step where it is not yet expecting block parts and silently drops
-// them; if we marked the part delivered we would never resend it, wedging the
-// peer with an incomplete block. The part must therefore keep being sent on
-// every tick until the peer applies the block and advances its height.
+// TestGossipBlockPartsForCatchupResends verifies the two halves of the catch-up
+// contract for a single-part block: the part is never optimistically recorded as
+// delivered (a lagging peer may silently drop it, and marking would wedge the
+// peer with an incomplete block), and it is replayed once the retry interval has
+// elapsed rather than on every gossip tick.
 func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResends() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -432,28 +438,42 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResends() {
 
 	suite.blockStore.On("LoadBlockMeta", int64(999)).Twice().Return(&blockMeta)
 	suite.blockStore.On("LoadBlockPart", int64(999), 0).Twice().Return(part0)
+	sends := 0
 	suite.dataCh.
 		On("Send", ctx, p2p.Envelope{
 			To:      suite.ps.peerID,
 			Message: &tmcons.BlockPart{Height: 999, Round: 0, Part: *protoPart0},
 		}).
+		Run(func(_ mock.Arguments) { sends++ }).
 		Twice().
 		Return(nil)
 
-	// First tick: send the missing part.
+	// First tick sends the missing part, completing the pass for this height.
 	suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	suite.Require().Equal(1, sends)
 	suite.Require().False(suite.ps.PRS.ProposalBlockParts.GetIndex(0),
 		"catch-up must not optimistically mark the peer as having the part")
 
-	// Second tick: the part is still considered missing, so it is resent.
+	// Further ticks inside the retry interval must not replay the part: that is
+	// what floods a peer we only believe to be lagging.
+	for range 100 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(1, sends, "catch-up must not resend within the retry interval")
+
+	// Once the interval elapses the peer is still behind, so the part is resent.
+	suite.clock.Advance(catchupResendInterval)
 	suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	suite.Require().Equal(2, sends, "catch-up must resend after the retry interval")
+	suite.Require().False(suite.ps.PRS.ProposalBlockParts.GetIndex(0),
+		"catch-up must not optimistically mark the peer as having the part")
 }
 
 // TestGossipBlockPartsForCatchupResendsMultiPart verifies that catch-up
 // block-part gossip iterates across ALL missing indices in a multi-part block,
-// not just a single index. With three parts all initially missing, every part
-// index must be sent to the lagging peer across repeated gossip ticks, and the
-// peer's ProposalBlockParts bit-array must never be optimistically marked.
+// not just a single index, while spending at most one part-set pass per retry
+// interval. The peer's ProposalBlockParts bit-array must never be optimistically
+// marked.
 func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResendsMultiPart() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -472,11 +492,11 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResendsMultiPart()
 		ProposalBlockPartSetHeader: partSet.Header(),
 	}
 
-	// Each gossip tick picks ONE random missing index via PickRandom.
-	// By the coupon-collector model, covering all 3 indices takes ~5.5 ticks on
-	// average; 90 ticks makes the probability of any single index going unseen
-	// below (2/3)^90 ≈ 10^-16 per index — negligible in practice.
-	const ticks = 90
+	// A pass spends one send per part, each picking a random missing index, so a
+	// single pass need not cover every index. By the coupon-collector model 30
+	// passes of 3 sends leave any index unseen with probability (2/3)^90 ≈
+	// 10^-16 — negligible in practice.
+	const passes = 30
 
 	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
 	for i := uint32(0); i < partSet.Total(); i++ {
@@ -485,6 +505,7 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResendsMultiPart()
 
 	// Capture which part indices the gossiper actually sends.
 	sentIndices := make(map[uint32]bool)
+	sends := 0
 	suite.dataCh.On("Send", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			env, ok := args.Get(1).(p2p.Envelope)
@@ -493,18 +514,31 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResendsMultiPart()
 			}
 			if bp, ok := env.Message.(*tmcons.BlockPart); ok {
 				sentIndices[bp.Part.Index] = true
+				sends++
 			}
 		}).
 		Return(nil)
 
-	for range ticks {
+	// One pass covers the part set; extra ticks within the interval are skipped.
+	for range int(partSet.Total()) + 5 {
 		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
 	}
+	suite.Require().Equal(int(partSet.Total()), sends,
+		"a catch-up pass must send exactly one part per part-set entry")
+
+	for range passes - 1 {
+		suite.clock.Advance(catchupResendInterval)
+		for range int(partSet.Total()) {
+			suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+		}
+	}
+	suite.Require().Equal(passes*int(partSet.Total()), sends,
+		"each elapsed retry interval must allow exactly one further pass")
 
 	// Every part index must have been sent to the peer at least once.
 	for i := uint32(0); i < partSet.Total(); i++ {
 		suite.Assert().True(sentIndices[i],
-			"part index %d was never sent across %d gossip ticks", i, ticks)
+			"part index %d was never sent across %d catch-up passes", i, passes)
 	}
 
 	// The peer's bit-array must remain un-marked (no optimistic delivery).

--- a/internal/consensus/gossiper_test.go
+++ b/internal/consensus/gossiper_test.go
@@ -18,6 +18,7 @@ import (
 	p2pmocks "github.com/dashpay/tenderdash/internal/p2p/mocks"
 	"github.com/dashpay/tenderdash/internal/state/mocks"
 	"github.com/dashpay/tenderdash/internal/test/factory"
+	"github.com/dashpay/tenderdash/libs/bits"
 	"github.com/dashpay/tenderdash/libs/log"
 	tmrand "github.com/dashpay/tenderdash/libs/rand"
 	tmcons "github.com/dashpay/tenderdash/proto/tendermint/consensus"
@@ -680,6 +681,111 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetsMissingPart
 	suite.clock.Advance(catchupResendInterval)
 	suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
 	suite.Require().Equal(2, sends, "the missing part is retried once the interval elapses")
+}
+
+// TestGossipBlockPartsForCatchupMismatchedHeaderEndsPass covers a pass that can
+// never produce a send. The peer supplies both the part-set header and the size
+// of the missing bit-array, and only their encoding is validated, so a pass
+// opened on a maximum-size array with a header matching no stored block would
+// otherwise charge a block-store read and an error log to every gossip tick for
+// the whole budget - and, its deadline having been armed when the pass opened,
+// reopen immediately afterwards.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupMismatchedHeaderEndsPass() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stored := types.NewPartSetFromData(tmrand.Bytes(100), 100)
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: stored.Header()}}
+
+	// Largest pass the peer can ask for: every bit of a maximum-length array
+	// reported missing, under a header no stored block can match.
+	bogus := types.NewPartSetFromData(tmrand.Bytes(100), 100)
+	suite.Require().False(bogus.Header().Equals(stored.Header()))
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         bits.NewBitArray(int(types.MaxBlockPartsCount)),
+		ProposalBlockPartSetHeader: bogus.Header(),
+	}
+
+	// The data channel has no expectations: a mismatched header must send nothing.
+	metaReads := 0
+	suite.blockStore.On("LoadBlockMeta", int64(999)).
+		Run(func(_ mock.Arguments) { metaReads++ }).
+		Return(&blockMeta)
+
+	for range 50 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(1, metaReads,
+		"a pass that cannot send must cost one attempt per interval, not one per tick")
+
+	suite.clock.Advance(catchupResendInterval)
+	for range 50 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(2, metaReads, "each elapsed interval allows exactly one further attempt")
+}
+
+// TestGossipBlockPartsForCatchupMalformedHeaderDoesNotFundSends pins the budget
+// to a pass that got as far as sending. A pass is deliberately not re-derived
+// from the peer's bit-array once open, so a budget opened against an unusable
+// header would otherwise stay spendable when the peer replaces its state, at the
+// same height, with the stored block's real header and a single missing part:
+// the whole inflated budget then lands as duplicate sends of that one part.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupMalformedHeaderDoesNotFundSends() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	partSet := types.NewPartSetFromData(tmrand.Bytes(100), 100)
+	suite.Require().Equal(uint32(1), partSet.Total())
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	bogus := types.NewPartSetFromData(tmrand.Bytes(100), 100)
+	suite.Require().False(bogus.Header().Equals(partSet.Header()))
+
+	// Open the largest pass available, under a header that cannot match.
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         bits.NewBitArray(int(types.MaxBlockPartsCount)),
+		ProposalBlockPartSetHeader: bogus.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	suite.blockStore.On("LoadBlockPart", int64(999), 0).Return(partSet.GetPart(0))
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+
+	// Same height, now with the real header and one part outstanding.
+	suite.ps.PRS.ProposalBlockPartSetHeader = partSet.Header()
+	suite.ps.PRS.ProposalBlockParts = partSet.BitArray().Not()
+
+	for range 50 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(0, sends,
+		"a budget opened against an unusable header must not fund sends after the peer swaps it out")
+
+	// The next interval opens a fresh pass, budgeted on what the peer now reports.
+	suite.clock.Advance(catchupResendInterval)
+	for range 50 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(1, sends, "the fresh pass is worth the single part the peer now reports missing")
 }
 
 // TestGossipBlockPartsForCatchupPeerHasEveryPart covers the peer reporting a

--- a/internal/consensus/gossiper_test.go
+++ b/internal/consensus/gossiper_test.go
@@ -683,6 +683,168 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetsMissingPart
 	suite.Require().Equal(2, sends, "the missing part is retried once the interval elapses")
 }
 
+// TestGossipBlockPartsForCatchupRetryIntervalArmsWhenPassEnds verifies the
+// pass's retry deadline is measured from its last send, not from when it
+// opened. A pass with enough missing parts to span more gossip ticks than
+// catchupResendInterval allows takes longer than the interval to exhaust; a
+// deadline armed at open time has already elapsed by then, so the next tick
+// would otherwise reopen a fresh pass immediately - leaving no quiet gap
+// between passes, which is exactly the flooding behavior this throttle
+// exists to stop.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupRetryIntervalArmsWhenPassEnds() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	const numParts = 6
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*numParts), partSize)
+	suite.Require().Equal(uint32(numParts), partSet.Total(), "need a 6-part block for this test")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         partSet.BitArray().Not(), // peer has none
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	for i := uint32(0); i < partSet.Total(); i++ {
+		suite.blockStore.On("LoadBlockPart", int64(999), int(i)).Return(partSet.GetPart(int(i)))
+	}
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	tick := func() {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+
+	// A gossip tick every fifth of the interval: 6 missing parts therefore
+	// take longer than catchupResendInterval to exhaust the pass.
+	step := catchupResendInterval / 5
+
+	// The first 5 ticks drain 5 of the pass's 6 sends, ending at
+	// t = catchupResendInterval.
+	for range 5 {
+		tick()
+		suite.clock.Advance(step)
+	}
+	suite.Require().Equal(5, sends)
+
+	// This tick, still at t = catchupResendInterval, spends the pass's last
+	// send.
+	tick()
+	suite.Require().Equal(6, sends, "the pass's budget covers all 6 missing parts")
+
+	// A tick right after the pass's last send must NOT open a new pass: a
+	// full interval must elapse after the LAST send, not after the pass
+	// opened (which was catchupResendInterval ago by now too).
+	tick()
+	suite.Require().Equal(6, sends,
+		"no further send until a full retry interval has elapsed since the pass's last send")
+
+	// Advancing to just short of a full interval past the last send still
+	// must not reopen the pass.
+	suite.clock.Advance(catchupResendInterval - step)
+	tick()
+	suite.Require().Equal(6, sends,
+		"the retry deadline must be measured from the pass's last send, not from when it opened")
+
+	// Only once a full interval has elapsed since the last send does a fresh
+	// pass open.
+	suite.clock.Advance(step)
+	tick()
+	suite.Require().Equal(7, sends, "a fresh pass opens once the full interval has elapsed")
+}
+
+// TestGossipBlockPartsForCatchupBudgetShrinksWithReportedMissing verifies the
+// pass's remaining budget is clamped down when the peer's bit-array later
+// reports fewer parts missing than when the pass opened. Successful catch-up
+// sends never mark parts delivered locally (see
+// TestGossipBlockPartsForCatchupResends), so the peer fully controls what
+// ProposalBlockParts.Not().CountTrueBits() reports on every tick -
+// NewValidBlockMessage.ValidateBasic checks only the array's length and
+// ApplyNewValidBlockMessage installs it wholesale. A peer that opens a pass
+// reporting many parts missing and then swaps in a bit-array with only one
+// unset bit must not keep the larger original budget: every remaining
+// attempt would draw that same single index, funding repeated duplicate
+// sends of it.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetShrinksWithReportedMissing() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	const numParts = 5
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*numParts), partSize)
+	suite.Require().Equal(uint32(numParts), partSet.Total(), "need a 5-part block for this test")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         partSet.BitArray().Not(), // peer has none: 5 missing
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	for i := uint32(0); i < partSet.Total(); i++ {
+		suite.blockStore.On("LoadBlockPart", int64(999), int(i)).Return(partSet.GetPart(int(i)))
+	}
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	tick := func() {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+
+	// The first two ticks open a 5-send pass and spend two of them.
+	tick()
+	tick()
+	suite.Require().Equal(2, sends)
+
+	// The peer now reports only one part missing, without the height
+	// changing - a bit-array the peer fully controls over the wire (see the
+	// doc comment above).
+	shrunk := partSet.BitArray().Copy() // every bit set: peer has them all
+	shrunk.SetIndex(4, false)           // except part 4
+	suite.ps.PRS.ProposalBlockParts = shrunk
+	suite.Require().Equal(1, shrunk.Not().CountTrueBits())
+
+	for range 5 {
+		tick()
+	}
+	suite.Require().Equal(3, sends,
+		"a pass must not fund more sends than the peer's currently-reported missing count once it shrinks")
+
+	// The next interval opens a fresh pass, budgeted on what the peer reports
+	// at that point (still 1 missing).
+	suite.clock.Advance(catchupResendInterval)
+	tick()
+	suite.Require().Equal(4, sends)
+}
+
 // TestGossipBlockPartsForCatchupMismatchedHeaderEndsPass covers a pass that can
 // never produce a send. The peer supplies both the part-set header and the size
 // of the missing bit-array, and only their encoding is validated, so a pass

--- a/internal/consensus/gossiper_test.go
+++ b/internal/consensus/gossiper_test.go
@@ -1075,6 +1075,63 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupSendFailureEndsPas
 	suite.Require().Equal(2, partReads, "each elapsed interval allows exactly one further attempt")
 }
 
+// TestGossipBlockPartsForCatchupPanicEndsPass is a regression test for a
+// defect where a panic out of sendCatchupBlockPart's block-store reads left
+// the pass open. LoadBlockMeta and LoadBlockPart panic deliberately on a
+// decode or read failure (see internal/store/store.go), and
+// peerGossipWorker.runGossipHandler recovers that per gossip tick and keeps
+// ticking - GossipBlockPartsForCatchup's own endCatchupPass call used to run
+// only on a normal false return, which a panic's unwind skips entirely,
+// leaving the remaining budget spendable. A peer that can trigger the panic
+// (any store corruption or read failure at a height it names) would then get
+// a fresh attempt - and a fresh panic, and a fresh full-stack log - on every
+// tick for the rest of the pass instead of ending on the first one, same as
+// TestGossipBlockPartsForCatchupSendFailureEndsPass covers for a normal
+// failure. The test recovers the panic itself, standing in for
+// runGossipHandler; that recovery is not itself under test here.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupPanicEndsPass() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*5), partSize)
+	suite.Require().Equal(uint32(5), partSet.Total(), "need multiple missing parts so the budget isn't the limiting factor")
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         partSet.BitArray().Not(), // peer has none
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	metaReads := 0
+	suite.blockStore.On("LoadBlockMeta", int64(999)).
+		Run(func(_ mock.Arguments) {
+			metaReads++
+			panic("simulated block-store decode failure")
+		}).
+		Return((*types.BlockMeta)(nil))
+
+	tick := func() {
+		func() {
+			defer func() { _ = recover() }() // stands in for runGossipHandler's recover
+			suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+		}()
+	}
+
+	for range 50 {
+		tick()
+	}
+	suite.Require().Equal(1, metaReads,
+		"a panicking attempt must end the pass just like a normal failed one, not retry every tick for the rest of the budget")
+
+	suite.clock.Advance(catchupResendInterval)
+	for range 50 {
+		tick()
+	}
+	suite.Require().Equal(2, metaReads, "each elapsed interval allows exactly one further attempt")
+}
+
 // TestGossipBlockPartsForCatchupMalformedHeaderDoesNotFundSends pins the budget
 // to a pass that got as far as sending. A pass is deliberately not re-derived
 // from the peer's bit-array once open, so a budget opened against an unusable

--- a/internal/consensus/gossiper_test.go
+++ b/internal/consensus/gossiper_test.go
@@ -912,6 +912,76 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetShrinksWithR
 	suite.Require().Equal(4, sends)
 }
 
+// TestGossipBlockPartsForCatchupCompleteReportMidPassClosesIt verifies that a
+// peer reporting a complete part set while a pass is still open (budget not
+// yet exhausted) closes the pass and arms the retry deadline, rather than
+// leaving it open indefinitely. Left open, a peer can freeze catchupRemaining
+// above zero by reporting a complete set whenever it likes, then resume
+// sending on the very next tick it reports parts missing again - the backoff
+// check only runs while no pass is open, so an open-but-frozen pass skips it
+// entirely and never honors the retry interval.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupCompleteReportMidPassClosesIt() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	const numParts = 3
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*numParts), partSize)
+	suite.Require().Equal(uint32(numParts), partSet.Total(), "need a 3-part block for this test")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         partSet.BitArray().Not(), // peer has none: 3 missing
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	for i := uint32(0); i < partSet.Total(); i++ {
+		suite.blockStore.On("LoadBlockPart", int64(999), int(i)).Return(partSet.GetPart(int(i)))
+	}
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	tick := func() {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+
+	// Open a 3-send pass and spend one of them.
+	tick()
+	suite.Require().Equal(1, sends)
+
+	// The peer now reports a complete part set, without the height changing -
+	// a bit-array the peer fully controls over the wire.
+	suite.ps.PRS.ProposalBlockParts = partSet.BitArray() // every bit set: peer has them all
+	tick()
+	suite.Require().Equal(1, sends, "a complete report must not itself send")
+
+	// The peer reports one part missing again, immediately (same simulated
+	// instant - the clock has not advanced at all since the pass opened).
+	suite.ps.PRS.ProposalBlockParts = partSet.BitArray().Not()
+	tick()
+	suite.Require().Equal(1, sends,
+		"a pass closed by a complete report must honor the retry interval before sending again")
+
+	// Only once the interval has elapsed does a fresh pass open.
+	suite.clock.Advance(catchupResendInterval)
+	tick()
+	suite.Require().Equal(2, sends, "a fresh pass opens once the retry interval has elapsed")
+}
+
 // TestGossipBlockPartsForCatchupMismatchedHeaderEndsPass covers a pass that can
 // never produce a send. The peer supplies both the part-set header and the size
 // of the missing bit-array, and only their encoding is validated, so a pass

--- a/internal/consensus/gossiper_test.go
+++ b/internal/consensus/gossiper_test.go
@@ -549,6 +549,80 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResendsMultiPart()
 	}
 }
 
+// TestGossipBlockPartsForCatchupBudgetsMissingParts pins the catch-up pass to
+// the number of parts the peer is actually missing rather than the size of its
+// bit-array. The peer supplies that bit-array over the wire and only its length
+// is validated, so budgeting on the length would let a peer reporting a single
+// missing part draw one resend of it per bit in the array.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetsMissingParts() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*3), partSize)
+	suite.Require().Equal(uint32(3), partSet.Total(), "need a 3-part block for this test")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	// The peer reports every part but the last, so exactly one is missing.
+	peerParts := partSet.BitArray().Copy()
+	peerParts.SetIndex(2, false)
+	suite.Require().Equal(2, peerParts.CountTrueBits())
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         peerParts,
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	suite.blockStore.On("LoadBlockPart", int64(999), 2).Return(partSet.GetPart(2))
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	for range int(partSet.Total()) + 5 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(1, sends,
+		"a pass must spend one send per missing part, not one per bit-array entry")
+
+	suite.clock.Advance(catchupResendInterval)
+	suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	suite.Require().Equal(2, sends, "the missing part is retried once the interval elapses")
+}
+
+// TestGossipBlockPartsForCatchupPeerHasEveryPart covers the peer reporting a
+// complete part set: there is nothing to send, and no pass may be opened.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupPeerHasEveryPart() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	partSet := types.NewPartSetFromData(tmrand.Bytes(100), 100)
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         partSet.BitArray(), // peer has them all
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	// Neither the block store nor the data channel may be touched; the mocks are
+	// constructed with no expectations, so any call fails the test.
+	for range 10 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+}
+
 func (suite *GossiperSuiteTest) TestGossipCommit() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/consensus/gossiper_test.go
+++ b/internal/consensus/gossiper_test.go
@@ -549,6 +549,86 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResendsMultiPart()
 	}
 }
 
+// TestGossipBlockPartsForCatchupBudgetIsFixedAtPassOpen pins a pass to the
+// budget it opened with. The peer supplies the bit-array the missing count is
+// derived from and may replace it between ticks, so re-reading it to decide
+// whether the pass is spent lets the peer both dodge the retry deadline and
+// enlarge the pass: lowering the count below the sends already made opens a
+// fresh pass, and raising it afterwards steps over a deadline already set.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetIsFixedAtPassOpen() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*3), partSize)
+	suite.Require().Equal(uint32(3), partSet.Total(), "need a 3-part block for this test")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	// reportMissing has the peer claim its first n parts are outstanding.
+	reportMissing := func(n int) {
+		reported := partSet.BitArray().Copy() // every bit set: peer has them all
+		for i := range n {
+			reported.SetIndex(i, false)
+		}
+		suite.Require().Equal(n, reported.Not().CountTrueBits())
+		suite.ps.PRS.ProposalBlockParts = reported
+	}
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+	reportMissing(3)
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	for i := range int(partSet.Total()) {
+		suite.blockStore.On("LoadBlockPart", int64(999), i).Return(partSet.GetPart(i))
+	}
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	tick := func() {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+
+	// Two sends against a pass opened with a budget of three.
+	tick()
+	tick()
+
+	// Drop the count to the number of sends already made. A pass whose budget is
+	// re-derived here looks spent, and reopens without a deadline to wait on.
+	reportMissing(2)
+	tick()
+	tick()
+
+	// Raise it again, stepping over any deadline the previous ticks may have set.
+	reportMissing(3)
+	tick()
+	tick()
+
+	suite.Require().Equal(3, sends,
+		"a pass must not exceed the budget it opened with, whatever the peer reports afterwards")
+
+	// The next interval opens exactly one further pass, of three sends.
+	suite.clock.Advance(catchupResendInterval)
+	for range 6 {
+		tick()
+	}
+	suite.Require().Equal(6, sends, "each elapsed interval must open exactly one further pass")
+}
+
 // TestGossipBlockPartsForCatchupBudgetsMissingParts pins the catch-up pass to
 // the number of parts the peer is actually missing rather than the size of its
 // bit-array. The peer supplies that bit-array over the wire and only its length

--- a/internal/consensus/gossiper_test.go
+++ b/internal/consensus/gossiper_test.go
@@ -771,6 +771,74 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupRetryIntervalArmsW
 	suite.Require().Equal(7, sends, "a fresh pass opens once the full interval has elapsed")
 }
 
+// TestGossipBlockPartsForCatchupRetryIntervalArmsAfterSendReturns is a
+// regression test for a defect where the pass's retry deadline was armed from
+// a timestamp taken before the send, so a send that blocked for part of the
+// interval - the p2p channel applies backpressure on this very goroutine -
+// had its own duration counted against the quiet gap that is supposed to
+// start once it returns. A send lasting a full catchupResendInterval left the
+// deadline already elapsed on return, so the next gossip tick opened a fresh
+// pass with no gap at all: the slower the peer's channel, the weaker the
+// throttle, which is exactly backwards.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupRetryIntervalArmsAfterSendReturns() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*3), partSize)
+	suite.Require().Equal(uint32(3), partSet.Total(), "need a 3-part block for this test")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	// The peer reports exactly one part missing, so a pass is one send wide
+	// and the very first tick spends its last slot.
+	peerParts := partSet.BitArray().Copy()
+	peerParts.SetIndex(2, false)
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         peerParts,
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	suite.blockStore.On("LoadBlockPart", int64(999), 2).Return(partSet.GetPart(2))
+
+	// Each send occupies the whole interval before it returns.
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+				suite.clock.Advance(catchupResendInterval)
+			}
+		}).
+		Return(nil)
+
+	tick := func() {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+
+	tick()
+	suite.Require().Equal(1, sends, "the pass's single slot is spent on the first tick")
+
+	tick()
+	suite.Require().Equal(1, sends,
+		"the time spent inside the send must not count towards the quiet gap that follows it")
+
+	suite.clock.Advance(catchupResendInterval - time.Nanosecond)
+	tick()
+	suite.Require().Equal(1, sends, "a full interval after the send returned is still not up")
+
+	suite.clock.Advance(time.Nanosecond)
+	tick()
+	suite.Require().Equal(2, sends, "a fresh pass opens an interval after the send returned")
+}
+
 // TestGossipBlockPartsForCatchupHeightAdvanceInterruptingPassIsThrottled is a
 // regression test for a defect where a height change interrupting a pass
 // BEFORE it exhausted its own budget left catchupRetryAt unarmed (only

--- a/internal/consensus/gossiper_test.go
+++ b/internal/consensus/gossiper_test.go
@@ -915,11 +915,14 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetShrinksWithR
 // TestGossipBlockPartsForCatchupCompleteReportMidPassClosesIt verifies that a
 // peer reporting a complete part set while a pass is still open (budget not
 // yet exhausted) closes the pass and arms the retry deadline, rather than
-// leaving it open indefinitely. Left open, a peer can freeze catchupRemaining
-// above zero by reporting a complete set whenever it likes, then resume
-// sending on the very next tick it reports parts missing again - the backoff
-// check only runs while no pass is open, so an open-but-frozen pass skips it
-// entirely and never honors the retry interval.
+// leaving it open indefinitely. This is not about exceeding the pass's
+// budget - catchupRemaining only ever counts down, so total sends per pass
+// are the same either way. It's about what an indefinitely-open pass costs:
+// the bit-array scan above runs on every tick instead of being skipped by
+// backoff (see TestGossipBlockPartsForCatchupRetryIntervalArmsWhenPassEnds'
+// sibling optimization), and the next report of missing parts resumes
+// sending on the very same tick instead of after a fresh
+// catchupResendInterval, which this test pins.
 func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupCompleteReportMidPassClosesIt() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/consensus/gossiper_test.go
+++ b/internal/consensus/gossiper_test.go
@@ -369,7 +369,7 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchup() {
 				suite.blockStore.On("Base").Once().Return(int64(1))
 				suite.blockStore.On("Height").Once().Return(int64(1000))
 			},
-			wantLog: `couldn't find a block meta`,
+			wantLog: `failed to load block meta`,
 		},
 		{
 			prs: cstypes.PeerRoundState{Height: 999, ProposalBlockParts: partSet1.BitArray().Not()},
@@ -387,7 +387,7 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchup() {
 				suite.blockStore.On("LoadBlockMeta", int64(999)).Once().Return(&blockMeta)
 				suite.blockStore.On("LoadBlockPart", int64(999), 0).Once().Return(nil)
 			},
-			wantLog: `couldn't find a block part`,
+			wantLog: `failed to load block part`,
 		},
 	}
 	for i, tc := range testCases {
@@ -550,19 +550,22 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResendsMultiPart()
 	}
 }
 
-// TestGossipBlockPartsForCatchupBudgetIsFixedAtPassOpen pins a pass to the
-// budget it opened with. The peer supplies the bit-array the missing count is
-// derived from and may replace it between ticks, so re-reading it to decide
-// whether the pass is spent lets the peer both dodge the retry deadline and
-// enlarge the pass: lowering the count below the sends already made opens a
-// fresh pass, and raising it afterwards steps over a deadline already set.
-func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetIsFixedAtPassOpen() {
+// TestGossipBlockPartsForCatchupBudgetIsNeverRaisedMidPass pins a pass's
+// budget as an upper bound fixed at open: it may be clamped down when the
+// peer's reported missing count drops (see
+// TestGossipBlockPartsForCatchupBudgetShrinksWithReportedMissing) but never
+// raised back up once clamped. The peer supplies the bit-array the missing
+// count is derived from and may replace it between ticks, so if raising the
+// count mid-pass were honored, a peer could both recover budget the clamp had
+// taken away and step over the deadline the clamp-triggered exhaustion armed.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetIsNeverRaisedMidPass() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	const partSize = uint32(100)
-	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*3), partSize)
-	suite.Require().Equal(uint32(3), partSet.Total(), "need a 3-part block for this test")
+	const numParts = 5
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*numParts), partSize)
+	suite.Require().Equal(uint32(numParts), partSet.Total(), "need headroom above the clamped-down budget")
 	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
 
 	// reportMissing has the peer claim its first n parts are outstanding.
@@ -580,7 +583,7 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetIsFixedAtPas
 		Round:                      0,
 		ProposalBlockPartSetHeader: partSet.Header(),
 	}
-	reportMissing(3)
+	reportMissing(numParts)
 
 	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
 	for i := range int(partSet.Total()) {
@@ -604,30 +607,30 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetIsFixedAtPas
 		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
 	}
 
-	// Two sends against a pass opened with a budget of three.
+	// Open a 5-send pass and spend two of them, leaving 3 in the budget.
 	tick()
 	tick()
 
-	// Drop the count to the number of sends already made. A pass whose budget is
-	// re-derived here looks spent, and reopens without a deadline to wait on.
-	reportMissing(2)
+	// Drop hard, to fewer than the 3 remaining: a genuine clamp, not a no-op.
+	// The pass now has only 1 slot left instead of 3, so it exhausts (and arms
+	// the deadline) on the very next tick.
+	reportMissing(1)
 	tick()
-	tick()
+	suite.Require().Equal(3, sends, "the clamp must actually shrink the remaining budget, ending the pass early")
 
-	// Raise it again, stepping over any deadline the previous ticks may have set.
-	reportMissing(3)
+	// Raise it back to the original count, at the same clock instant the
+	// deadline was just armed at.
+	reportMissing(numParts)
 	tick()
 	tick()
-
 	suite.Require().Equal(3, sends,
-		"a pass must not exceed the budget it opened with, whatever the peer reports afterwards")
+		"raising the reported count after the clamp ended the pass must not reopen it before the deadline")
 
-	// The next interval opens exactly one further pass, of three sends.
+	// Only once the interval elapses does a fresh pass open, budgeted on
+	// whatever the peer currently reports -- all 5 parts once again.
 	suite.clock.Advance(catchupResendInterval)
-	for range 6 {
-		tick()
-	}
-	suite.Require().Equal(6, sends, "each elapsed interval must open exactly one further pass")
+	tick()
+	suite.Require().Equal(4, sends, "the next pass opens fresh, unrelated to the one the clamp cut short")
 }
 
 // TestGossipBlockPartsForCatchupBudgetsMissingParts pins the catch-up pass to
@@ -766,6 +769,70 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupRetryIntervalArmsW
 	suite.clock.Advance(step)
 	tick()
 	suite.Require().Equal(7, sends, "a fresh pass opens once the full interval has elapsed")
+}
+
+// TestGossipBlockPartsForCatchupHeightAdvanceInterruptingPassIsThrottled is a
+// regression test for a defect where a height change interrupting a pass
+// BEFORE it exhausted its own budget left catchupRetryAt unarmed (only
+// exhaustion or a failed send armed it). A peer that advances its reported
+// height every tick -- legitimate and monotonic, no protocol violation -- then
+// forced a fresh full-budget pass on every single tick, forever, whenever the
+// block at each claimed height took more than one tick to exhaust (i.e. any
+// block with more than one missing part, the common case). The clock is never
+// advanced across the first block of ticks below: a working throttle must
+// still bound the send rate even though the peer supplies a "new" pass at
+// every step.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupHeightAdvanceInterruptingPassIsThrottled() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	const numParts = 3
+	const numHeights = 20
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	tick := func(height int64) {
+		partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*numParts), partSize)
+		suite.Require().Equal(uint32(numParts), partSet.Total())
+		blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+		suite.blockStore.On("LoadBlockMeta", height).Return(&blockMeta)
+		for i := uint32(0); i < partSet.Total(); i++ {
+			suite.blockStore.On("LoadBlockPart", height, int(i)).Return(partSet.GetPart(int(i)))
+		}
+		suite.ps.PRS = cstypes.PeerRoundState{
+			Height:                     height,
+			Round:                      0,
+			ProposalBlockParts:         partSet.BitArray().Not(), // peer has none
+			ProposalBlockPartSetHeader: partSet.Header(),
+		}
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+
+	// The peer advances its reported height on every tick, at the same clock
+	// instant, before any pass at a prior height could exhaust its 3-send
+	// budget. A throttle that only arms its deadline on exhaustion or failure
+	// never gets a chance to arm it here.
+	for h := int64(1); h <= numHeights; h++ {
+		tick(h)
+	}
+	suite.Require().Equal(1, sends,
+		"an unexhausted pass interrupted by a height change must still throttle to one pass per interval")
+
+	suite.clock.Advance(catchupResendInterval)
+	tick(numHeights + 1)
+	suite.Require().Equal(2, sends, "a fresh pass opens once the interval has elapsed since the interrupted pass")
 }
 
 // TestGossipBlockPartsForCatchupBudgetShrinksWithReportedMissing verifies the
@@ -1011,10 +1078,11 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupPeerHasEveryPart()
 	}
 
 	// Neither the block store nor the data channel may be touched; the mocks are
-	// constructed with no expectations, so any call fails the test.
+	// constructed with no expectations, so any call fails the test too.
 	for range 10 {
 		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
 	}
+	suite.dataCh.AssertNotCalled(suite.T(), "Send", mock.Anything, mock.Anything)
 }
 
 func (suite *GossiperSuiteTest) TestGossipCommit() {

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -559,16 +559,24 @@ func TestReactorValidatorSetChanges(t *testing.T) {
 		{height: 10, count: 2, operation: addValsOp},
 		{height: 17, count: 2, operation: removeValsOp},
 	}
+	// The network needs a real timeout ticker: it recovers from a missing or late
+	// proposal only through the timeoutPropose / timeoutPrecommitWait round change,
+	// and mockTicker discards every timeout but the first.
 	gen := consensusNetGen{
 		cfg:              cfg,
 		nPeers:           nPeers,
 		nVals:            nVals,
 		appFunc:          newKVStoreFunc(t),
-		tickerFun:        newMockTickerFunc(true),
+		tickerFun:        newTickerFunc(),
 		validatorUpdates: updates,
 		consensusParams: factory.ConsensusParams(func(cp *types.ConsensusParams) {
-			cp.Timeout.Propose = 2 * time.Second
-			cp.Timeout.Vote = 1 * time.Second
+			// Seven nodes gossiping in one process under the race detector need far
+			// more wall clock per round than production does. These timeouts only
+			// fire when the network stalls; tighter ones make a loaded runner
+			// abandon rounds it would have completed, so it churns instead of
+			// converging.
+			cp.Timeout.Propose = 5 * time.Second
+			cp.Timeout.Vote = 2 * time.Second
 		}),
 	}
 	states, genDoc, _, validatorSetUpdates := gen.generate(ctx, t)


### PR DESCRIPTION
**TL;DR:** Fixes a consensus bug where a node helping a peer catch up would flood it with block parts it had already moved past, starving the current round — and fixes the CI test that had been hanging because of it.

## Detailed discussion

Two commits. The first is internal test infrastructure with no user-observable behaviour change; the second is a production consensus fix. `User story` and `Scenario` are omitted because the user-visible effect is limited to the second commit and is fully described below.

### Issue being fixed or feature implemented

Partially addresses #1405. `TestReactorValidatorSetChanges` intermittently hangs for its full 2-minute budget, most recently on #1417 (a pure Go-toolchain bump): [run 32835423456](https://github.com/dashpay/tenderdash/actions/runs/32835423456/job/97763075985?pr=1417).

It does not close #1405, which also names `TestRouter_EvictPeers` in `internal/p2p` — a separate matter (a hardcoded 1-second wait in `p2ptest.RequireUpdate` over a mocked transport), sharing no mechanism with this test.

### Root cause 1 — the test harness disabled consensus recovery

`TestReactorValidatorSetChanges` drove its 7-node network with `newMockTickerFunc(true)`. `mockTicker.ScheduleTimeout` forwards **only** `RoundStepNewHeight` timeouts, and with `onlyOnce=true` only the first one; every other scheduled timeout is discarded. The network ran with no `timeoutPropose`, no `timeoutPrevoteWait`/`timeoutPrecommitWait` — so **round changes were impossible** — and, after the first height, no `timeoutNewHeight`, so a node that assembled a commit itself never started the next height.

With recovery disabled, any perturbation wedged the network permanently. Both observed CI shapes follow: a proposal delayed past `MessageDelay + Precision` makes every validator prevote nil and the round change that would recover never fires; separately, a node that applies a commit itself sits at `RoundStepNewHeight` forever, and when it is the next proposer nobody proposes and nobody times out waiting.

This also explains why #1204 did not fix the flake — it introduced the mock ticker, reverting the deliberate move to a real ticker made by `chore(consensus): stabilize consensus algorithm (#284)`.

### Root cause 2 — unbounded catch-up block-part resends

Restoring round changes exposed a second, pre-existing defect. `GossipBlockPartsForCatchup` never marks catch-up parts as delivered, so `prs.ProposalBlockParts.Not().PickRandom()` keeps finding the same index missing and the part is re-sent on **every gossip tick**. The loop ends only when our own view of the peer's height advances — and the traffic it generates delays exactly the `NewRoundStep` messages that would advance it.

Measured in the reactor test: **1091** height-11 block parts pushed at a node that had already reached height 12, every one discarded, against **9** completed proposal blocks in the same window. The live round cannot assemble its proposal, every validator prevotes nil, and the height churns rounds until the deadline. The same loop drives the part-set-header mismatch branch, which logs at error level every tick without sending anything.

This was not caused by the first commit — before it, the network froze at round 0 with every node on the same height, so no peer was ever "behind" and the catch-up path never engaged.

### What was done

1. `internal/consensus/reactor_test.go` — `tickerFun: newTickerFunc()` restores real round timeouts, and `Timeout.Propose`/`Timeout.Vote` are raised to 5s/2s. Round timeouts only fire when the network stalls, so larger values cost nothing on the healthy path; the previous values made a starved runner abandon rounds it would otherwise have completed.
2. `internal/consensus/gossiper.go` — catch-up is bounded to **one part-set pass per `catchupResendInterval`** (500ms). A pass spends one send per part; once complete, further ticks are skipped until the interval elapses, then a new pass begins.

The bound preserves #1365's guarantee. A peer that silently dropped its parts is still served repeatedly for as long as it stays behind, so the wedge that PR fixed stays fixed; only a peer we *believe* to be lagging is cheap. Parts are still never marked delivered, which keeps that guarantee independent of `PeerState` bookkeeping — deliberately, because `SetHasProposalBlockPart` ignores updates whose round differs from the peer's current round, and catch-up passes the committed block's round.

Rejected on measurement: widening the test's `Synchrony` params (no benefit), pacing block production via `CreateEmptyBlocksInterval` (worse, 4/18), and simply lowering the gossip cadence (5ms → 25ms → 100ms moved 2/16 → 7/16 → 5/16, confirming the cure is *stopping* after a pass, not sending more slowly).

### How Has This Been Tested?

Locally, `go test -race`, 16-core host. N concurrent copies of the test binary on the same host, same bed throughout:

| Load | Before both fixes | Ticker fix only | Both fixes |
|---|---|---|---|
| 4 concurrent copies | — | 2/16 | **16/16** |
| 3 concurrent copies | 10/18 | 10/18 | **18/18** |
| unloaded, `-count=10` | 9/10 | 20/20 | **10/10** |

The unloaded baseline reproduced the CI signature exactly — all seven nodes reporting a `waitForAndValidateBlock` deadline, one with `subscription terminated by publisher`.

Mechanistic confirmation for commit 1: counting round changes after the last committed block, the old code shows `max_round = 0` and one `entering new round` per node — frozen, and no extra time would help. After it, 16–62 events reaching rounds 2 through 11.

Mechanistic confirmation for commit 2: wasted catch-up parts per batch drop from **164592 to 2845** (a full revert of the resend behaviour scores 2736, so the bound gives up almost nothing), and part-set mismatch errors fall from 73 to 4. The wedge precondition `Commit came in before proposal` occurs **632 times across those runs with zero wedges**.

Unit tests: full `TestGossiper` and `TestPeerGossipWorker` suites pass. The two tests added by #1365 were updated rather than removed — they still assert that catch-up never marks parts delivered, and now additionally assert that no resend happens inside the interval and that one does once the clock advances past it. `TestGossipBlockPartsForCatchup`'s table cases now advance the fake clock between cases, since they are independent occasions at the same height.

### Breaking Changes

None.

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

### Follow-ups worth a look (deliberately out of scope)

- `internal/consensus/init_test.go` sets `deadlock.Opts.DeadlockTimeout = 5s`. Under contention that detector fires on a benign lock wait and `os.Exit(2)`s the entire package test binary.
- `newMockTickerFunc(true)` is still used by `helper_test.go:216`, `replay_test.go:376` and `byzantine_test.go:50`. Same trap, unexamined.
- `AGENTS.md` states CI runs tests with `-p 1`, but `test-group-%` in the `Makefile` does not pass it, so up to `GOMAXPROCS` package binaries run concurrently. That is the contention source behind this class of flake.
- Within a catch-up pass, indices are still picked at random rather than iterated, so a pass need not cover every index of a multi-part block; successive passes converge. This is #1365's own acknowledged tradeoff, unchanged here.

### Prior work

- #1204 — previous attempt at this test; introduced the mock ticker this PR removes.
- #1352 — hardened `waitForAndValidateBlock`'s failure path; still in place, and what makes these logs legible enough to diagnose.
- #1365 — added the catch-up resend whose unbounded form is fixed here. Its protection is retained, not reverted.

### Attribution

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
