### PR TITLE
fix(statesync): full-node privval error, backfill failure visibility, docs refresh

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1013,7 +1013,8 @@ type StateSyncConfig struct {
 	DiscoveryTime time.Duration `mapstructure:"discovery-time"`
 
 	// Number of times to retry state sync. When retries are exhausted, the node will
-	// fall back to the regular block sync. Set to 0 to disable retries. Default is 3.
+	// fall back to the regular block sync. Set to 0 to retry
+	// indefinitely, never falling back to block sync. Default is 3.
 	//
 	// Note that in pessimistic case, it will take at least `discovery-time * retries` before
 	// falling back to block sync.

--- a/config/toml.go
+++ b/config/toml.go
@@ -508,7 +508,8 @@ rpc-servers = "{{ StringsJoin .StateSync.RPCServers "," }}"
 discovery-time = "{{ .StateSync.DiscoveryTime }}"
 
 # Number of times to retry state sync. When retries are exhausted, the node will
-# fall back to the regular block sync. Set to 0 to disable retries. Default is 3.
+# fall back to the regular block sync. Set to 0 to retry
+# indefinitely, never falling back to block sync. Default is 3.
 # Note that in pessimistic case, it will take at least (discovery-time * retries) before
 # falling back to block sync.
 retries = {{ .StateSync.Retries }}

--- a/docs/nodes/configuration.md
+++ b/docs/nodes/configuration.md
@@ -353,7 +353,8 @@ rpc-servers = ""
 discovery-time = "15s"
 
 # Number of times to retry state sync. When retries are exhausted, the node will
-# fall back to the regular block sync. Set to 0 to disable retries. Default is 3.
+# fall back to the regular block sync. Set to 0 to retry
+# indefinitely, never falling back to block sync. Default is 3.
 # Note that in pessimistic case, it will take at least (discovery-time * retries) before
 # falling back to block sync.
 retries = 3

--- a/docs/nodes/configuration.md
+++ b/docs/nodes/configuration.md
@@ -349,17 +349,14 @@ use-p2p = false
 # for example: "host.example.com:2125"
 rpc-servers = ""
 
-# The hash and height of a trusted block. Must be within the trust-period.
-trust-height = 0
-trust-hash = ""
-
-# The trust period should be set so that Tendermint can detect and gossip misbehavior before
-# it is considered expired. For chains based on the Cosmos SDK, one day less than the unbonding
-# period should suffice.
-trust-period = "168h0m0s"
-
 # Time to spend discovering snapshots before initiating a restore.
 discovery-time = "15s"
+
+# Number of times to retry state sync. When retries are exhausted, the node will
+# fall back to the regular block sync. Set to 0 to disable retries. Default is 3.
+# Note that in pessimistic case, it will take at least (discovery-time * retries) before
+# falling back to block sync.
+retries = 3
 
 # Temporary directory for state sync snapshot chunks, defaults to os.TempDir().
 # The synchronizer will create a new, randomly named directory within this directory

--- a/docs/nodes/state-sync.md
+++ b/docs/nodes/state-sync.md
@@ -24,14 +24,21 @@ out of band. If you are migrating a configuration that still contains
 `trust-height`, `trust-hash`, or `trust-period` under `[statesync]`, remove
 them — they are no longer valid options.
 
+Because light block verification goes through Dash Core, a full node **must**
+be configured with a Dash Core RPC connection or it will refuse to start: set
+`core-rpc-host` (and `core-rpc-username`/`core-rpc-password` as needed) in the
+`[priv-validator]` section of `config.toml`. Validator nodes already have this
+connection configured.
+
 Under the `[statesync]` section in `config.toml` you will find the settings
 that need to be configured in order for your node to use state sync.
 
 Let's break down the settings:
 
 - `enable`: Inform the node that you will be using state sync to bootstrap.
-  This only controls *consuming* snapshots at first start; every node serves
-  snapshots and light blocks to peers regardless of this setting.
+  This only controls *consuming* snapshots at first start; full and validator
+  nodes serve snapshots and light blocks to peers regardless of this setting
+  (seed nodes only run peer exchange and serve neither).
 - `use-p2p`: State sync uses light client verification to verify state. This
   can be done either through the P2P layer or the RPC layer. Set this to `true`
   to use the P2P layer. If `false` (default), the RPC layer will be used.
@@ -41,12 +48,15 @@ Let's break down the settings:
   `net.Dial`, for example: `host.example.com:2125`. Ignored when
   `use-p2p = true`.
 - `discovery-time`: Time to spend discovering snapshots before initiating a
-  restore (default: `15s`). Must be `0s` or at least `5s`.
+  restore (default: `15s`). Must be `0s` or at least `5s`. With `0s` the node
+  gives up as soon as no suitable snapshot is available and falls back to
+  block sync.
 - `retries`: Number of times to retry state sync before giving up. When
   retries are exhausted, the node **falls back to regular block sync**. Set to
-  `0` to disable retries (default: `3`). Note that in the pessimistic case it
-  will take at least `discovery-time * retries` before falling back to block
-  sync.
+  `0` to retry indefinitely — the node keeps requesting snapshots forever and
+  **never** falls back to block sync (default: `3`). Note that in the
+  pessimistic case it will take at least `discovery-time * retries` before
+  falling back to block sync.
 - `temp-dir`: Temporary directory for snapshot chunks; defaults to the
   operating system temporary directory (e.g. `/tmp`). The synchronizer creates
   a new, randomly named directory within it and removes it when the sync is
@@ -56,9 +66,16 @@ Let's break down the settings:
 - `fetchers`: The number of concurrent chunk and block fetchers to run
   (default: `4`).
 
-Example configuration using RPC-based light client verification:
+Example configuration for a full node using RPC-based light client
+verification (the `[priv-validator]` Dash Core connection is required on full
+nodes regardless of state sync):
 
 ```toml
+[priv-validator]
+core-rpc-host = "127.0.0.1:9998"
+core-rpc-username = "dashrpc"
+core-rpc-password = "changeme"
+
 [statesync]
 enable = true
 use-p2p = false
@@ -68,6 +85,11 @@ rpc-servers = "seed-1.example.com:26657,seed-2.example.com:26657"
 Or, using the P2P layer for verification (no RPC servers needed):
 
 ```toml
+[priv-validator]
+core-rpc-host = "127.0.0.1:9998"
+core-rpc-username = "dashrpc"
+core-rpc-password = "changeme"
+
 [statesync]
 enable = true
 use-p2p = true

--- a/docs/nodes/state-sync.md
+++ b/docs/nodes/state-sync.md
@@ -4,39 +4,71 @@ order: 5
 
 # Configure State-Sync
 
-State sync will continuously work in the background to supply nodes with chunked data when bootstrapping.
+State sync rapidly bootstraps a new node by discovering, fetching, and restoring
+a state machine snapshot from peers instead of fetching and replaying historical
+blocks. The node will have a truncated block history, starting from the height
+of the snapshot.
 
-> NOTE: Before trying to use state sync, see if the application you are operating a node for supports it. 
+> NOTE: Before trying to use state sync, see if the application you are
+> operating a node for supports it.
 
-Under the state sync section in `config.toml` you will find multiple settings that need to be configured in order for your node to use state sync.
+State sync is only attempted on first start: if the node already has any local
+state (`LastBlockHeight > 0`), it is skipped and the node falls back to block
+sync.
 
-Lets breakdown the settings:
+Unlike upstream Tendermint, Tenderdash does **not** require trust anchors
+(`trust-height`, `trust-hash`, `trust-period`). Light blocks are verified by
+checking the quorum threshold signature against the active validator quorum via
+Dash Core (`quorum verify`), so there is no need to obtain a trusted block hash
+out of band. If you are migrating a configuration that still contains
+`trust-height`, `trust-hash`, or `trust-period` under `[statesync]`, remove
+them — they are no longer valid options.
 
-- `enable`: Enable is to inform the node that you will be using state sync to bootstrap your node.
-- `rpc_servers`: RPC servers are needed because state sync utilizes the light client for verification. 
-    - 2 servers are required, more is always helpful. 
-- `temp_dir`: Temporary directory is store the chunks in the machines local storage, If nothing is set it will create a directory in `/tmp`
+Under the `[statesync]` section in `config.toml` you will find the settings
+that need to be configured in order for your node to use state sync.
 
-The next information you will need to acquire it through publicly exposed RPC's or a block explorer which you trust. 
+Let's break down the settings:
 
-- `trust_height`: Trusted height defines at which height your node should trust the chain.
-- `trust_hash`: Trusted hash is the hash in the `BlockID` corresponding to the trusted height.
-- `trust_period`: Trust period is the period in which headers can be verified. 
-  > :warning: This value should be significantly smaller than the unbonding period.
+- `enable`: Inform the node that you will be using state sync to bootstrap.
+  This only controls *consuming* snapshots at first start; every node serves
+  snapshots and light blocks to peers regardless of this setting.
+- `use-p2p`: State sync uses light client verification to verify state. This
+  can be done either through the P2P layer or the RPC layer. Set this to `true`
+  to use the P2P layer. If `false` (default), the RPC layer will be used.
+- `rpc-servers`: Comma-separated list of RPC servers used for light client
+  verification when `use-p2p = false`. In that mode at least **two** servers
+  are required (more is always helpful). They should be compatible with
+  `net.Dial`, for example: `host.example.com:2125`. Ignored when
+  `use-p2p = true`.
+- `discovery-time`: Time to spend discovering snapshots before initiating a
+  restore (default: `15s`). Must be `0s` or at least `5s`.
+- `retries`: Number of times to retry state sync before giving up. When
+  retries are exhausted, the node **falls back to regular block sync**. Set to
+  `0` to disable retries (default: `3`). Note that in the pessimistic case it
+  will take at least `discovery-time * retries` before falling back to block
+  sync.
+- `temp-dir`: Temporary directory for snapshot chunks; defaults to the
+  operating system temporary directory (e.g. `/tmp`). The synchronizer creates
+  a new, randomly named directory within it and removes it when the sync is
+  complete.
+- `chunk-request-timeout`: The timeout before re-requesting a chunk, possibly
+  from a different peer (default: `15s`). Must be at least `5s`.
+- `fetchers`: The number of concurrent chunk and block fetchers to run
+  (default: `4`).
 
-If you are relying on publicly exposed RPC's to get the need information, you can use `curl`.
+Example configuration using RPC-based light client verification:
 
-Example: 
-
-```bash
-curl -s https://233.123.0.140:26657/commit | jq "{height: .result.signed_header.header.height, hash: .result.signed_header.commit.block_id.hash}"
+```toml
+[statesync]
+enable = true
+use-p2p = false
+rpc-servers = "seed-1.example.com:26657,seed-2.example.com:26657"
 ```
 
-The response will be: 
+Or, using the P2P layer for verification (no RPC servers needed):
 
-```json
-{
-  "height": "273",
-  "hash": "188F4F36CBCD2C91B57509BBF231C777E79B52EE3E0D90D06B1A25EB16E6E23D"
-}
+```toml
+[statesync]
+enable = true
+use-p2p = true
 ```

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -375,8 +375,10 @@ func (r *Reactor) Sync(ctx context.Context) (sm.State, error) {
 		r.logger.Error("state sync backfill failed; proceeding optimistically. "+
 			"The node is missing historical light blocks within the evidence age and may be "+
 			"unable to validate evidence of misbehavior committed before the snapshot height. "+
-			"Check connectivity to peers that retain older blocks, or restart state sync from "+
-			"a more recent snapshot.",
+			"Check connectivity to peers that retain older blocks. To retry state sync "+
+			"(e.g. from a more recent snapshot), stop the node and reset BOTH the tenderdash "+
+			"data directory and the application state: state sync only runs on first start, "+
+			"and this node has already persisted state at the snapshot height.",
 			"error", err)
 	}
 

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -372,7 +372,12 @@ func (r *Reactor) Sync(ctx context.Context) (sm.State, error) {
 	}
 
 	if err := r.Backfill(ctx, state); err != nil {
-		r.logger.Error("backfill failed. Proceeding optimistically...", "error", err)
+		r.logger.Error("state sync backfill failed; proceeding optimistically. "+
+			"The node is missing historical light blocks within the evidence age and may be "+
+			"unable to validate evidence of misbehavior committed before the snapshot height. "+
+			"Check connectivity to peers that retain older blocks, or restart state sync from "+
+			"a more recent snapshot.",
+			"error", err)
 	}
 
 	if r.eventBus != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -205,18 +206,19 @@ func makeNode(
 		// Special handling on non-Validator nodes
 		logger.Info("this node is NOT a validator")
 
-		if cfg.PrivValidator.CoreRPCHost != "" {
-			dashCoreRPCClient, err = DefaultDashCoreRPCClient(cfg, logger.With("module", core.ModuleName))
-			if err != nil {
-				return nil, fmt.Errorf("failed to create Dash Core RPC client: %w", err)
-			}
-		} else {
-			llmqType := genDoc.QuorumType
-			if err := llmqType.Validate(); err != nil {
-				return nil, fmt.Errorf("invalid genesis quorum type %d: %w", llmqType, err)
-			}
-			// This is used for light client verification only
-			dashCoreRPCClient = core.NewMockClient(cfg.ChainID(), llmqType, privValidator, false)
+		// Full nodes still need a Dash Core RPC connection: light client
+		// verification (used by state sync and evidence handling) checks quorum
+		// threshold signatures via Dash Core. Without core-rpc-host the only
+		// fallback would be a mock client backed by a local private validator,
+		// which a full node does not have.
+		if cfg.PrivValidator.CoreRPCHost == "" {
+			return nil, errors.New("a full node requires a Dash Core RPC connection for light client " +
+				"verification: set core-rpc-host in the [priv-validator] section of config.toml " +
+				"(and core-rpc-username/core-rpc-password as needed)")
+		}
+		dashCoreRPCClient, err = DefaultDashCoreRPCClient(cfg, logger.With("module", core.ModuleName))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Dash Core RPC client: %w", err)
 		}
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -127,6 +127,17 @@ func makeNode(
 	dbProvider config.DBProvider,
 	logger log.Logger,
 ) (service.Service, error) {
+	// Full nodes need a Dash Core RPC connection: the state sync light client
+	// providers verify quorum threshold signatures via Dash Core. Without
+	// core-rpc-host the only fallback would be a mock client backed by a local
+	// private validator, which a full node does not have. Validate this up
+	// front, before any resources (databases, event sinks) are opened.
+	if cfg.Mode == config.ModeFull && cfg.PrivValidator.CoreRPCHost == "" {
+		return nil, errors.New("a full node requires a Dash Core RPC connection for light client " +
+			"verification: set core-rpc-host in the [priv-validator] section of config.toml " +
+			"(and core-rpc-username/core-rpc-password as needed)")
+	}
+
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithCancel(ctx)
 
@@ -206,16 +217,8 @@ func makeNode(
 		// Special handling on non-Validator nodes
 		logger.Info("this node is NOT a validator")
 
-		// Full nodes still need a Dash Core RPC connection: light client
-		// verification (used by state sync and evidence handling) checks quorum
-		// threshold signatures via Dash Core. Without core-rpc-host the only
-		// fallback would be a mock client backed by a local private validator,
-		// which a full node does not have.
-		if cfg.PrivValidator.CoreRPCHost == "" {
-			return nil, errors.New("a full node requires a Dash Core RPC connection for light client " +
-				"verification: set core-rpc-host in the [priv-validator] section of config.toml " +
-				"(and core-rpc-username/core-rpc-password as needed)")
-		}
+		// core-rpc-host is validated at the top of makeNode; the client feeds
+		// the state sync light client providers.
 		dashCoreRPCClient, err = DefaultDashCoreRPCClient(cfg, logger.With("module", core.ModuleName))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Dash Core RPC client: %w", err)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -95,6 +95,52 @@ func TestNodeStartStop(t *testing.T) {
 	require.False(t, n.IsRunning(), "node must shut down")
 }
 
+// TestNodeFullModeRequiresCoreRPCHost ensures that constructing a full node
+// without a Dash Core RPC host fails with a descriptive error (instead of
+// panicking) and does not leak resources: the config is validated before any
+// databases or event sinks are opened.
+func TestNodeFullModeRequiresCoreRPCHost(t *testing.T) {
+	cfg, err := config.ResetTestRoot(t.TempDir(), t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(cfg.RootDir)
+
+	cfg.Mode = config.ModeFull
+	cfg.PrivValidator.CoreRPCHost = ""
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := log.NewTestingLogger(t)
+
+	dirEntries := func(dir string) []string {
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		return names
+	}
+	before := dirEntries(cfg.DBDir())
+
+	ns, err := newDefaultNode(ctx, cfg, logger)
+	require.Error(t, err)
+	require.Nil(t, ns)
+	require.Contains(t, err.Error(), "core-rpc-host")
+
+	// the check must run before any resources are opened: the data directory
+	// must be untouched (no block/state store DBs were created) ...
+	require.Equal(t, before, dirEntries(cfg.DBDir()),
+		"constructor must not open databases before config validation")
+
+	// ... and a retry must fail with the same config error, not a DB-lock
+	// error from handles leaked by the first attempt
+	ns, err = newDefaultNode(ctx, cfg, logger)
+	require.Error(t, err)
+	require.Nil(t, ns)
+	require.Contains(t, err.Error(), "core-rpc-host")
+}
+
 func getTestNode(ctx context.Context, t *testing.T, conf *config.Config, logger log.Logger) *nodeImpl {
 	t.Helper()
 	ctx, cancel := context.WithCancel(ctx)

--- a/spec/p2p/messages/state-sync.md
+++ b/spec/p2p/messages/state-sync.md
@@ -15,67 +15,89 @@ State sync has four distinct channels. The channel identifiers are listed below.
 | LightBlockChannel | 98     |
 | ParamsChannel     | 99     |
 
+## Snapshot and chunk model
+
+Tenderdash uses a content-addressed chunk model that differs from upstream
+Tendermint. A snapshot is identified by its `height`, an application-specific
+`version`, and a `hash`; there is no `format` field and no up-front chunk
+count. Chunks are identified by an opaque, application-defined `chunk_id`
+(in practice the hash of the corresponding node or subtree of the snapshot)
+rather than by a sequential index.
+
+Chunk discovery is driven by the ABCI application during restoration:
+
+1. The syncer requests the first chunk using the snapshot `hash` as the
+   initial `chunk_id`.
+2. Each applied chunk is handed to the application via `ApplySnapshotChunk`;
+   the response's `next_chunks` field lists the chunk IDs to fetch next, and
+   `refetch_chunks` can ask for chunks to be re-fetched.
+3. Restoration terminates when the application returns the
+   `COMPLETE_SNAPSHOT` result — not when a predefined number of chunks has
+   been applied.
+
 ## Message Types
 
-### SnapshotRequest
+### SnapshotsRequest
 
-When a new node begin state syncing, it will ask all peers it encounters if it has any
-available snapshots:
+When a new node begins state syncing, it will ask all peers it encounters if
+they have any available snapshots. The message has no fields:
 
 | Name     | Type   | Description | Field Number |
 |----------|--------|-------------|--------------|
 
-### SnapShotResponse
+### SnapshotsResponse
 
-The receiver will query the local ABCI application via `ListSnapshots`, and send a message
-containing snapshot metadata (limited to 4 MB) for each of the 10 most recent snapshots: and stored at the application layer. When a peer is starting it will request snapshots.  
+The receiver will query the local ABCI application via `ListSnapshots`, and
+send a message containing snapshot metadata (limited to 4 MB) for each of the
+10 most recent snapshots:
 
 | Name     | Type   | Description                                               | Field Number |
 |----------|--------|-----------------------------------------------------------|--------------|
 | height   | uint64 | Height at which the snapshot was taken                    | 1            |
-| format   | uint32 | Format of the snapshot.                                   | 2            |
-| chunks   | uint32 | How many chunks make up the snapshot                      | 3            |
-| hash     | bytes  | Arbitrary snapshot hash                                   | 4            |
-| metadata | bytes  | Arbitrary application data. **May be non-deterministic.** | 5            |
+| version  | uint32 | Application-specific snapshot version                     | 2            |
+| hash     | bytes  | Snapshot hash; also the ID of the first chunk to request  | 3            |
+| metadata | bytes  | Arbitrary application data. **May be non-deterministic.** | 4            |
 
 ### ChunkRequest
 
-The node running state sync will offer these snapshots to the local ABCI application via
-`OfferSnapshot` ABCI calls, and keep track of which peers contain which snapshots. Once a snapshot
-is accepted, the state syncer will request snapshot chunks from appropriate peers:
+The node running state sync will offer these snapshots to the local ABCI
+application via `OfferSnapshot` ABCI calls, and keep track of which peers
+contain which snapshots. Once a snapshot is accepted, the state syncer will
+request snapshot chunks from appropriate peers:
 
-| Name   | Type   | Description                                                 | Field Number |
-|--------|--------|-------------------------------------------------------------|--------------|
-| height | uint64 | Height at which the chunk was created                       | 1            |
-| format | uint32 | Format chosen for the chunk.  **May be non-deterministic.** | 2            |
-| index  | uint32 | Index of the chunk within the snapshot.                     | 3            |
+| Name     | Type   | Description                                 | Field Number |
+|----------|--------|---------------------------------------------|--------------|
+| height   | uint64 | Height at which the snapshot was taken      | 1            |
+| version  | uint32 | Application-specific snapshot version       | 2            |
+| chunk_id | bytes  | Content-addressed ID of the requested chunk | 3            |
 
 ### ChunkResponse
 
-The receiver will load the requested chunk from its local application via `LoadSnapshotChunk`,
-and respond with it (limited to 16 MB):
+The receiver will load the requested chunk from its local application via
+`LoadSnapshotChunk`, and respond with it (limited to 16 MB):
 
-| Name    | Type   | Description                                                 | Field Number |
-|---------|--------|-------------------------------------------------------------|--------------|
-| height  | uint64 | Height at which the chunk was created                       | 1            |
-| format  | uint32 | Format chosen for the chunk.  **May be non-deterministic.** | 2            |
-| index   | uint32 | Index of the chunk within the snapshot.                     | 3            |
-| hash    | bytes  | Arbitrary snapshot hash                                     | 4            |
-| missing | bool   | Arbitrary application data. **May be non-deterministic.**   | 5            |
+| Name     | Type   | Description                                 | Field Number |
+|----------|--------|---------------------------------------------|--------------|
+| height   | uint64 | Height at which the snapshot was taken      | 1            |
+| version  | uint32 | Application-specific snapshot version       | 2            |
+| chunk_id | bytes  | Content-addressed ID of the chunk           | 3            |
+| chunk    | bytes  | Binary chunk contents                       | 4            |
+| missing  | bool   | True if the chunk was not found on the peer | 5            |
 
-Here, `Missing` is used to signify that the chunk was not found on the peer, since an empty
-chunk is a valid (although unlikely) response.
+Here, `missing` is used to signify that the chunk was not found on the peer,
+since an empty chunk is a valid (although unlikely) response.
 
-The returned chunk is given to the ABCI application via `ApplySnapshotChunk` until the snapshot
-is restored. If a chunk response is not returned within some time, it will be re-requested,
-possibly from a different peer.
-
-The ABCI application is able to request peer bans and chunk refetching as part of the ABCI protocol.
+The returned chunk is given to the ABCI application via `ApplySnapshotChunk`.
+The application response determines what happens next: `next_chunks` lists
+further chunk IDs to fetch, `refetch_chunks` requests re-fetching of chunks,
+`reject_senders` requests peer bans, and the `COMPLETE_SNAPSHOT` result ends
+the restoration. If a chunk response is not returned within some time, it will
+be re-requested, possibly from a different peer.
 
 ### LightBlockRequest
 
-To verify state and to provide state relevant information for consensus, the node will ask peers for
-light blocks at specified heights.
+To verify state and to provide state relevant information for consensus, the
+node will ask peers for light blocks at specified heights.
 
 | Name     | Type   | Description                | Field Number |
 |----------|--------|----------------------------|--------------|
@@ -83,52 +105,38 @@ light blocks at specified heights.
 
 ### LightBlockResponse
 
-The receiver will retrieve and construct the light block from both the block and state stores. The
-receiver will verify the data by comparing the hashes and store the header, commit and validator set
-if necessary. The light block at the height of the snapshot will be used to verify the `AppHash`.
+The receiver will retrieve and construct the light block from both the block
+and state stores. The receiver will verify the data by comparing the hashes
+and store the header, commit and validator set if necessary. The light block
+at the height of the snapshot will be used to verify the `AppHash`.
 
 | Name          | Type                                                    | Description                          | Field Number |
 |---------------|---------------------------------------------------------|--------------------------------------|--------------|
 | light_block   | [LightBlock](../../core/data_structures.md#lightblock)  | Light block at the height requested  | 1            |
 
-State sync will use [light client
-verification](https://github.com/tendermint/tendermint/blob/master/docs/tendermint-core/light-client.md)
-to verify the light blocks.
+Unlike upstream Tendermint, light blocks are not verified against a trusted
+header obtained out of band. Tenderdash's light client verifies the quorum
+threshold signature on the block commit via Dash Core (`quorum verify`), so no
+trust anchors (trusted height, hash, or period) are required.
 
-
-If no state sync is in progress (i.e. during normal operation), any unsolicited response messages
-are discarded.
+If no state sync is in progress (i.e. during normal operation), any
+unsolicited response messages are discarded.
 
 ### ParamsRequest
 
-In order to build tendermint state, the state provider will request the params at the height of the snapshot and use the header to verify it.
-
-| Name     | Type   | Description                | Field Number |
-|----------|--------|----------------------------|--------------|
-| height   | uint64 | Height of the consensus params  | 1            |
-
-
-### ParamsResponse
-
-A reciever to the request will use the state store to fetch the consensus params at that height and return it to the sender.
+In order to build tendermint state, the state provider will request the params
+at the height of the snapshot and use the header to verify it.
 
 | Name     | Type   | Description                     | Field Number |
 |----------|--------|---------------------------------|--------------|
 | height   | uint64 | Height of the consensus params  | 1            |
-| consensus_params | [ConsensusParams](../../core/data_structures.md#ConsensusParams) | Consensus params at the height requested | 2 |
 
+### ParamsResponse
 
-### Message
+A receiver to the request will use the state store to fetch the consensus
+params at that height and return it to the sender.
 
-Message is a [`oneof` protobuf type](https://developers.google.com/protocol-buffers/docs/proto#oneof). The `oneof` consists of eight messages.
-
-| Name                 | Type                                       | Description                                  | Field Number |
-|----------------------|--------------------------------------------|----------------------------------------------|--------------|
-| snapshots_request    | [SnapshotRequest](#snapshotrequest)        | Request a recent snapshot from a peer        | 1            |
-| snapshots_response   | [SnapshotResponse](#snapshotresponse)      | Respond with the most recent snapshot stored | 2            |
-| chunk_request        | [ChunkRequest](#chunkrequest)              | Request chunks of the snapshot.              | 3            |
-| chunk_response       | [ChunkRequest](#chunkresponse)             | Response of chunks used to recreate state.   | 4            |
-| light_block_request  | [LightBlockRequest](#lightblockrequest)    | Request a light block.                       | 5            |
-| light_block_response | [LightBlockResponse](#lightblockresponse)  | Respond with a light block                   | 6            |
-| params_request  | [ParamsRequest](#paramsrequest)    | Request the consensus params at a height.                       | 7            |
-| params_response | [ParamsResponse](#paramsresponse)  | Respond with the consensus params                   | 8            |
+| Name             | Type                                                             | Description                              | Field Number |
+|------------------|------------------------------------------------------------------|------------------------------------------|--------------|
+| height           | uint64                                                           | Height of the consensus params           | 1            |
+| consensus_params | [ConsensusParams](../../core/data_structures.md#ConsensusParams) | Consensus params at the height requested | 2            |


### PR DESCRIPTION
## Issue being fixed or feature implemented

Polish pass on state sync ahead of enabling it for Dash Platform nodes: the operator docs no longer match the shipped implementation, non-validator full nodes crash with an unhelpful panic when `core-rpc-host` is unset, and backfill failures are swallowed with no operator guidance.

## What was done?

* Rewrote `docs/nodes/state-sync.md` and fixed `docs/nodes/configuration.md` to match the actual config surface: removed the `trust-height`/`trust-hash`/`trust-period` keys (deleted from the code in 33cda2df), fixed key names to their real dashed forms, documented `use-p2p`, `retries` (with block-sync fallback), the ≥2 `rpc-servers` requirement in RPC mode, and that Dash needs no trust anchors (light blocks are verified via Dash Core quorum signatures).
* Rewrote `spec/p2p/messages/state-sync.md` from the shipped protos: content-addressed `chunk_id`, `next_chunks`-driven fetching, `COMPLETE_SNAPSHOT` terminator, `version`+`hash` snapshot identity (no `format`/`chunks` count).
* `makeNode`: a full node without `[priv-validator] core-rpc-host` previously hit an eager `panic("localPV must be set")` via `core.NewMockClient` with a nil privval. It now returns a configuration error telling the operator exactly what to set. No working configuration changes behavior: the panic fired unconditionally for this mode/config combination, and all CI e2e manifests set `privval_protocol = "dashcore"` on their full nodes.
* Backfill failure in the statesync reactor now logs at error level with consequences and remediation. The proceed-optimistically behavior is unchanged.

## How Has This Been Tested?

`gofmt` clean; `go build ./...` clean; `go test -short ./internal/statesync/... ./light/... ./node/...` all pass.

## Breaking Changes

None. (`test/e2e/networks/ci.toml`'s `full01` still omits `privval_protocol` — it now gets the clear error instead of a panic; that manifest is not in the CI matrix.)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
