### PR TITLE
perf(state): skip the second LastCommit verification when the memo proves it ran

### DIFF
--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -527,7 +527,14 @@ func (blockExec *BlockExecutor) ValidateBlockWithRoundState(
 		)
 	}
 
-	if block.Height > state.InitialHeight {
+	// ValidateBlock above normally verifies block.LastCommit, but it short-circuits
+	// on its per-height cache, which is keyed on the block hash alone and so says
+	// nothing about the state the earlier validation ran against. That is why this
+	// second verification exists. Skip it only when the memo proves this exact
+	// commit was already verified against these exact inputs — same chain, height,
+	// block ID, quorum, threshold key and byte-identical commit — which is a
+	// property of the data rather than of the cache.
+	if block.Height > state.InitialHeight && !blockExec.lastCommitAlreadyVerified(state, block) {
 		if err := state.LastValidators.VerifyCommit(
 			state.ChainID, state.LastBlockID, block.Height-1, block.LastCommit); err != nil {
 			return fmt.Errorf("error validating block: %w", err)


### PR DESCRIPTION
Stacked on #1427 — base is `perf/verify-commit-once`, so the diff here is the 8 lines this change adds. Review #1427 first.

`ValidateBlockWithRoundState` verifies `block.LastCommit` even though the `ValidateBlock` call at the top of the same function normally does it.

That second verification is load-bearing rather than plainly redundant: `ValidateBlock` short-circuits on `blockExec.cache`, which is keyed on the block hash alone and carries no promise about the state the earlier validation ran against. Deleting it outright breaks `TestStateProposalTime`.

So gate it on the memo #1427 introduces instead of on the cache. The skip fires only when this exact commit was already verified against identical inputs — same chain ID, height, block ID, quorum type, quorum hash, threshold public key and byte-identical marshalled commit. That is a property of the data rather than of the cache, so it holds regardless of which path populated the cache.

## Measurements

Same 3,000-block window at mainnet height 190k, on top of #1427:

| | ms/block | `fb_validate` |
|---|---|---|
| #1427 alone | 10.31 | 1.977 ms |
| with this change | **8.36** | **0.010 ms** |

A further −18.9% off the block. Against `v1.7-dev` the pair is 12.81 → 8.36 ms/block, −34.7%: block sync now performs one threshold verification per block instead of three.

Same caveat as #1427 on the measurement method — tenderdash's per-block fsync is removed so macOS `F_FULLFSYNC` does not swamp the result.

## Tests

`internal/state/...`, `internal/blocksync/...`, `internal/consensus` all pass, `TestStateProposalTime` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
