### PR TITLE
perf(blocksync): per-stage apply histograms and an unsafe-no-fsync switch for profiling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -234,6 +234,15 @@ type BaseConfig struct { //nolint: maligned
 	// Default: 0
 	DeadlockDetection time.Duration `mapstructure:"deadlock-detection"`
 
+	// UnsafeNoFsync makes block store and state store writes return before
+	// they have reached the disk. It exists to take the cost of fsync out of a
+	// block sync benchmark. Never enable it on a node whose data matters: a
+	// power loss can leave the stores behind the application, and the node
+	// will refuse to start. See store.WithUnsafeNoFsync.
+	//
+	// Default: false
+	UnsafeNoFsync bool `mapstructure:"unsafe-no-fsync"`
+
 	Other map[string]interface{} `mapstructure:",remain"`
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -142,6 +142,13 @@ filter-peers = {{ .BaseConfig.FilterPeers }}
 # Default: 0
 deadlock-detection = "{{ .BaseConfig.DeadlockDetection }}"
 
+# If true, block store and state store writes return before they have reached
+# the disk. This exists to take the cost of fsync out of a block sync benchmark
+# and nothing else. Never enable it on a node whose data matters: a power loss
+# can leave the stores behind the application, and the node will refuse to start.
+# Default: false
+unsafe-no-fsync = {{ .BaseConfig.UnsafeNoFsync }}
+
 #######################################################
 ###       ABCI App Connection Options               ###
 #######################################################

--- a/config/toml_test.go
+++ b/config/toml_test.go
@@ -121,3 +121,20 @@ func checkConfig(t *testing.T, configFile string) {
 		}
 	}
 }
+
+// The no-fsync switch removes durability, so the generated file must show it
+// off by default and carry the warning next to it, where an operator reading
+// the file will see it before turning it on.
+func TestGeneratedConfigShowsUnsafeNoFsyncOffWithWarning(t *testing.T) {
+	tmpDir := t.TempDir()
+	EnsureRoot(tmpDir)
+	require.NoError(t, WriteConfigFile(tmpDir, DefaultConfig()))
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, defaultConfigFilePath))
+	require.NoError(t, err)
+	rendered := string(data)
+
+	require.Contains(t, rendered, "unsafe-no-fsync = false")
+	require.Contains(t, rendered, "Never enable it on a node whose data matters")
+	require.False(t, DefaultConfig().UnsafeNoFsync, "the default must be durable writes")
+}

--- a/docs/nodes/configuration.md
+++ b/docs/nodes/configuration.md
@@ -78,6 +78,18 @@ abci = "socket"
 # so the app can decide if we should keep the connection or not
 filter-peers = false
 
+# If set to positive duration, deadlock detection is enabled and set to the given time.
+# Use 0 to disable.
+# Default: 0
+deadlock-detection = "0s"
+
+# If true, block store and state store writes return before they have reached
+# the disk. This exists to take the cost of fsync out of a block sync benchmark
+# and nothing else. Never enable it on a node whose data matters: a power loss
+# can leave the stores behind the application, and the node will refuse to start.
+# Default: false
+unsafe-no-fsync = false
+
 
 #######################################################
 ###       Priv Validator Configuration              ###

--- a/docs/nodes/metrics.md
+++ b/docs/nodes/metrics.md
@@ -43,6 +43,7 @@ The following metrics are available:
 | consensus_step_duration                 | Histogram | step            | Histogram of durations for each step in the consensus protocol                                                                             |
 | consensus_block_gossip_receive_latency  | Histogram |                 | Histogram of time taken to receive a block in seconds, measure between when a new block is first discovered to when the block is completed |
 | consensus_block_gossip_parts_received   | Counter   | matches_current | Number of block parts received by the node                                                                                                 |
+| consensus_block_sync_apply_stage_duration | Histogram | stage         | Time a block spent in each stage of the block sync applier, in ms: partset, verify_commit, verify_block, save, exec, and wait (idle time between blocks) |
 | consensus_quorum_prevote_delay          | Gauge     |                 | Interval in seconds between the proposal timestamp and the timestamp of the earliest prevote that achieved a quorum                        |
 | consensus_full_prevote_delay            | Gauge     |                 | Interval in seconds between the proposal timestamp and the timestamp of the latest prevote in a round where all validators voted           |
 | consensus_proposal_timestamp_difference | Histogram |                 | Difference between the timestamp in the proposal message and the local time of the validator at the time it received the message           |
@@ -78,6 +79,7 @@ The following metrics are available:
 | state_block_processing_time             | Histogram |                 | time between BeginBlock and EndBlock in ms                                                                                                 |
 | state_consensus_param_updates           | Counter   |                 | number of consensus parameter updates returned by the application since process start                                                      |
 | state_validator_set_updates             | Counter   |                 | number of validator set updates returned by the application since process start                                                            |
+| state_block_apply_stage_duration        | Histogram | stage           | Time spent in each stage of applying a committed block, in ms: the ABCI calls, the state and ABCI response writes, the mempool update and the event publish |
 
 ## Useful queries
 

--- a/internal/blocksync/applier.go
+++ b/internal/blocksync/applier.go
@@ -64,6 +64,7 @@ func newBlockApplier(blockExec sm.Executor, store sm.BlockStore, opts ...applier
 func (e *blockApplier) Apply(ctx context.Context, block *types.Block, commit *types.Commit) error {
 	e.mtx.Lock()
 	defer e.mtx.Unlock()
+	defer func() { e.lastDone = time.Now() }()
 
 	// Time between the end of the previous apply and the start of this one. With
 	// a fast application this is what the sync rate is actually limited by, and
@@ -106,7 +107,6 @@ func (e *blockApplier) Apply(ctx context.Context, block *types.Block, commit *ty
 	// ByteSize is the size of the serialized block we just built, so the metric
 	// costs nothing extra here
 	e.metrics.RecordConsMetrics(block, blockParts.ByteSize())
-	e.lastDone = time.Now()
 	return nil
 }
 

--- a/internal/blocksync/applier.go
+++ b/internal/blocksync/applier.go
@@ -23,6 +23,9 @@ type (
 		state     sm.State
 		metrics   *consensus.Metrics
 		stats     applyStats
+		// lastDone is when the previous Apply returned, so the time the applier
+		// sits idle waiting for the next block can be measured
+		lastDone time.Time
 	}
 )
 
@@ -62,6 +65,13 @@ func (e *blockApplier) Apply(ctx context.Context, block *types.Block, commit *ty
 	e.mtx.Lock()
 	defer e.mtx.Unlock()
 
+	// Time between the end of the previous apply and the start of this one. With
+	// a fast application this is what the sync rate is actually limited by, and
+	// it is block fetching, not block execution.
+	if !e.lastDone.IsZero() {
+		e.observeSince("wait", e.lastDone)
+	}
+
 	// The part set is needed twice: to derive the block ID and to persist the
 	// block. Building it serializes the whole block and builds a Merkle tree over
 	// the parts, so build it once and pass it to both.
@@ -71,7 +81,7 @@ func (e *blockApplier) Apply(ctx context.Context, block *types.Block, commit *ty
 		return err
 	}
 	blockID := block.BlockID(blockParts)
-	partSetTime := time.Since(start)
+	partSetTime := e.observeSince("partset", start)
 
 	start = time.Now()
 	err = e.verify(ctx, blockID, block, commit)
@@ -82,7 +92,7 @@ func (e *blockApplier) Apply(ctx context.Context, block *types.Block, commit *ty
 
 	start = time.Now()
 	e.store.SaveBlock(block, blockParts, commit)
-	saveTime := time.Since(start)
+	saveTime := e.observeSince("save", start)
 
 	start = time.Now()
 	// TODO: Same thing for app - but we would need a way to get the hash without persisting the state.
@@ -90,12 +100,13 @@ func (e *blockApplier) Apply(ctx context.Context, block *types.Block, commit *ty
 	if err != nil {
 		panic(fmt.Sprintf("failed to process committed block (%d:%X): %v", block.Height, block.Hash(), err))
 	}
-	execTime := time.Since(start)
+	execTime := e.observeSince("exec", start)
 
 	e.stats.add(partSetTime, verifyTime, saveTime, execTime)
 	// ByteSize is the size of the serialized block we just built, so the metric
 	// costs nothing extra here
 	e.metrics.RecordConsMetrics(block, blockParts.ByteSize())
+	e.lastDone = time.Now()
 	return nil
 }
 
@@ -121,7 +132,12 @@ func (e *blockApplier) UpdateState(newState sm.State) {
 }
 
 func (e *blockApplier) verify(ctx context.Context, blockID types.BlockID, block *types.Block, commit *types.Commit) error {
+	// The two checks are timed separately: the commit check is a BLS threshold
+	// signature verification and is nearly the whole stage, block validation is
+	// free.
+	start := time.Now()
 	err := e.state.Validators.VerifyCommit(e.state.ChainID, blockID, block.Height, commit)
+	e.observeSince("verify_commit", start)
 
 	// If either of the checks failed we log the error and request for a new block
 	// at that height
@@ -135,7 +151,9 @@ func (e *blockApplier) verify(ctx context.Context, blockID types.BlockID, block 
 		return err
 	}
 	// validate the block before we persist it
+	start = time.Now()
 	err = e.blockExec.ValidateBlock(ctx, e.state, block)
+	e.observeSince("verify_block", start)
 	if err != nil {
 		err = fmt.Errorf("invalid block: %w", err)
 		e.logger.Error(err.Error(),
@@ -146,6 +164,14 @@ func (e *blockApplier) verify(ctx context.Context, blockID types.BlockID, block 
 		return err
 	}
 	return nil
+}
+
+// observeSince records the time since start under stage and returns it, so the
+// same measurement can also feed the per-block averages in applyStats.
+func (e *blockApplier) observeSince(stage string, start time.Time) time.Duration {
+	elapsed := time.Since(start)
+	e.metrics.ObserveBlockSyncStage(stage, elapsed)
+	return elapsed
 }
 
 // applyTimings is the average time a single block spends in each stage of the

--- a/internal/blocksync/applier_test.go
+++ b/internal/blocksync/applier_test.go
@@ -155,8 +155,8 @@ func TestApplyStatsSubMillisecondPreserved(t *testing.T) {
 // TestBlockApplierRecordsStageMetrics checks that a successful apply records
 // one sample per stage of the pipeline, that the verify stage is split into
 // the commit signature check and block validation, and that the idle time
-// between blocks is only recorded once there is a previous block to measure
-// from.
+// between attempts excludes failed applies and is only recorded once there is
+// a previous attempt to measure from.
 func TestBlockApplierRecordsStageMetrics(t *testing.T) {
 	ctx := context.Background()
 	mockBlockExec := mocks.NewExecutor(t)
@@ -187,10 +187,24 @@ func TestBlockApplierRecordsStageMetrics(t *testing.T) {
 	}
 	require.Empty(t, hist.Samples["wait"], "there is no previous block to wait from on the first apply")
 
-	// the second apply has a previous block, so the idle time between the two
-	// is measured as well
-	require.NoError(t, applier.Apply(ctx, blockH1, commitH1))
+	// A failed attempt must advance the idle-time boundary as well, so a retry
+	// does not count the failed attempt's wait and verification time again.
+	failureStart := time.Now()
+	require.Error(t, applier.Apply(ctx, blockH1, new(types.Commit)))
+	failureEnd := time.Now()
+	failureDone := applier.lastDone
+	require.False(t, failureDone.Before(failureStart), "failed apply must advance lastDone")
+	require.False(t, failureDone.After(failureEnd), "lastDone must be set before Apply returns")
 	require.Len(t, hist.Samples["wait"], 1)
+
+	// The retry measures only the idle time after the failed attempt.
+	retryStart := time.Now()
+	require.NoError(t, applier.Apply(ctx, blockH1, commitH1))
+	retryEnd := time.Now()
+	require.Len(t, hist.Samples["wait"], 2)
+	wait := hist.Samples["wait"][1]
+	require.GreaterOrEqual(t, wait, float64(retryStart.Sub(failureDone))/float64(time.Millisecond))
+	require.LessOrEqual(t, wait, float64(retryEnd.Sub(failureDone))/float64(time.Millisecond))
 	require.Len(t, hist.Samples["exec"], 2)
 }
 

--- a/internal/blocksync/applier_test.go
+++ b/internal/blocksync/applier_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dashpay/tenderdash/internal/consensus"
 	"github.com/dashpay/tenderdash/internal/state/mocks"
 	statefactory "github.com/dashpay/tenderdash/internal/state/test/factory"
 	"github.com/dashpay/tenderdash/internal/test/factory"
+	"github.com/dashpay/tenderdash/internal/test/metricspy"
 	tmrequire "github.com/dashpay/tenderdash/internal/test/require"
 	"github.com/dashpay/tenderdash/types"
 )
@@ -148,4 +150,75 @@ func TestApplyStatsSubMillisecondPreserved(t *testing.T) {
 	require.True(t, measured)
 	require.Equal(t, 300*time.Microsecond, timings.PartSet)
 	require.Zero(t, timings.PartSet.Milliseconds(), "the value this test exists to protect")
+}
+
+// TestBlockApplierRecordsStageMetrics checks that a successful apply records
+// one sample per stage of the pipeline, that the verify stage is split into
+// the commit signature check and block validation, and that the idle time
+// between blocks is only recorded once there is a previous block to measure
+// from.
+func TestBlockApplierRecordsStageMetrics(t *testing.T) {
+	ctx := context.Background()
+	mockBlockExec := mocks.NewExecutor(t)
+	mockBlockStore := mocks.NewBlockStore(t)
+	valSet, privVals := factory.MockValidatorSet()
+	initialState := fakeInitialState(valSet)
+	state := initialState.Copy()
+	blocks := statefactory.MakeBlocks(ctx, t, 2, &state, privVals, 1)
+	blockH1 := blocks[0]
+	commitH1 := blocks[1].LastCommit
+
+	mockBlockStore.On("SaveBlock", blockH1, mock.Anything, commitH1).Twice()
+	mockBlockExec.On("ValidateBlock", mock.Anything, mock.Anything, blockH1).Twice().Return(nil)
+	mockBlockExec.On("ApplyBlock", mock.Anything, mock.Anything, mock.Anything, blockH1, commitH1).
+		Twice().Return(initialState, nil)
+
+	hist := metricspy.NewHistogram("stage")
+	m := consensus.NopMetrics()
+	m.BlockSyncApplyStageDuration = hist
+	applier := newBlockApplier(mockBlockExec, mockBlockStore,
+		applierWithState(initialState), applierWithMetrics(m))
+
+	require.NoError(t, applier.Apply(ctx, blockH1, commitH1))
+
+	for _, stage := range []string{"partset", "verify_commit", "verify_block", "save", "exec"} {
+		require.Len(t, hist.Samples[stage], 1, "stage %q after the first apply", stage)
+		require.GreaterOrEqual(t, hist.Samples[stage][0], 0.0, "stage %q", stage)
+	}
+	require.Empty(t, hist.Samples["wait"], "there is no previous block to wait from on the first apply")
+
+	// the second apply has a previous block, so the idle time between the two
+	// is measured as well
+	require.NoError(t, applier.Apply(ctx, blockH1, commitH1))
+	require.Len(t, hist.Samples["wait"], 1)
+	require.Len(t, hist.Samples["exec"], 2)
+}
+
+// TestBlockApplierVerifyFailureTimesOnlyTheCheckThatRan guards the attribution
+// of a failed verify: when the commit check fails, block validation never runs
+// and must not get a sample, so repeated bad commits do not skew its mean.
+func TestBlockApplierVerifyFailureTimesOnlyTheCheckThatRan(t *testing.T) {
+	ctx := context.Background()
+	mockBlockExec := mocks.NewExecutor(t)
+	mockBlockStore := mocks.NewBlockStore(t)
+	valSet, privVals := factory.MockValidatorSet()
+	initialState := fakeInitialState(valSet)
+	state := initialState.Copy()
+	blocks := statefactory.MakeBlocks(ctx, t, 2, &state, privVals, 1)
+	blockH1 := blocks[0]
+
+	hist := metricspy.NewHistogram("stage")
+	m := consensus.NopMetrics()
+	m.BlockSyncApplyStageDuration = hist
+	applier := newBlockApplier(mockBlockExec, mockBlockStore,
+		applierWithState(initialState), applierWithMetrics(m))
+
+	// an empty commit fails the signature check before ValidateBlock is reached
+	require.Error(t, applier.Apply(ctx, blockH1, new(types.Commit)))
+
+	require.Len(t, hist.Samples["partset"], 1)
+	require.Len(t, hist.Samples["verify_commit"], 1)
+	require.Empty(t, hist.Samples["verify_block"], "block validation did not run")
+	require.Empty(t, hist.Samples["save"])
+	require.Empty(t, hist.Samples["exec"])
 }

--- a/internal/consensus/metrics.gen.go
+++ b/internal/consensus/metrics.gen.go
@@ -264,6 +264,14 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "peer_lane_max_depth",
 			Help:      "Largest number of messages queued in any single peer lane.",
 		}, labels).With(labelsAndValues...),
+		BlockSyncApplyStageDuration: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "block_sync_apply_stage_duration",
+			Help:      "Time spent in each stage of applying a block during block sync, in milliseconds.",
+
+			Buckets: stdprometheus.ExponentialBucketsRange(0.01, 1000, 12),
+		}, append(labels, "stage")).With(labelsAndValues...),
 	}
 }
 
@@ -309,5 +317,6 @@ func NopMetrics() *Metrics {
 		VerificationBudgetSaturation: discard.NewGauge(),
 		PeerLaneActiveCount:          discard.NewGauge(),
 		PeerLaneMaxDepth:             discard.NewGauge(),
+		BlockSyncApplyStageDuration:  discard.NewHistogram(),
 	}
 }

--- a/internal/consensus/metrics.go
+++ b/internal/consensus/metrics.go
@@ -201,6 +201,18 @@ type Metrics struct {
 	// fairness pressure is felt first.
 	//metrics:Largest number of messages queued in any single peer lane.
 	PeerLaneMaxDepth metrics.Gauge
+
+	// BlockSyncApplyStageDuration is the wall-clock cost of each stage the block
+	// sync applier takes a fetched block through, plus "wait": the idle time
+	// between blocks, which is block fetching holding the sync back.
+	//metrics:Time spent in each stage of applying a block during block sync, in milliseconds.
+	BlockSyncApplyStageDuration metrics.Histogram `metrics_labels:"stage" metrics_buckettype:"exprange" metrics_bucketsizes:"0.01, 1000, 12"`
+}
+
+// ObserveBlockSyncStage records the time a block spent in one stage of the
+// block sync apply pipeline.
+func (m *Metrics) ObserveBlockSyncStage(stage string, d time.Duration) {
+	m.BlockSyncApplyStageDuration.With("stage", stage).Observe(float64(d) / float64(time.Millisecond))
 }
 
 // RecordConsMetrics uses for recording the block related metrics during fast-sync.

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -77,7 +77,7 @@ func NewFromConfig(logger log.Logger, cfg *config.Config) (*Inspector, error) {
 	if err != nil {
 		return nil, err
 	}
-	ss := state.NewStore(sDB, logger.With("module", "state_store"))
+	ss := state.NewStore(sDB, state.StoreWithLogger(logger.With("module", "state_store")))
 	return New(cfg.RPC, bs, ss, sinks, logger), nil
 }
 

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -336,6 +336,7 @@ func (blockExec *BlockExecutor) ProcessProposal(
 	verify bool,
 ) (CurrentRoundState, error) {
 	version := block.Version.ToProto()
+	stages := blockExec.metrics.startStages()
 	resp, err := blockExec.appClient.ProcessProposal(ctx, &abci.RequestProcessProposal{
 		Hash:               block.Header.Hash(),
 		Height:             block.Header.Height,
@@ -370,6 +371,8 @@ func (blockExec *BlockExecutor) ProcessProposal(
 		return CurrentRoundState{}, fmt.Errorf("invalid tx results: %w", err)
 	}
 
+	stages.done("process_proposal_abci")
+
 	rp := RoundParamsFromProcessProposal(resp, block.CoreChainLock, round)
 
 	// update some round state data
@@ -385,6 +388,8 @@ func (blockExec *BlockExecutor) ProcessProposal(
 		return stateChanges, errors.New("invalid App Hash size")
 	}
 
+	stages.done("process_proposal_changeset")
+
 	if verify {
 		// Here we check if the ProcessProposal response matches
 		// block received from proposer, eg. if `uncommittedState`
@@ -393,6 +398,7 @@ func (blockExec *BlockExecutor) ProcessProposal(
 		if err != nil {
 			return stateChanges, ErrInvalidBlock{err}
 		}
+		stages.done("process_proposal_validate")
 	}
 
 	return stateChanges, nil
@@ -497,9 +503,11 @@ func (blockExec *BlockExecutor) FinalizeBlock(
 	// the time block sync gets here the block has already been delivered to the
 	// app by ProcessProposal and written by blockApplier.Apply; what this guards
 	// is the state and ABCI responses written below.
+	stages := blockExec.metrics.startStages()
 	if err := blockExec.ValidateBlockWithRoundState(ctx, state, uncommittedState, block); err != nil {
 		return state, ErrInvalidBlock{err}
 	}
+	stages.done("finalize_validate")
 
 	// Save ResponseProcessProposal before FinalizeBlock to be able to recover when app state is ahead of tenderdash state
 	// (eg. when tenderdash fails just after receiving ResponseFinalizeBlock).
@@ -509,6 +517,7 @@ func (blockExec *BlockExecutor) FinalizeBlock(
 	if err := blockExec.store.SaveABCIResponses(block.Height, abciResponses); err != nil {
 		return state, err
 	}
+	stages.done("finalize_save_abci_responses")
 
 	startTime := time.Now().UnixNano()
 	fbResp, err := execBlockWithoutState(ctx, blockExec.appClient, block, commit, blockExec.logger)
@@ -517,26 +526,32 @@ func (blockExec *BlockExecutor) FinalizeBlock(
 	}
 	endTime := time.Now().UnixNano()
 	blockExec.metrics.BlockProcessingTime.Observe(float64(endTime-startTime) / 1000000)
+	stages.done("finalize_block_abci")
 
 	if state, err = state.Update(blockID, &block.Header, &uncommittedState); err != nil {
 		return state, fmt.Errorf("commit failed for application: %w", err)
 	}
+	stages.done("finalize_state_update")
 
 	// Lock mempool, commit app state, update mempoool.
 	err = blockExec.flushMempool(ctx, state, block, uncommittedState.TxResults)
 	if err != nil {
 		return state, fmt.Errorf("commit failed for application: %w", err)
 	}
+	stages.done("finalize_mempool")
 
 	// Update evpool with the latest state.
 	blockExec.evpool.Update(ctx, state, block.Evidence)
+	stages.done("finalize_evidence_pool")
 
 	if err = blockExec.store.Save(state); err != nil {
 		return state, err
 	}
+	stages.done("finalize_save_state")
 
 	// Prune old heights, if requested by ABCI app
 	blockExec.pruneBlocks(fbResp.RetainHeight)
+	stages.done("finalize_prune")
 
 	// reset the verification cache
 	blockExec.cache = make(map[string]struct{})
@@ -547,6 +562,7 @@ func (blockExec *BlockExecutor) FinalizeBlock(
 	if err = es.Publish(blockExec.eventPublisher); err != nil {
 		blockExec.logger.Error("failed publishing event", "err", err)
 	}
+	stages.done("finalize_publish_events")
 
 	return state, nil
 }

--- a/internal/state/metrics.gen.go
+++ b/internal/state/metrics.gen.go
@@ -34,13 +34,22 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "validator_set_updates",
 			Help:      "Number of validator set updates returned by the application since process start.",
 		}, labels).With(labelsAndValues...),
+		BlockApplyStageDuration: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "block_apply_stage_duration",
+			Help:      "Time spent in each stage of applying a committed block, in milliseconds.",
+
+			Buckets: stdprometheus.ExponentialBucketsRange(0.01, 1000, 12),
+		}, append(labels, "stage")).With(labelsAndValues...),
 	}
 }
 
 func NopMetrics() *Metrics {
 	return &Metrics{
-		BlockProcessingTime:   discard.NewHistogram(),
-		ConsensusParamUpdates: discard.NewCounter(),
-		ValidatorSetUpdates:   discard.NewCounter(),
+		BlockProcessingTime:     discard.NewHistogram(),
+		ConsensusParamUpdates:   discard.NewCounter(),
+		ValidatorSetUpdates:     discard.NewCounter(),
+		BlockApplyStageDuration: discard.NewHistogram(),
 	}
 }

--- a/internal/state/metrics.go
+++ b/internal/state/metrics.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"time"
+
 	"github.com/go-kit/kit/metrics"
 )
 
@@ -26,4 +28,31 @@ type Metrics struct {
 	// udated the validator set since process start.
 	//metrics:Number of validator set updates returned by the application since process start.
 	ValidatorSetUpdates metrics.Counter
+
+	// BlockApplyStageDuration is the wall-clock cost of each stage a committed
+	// block goes through in ProcessProposal and FinalizeBlock. During block sync
+	// those stages are most of a block; this says which one a slow sync is in.
+	//metrics:Time spent in each stage of applying a committed block, in milliseconds.
+	BlockApplyStageDuration metrics.Histogram `metrics_labels:"stage" metrics_buckettype:"exprange" metrics_bucketsizes:"0.01, 1000, 12"`
+}
+
+// stageTimer attributes the time between successive calls to done to a named
+// stage of BlockApplyStageDuration.
+type stageTimer struct {
+	h    metrics.Histogram
+	last time.Time
+}
+
+// startStages begins timing stages of a block apply; the first stage is
+// measured from this moment.
+func (m *Metrics) startStages() *stageTimer {
+	return &stageTimer{h: m.BlockApplyStageDuration, last: time.Now()}
+}
+
+// done records the time since the previous stage ended under stage, and starts
+// the next one.
+func (t *stageTimer) done(stage string) {
+	now := time.Now()
+	t.h.With("stage", stage).Observe(float64(now.Sub(t.last)) / float64(time.Millisecond))
+	t.last = now
 }

--- a/internal/state/metrics_test.go
+++ b/internal/state/metrics_test.go
@@ -19,15 +19,16 @@ func TestStageTimerAttributesEachIntervalOnce(t *testing.T) {
 	m.BlockApplyStageDuration = h
 
 	timer := m.startStages()
-	time.Sleep(20 * time.Millisecond)
+	start := timer.last
 	timer.done("first")
-	time.Sleep(2 * time.Millisecond)
+	firstDone := timer.last
 	timer.done("second")
+	secondDone := timer.last
 
 	require.Len(t, h.Samples["first"], 1)
 	require.Len(t, h.Samples["second"], 1)
-	require.GreaterOrEqual(t, h.Samples["first"][0], 20.0, "first stage covers its own sleep, in ms")
-	require.Less(t, h.Samples["second"][0], 20.0, "second stage must not include the first")
+	require.Equal(t, float64(firstDone.Sub(start))/float64(time.Millisecond), h.Samples["first"][0])
+	require.Equal(t, float64(secondDone.Sub(firstDone))/float64(time.Millisecond), h.Samples["second"][0])
 }
 
 // TestStageTimerNopMetricsIsSilent guards the default: with NopMetrics the

--- a/internal/state/metrics_test.go
+++ b/internal/state/metrics_test.go
@@ -1,0 +1,38 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dashpay/tenderdash/internal/test/metricspy"
+)
+
+// TestStageTimerAttributesEachIntervalOnce checks that consecutive done calls
+// carve the elapsed time into non-overlapping intervals, each recorded under
+// its own stage label in milliseconds, so the stage histograms sum to the
+// whole apply rather than counting early stages several times.
+func TestStageTimerAttributesEachIntervalOnce(t *testing.T) {
+	h := metricspy.NewHistogram("stage")
+	m := NopMetrics()
+	m.BlockApplyStageDuration = h
+
+	timer := m.startStages()
+	time.Sleep(20 * time.Millisecond)
+	timer.done("first")
+	time.Sleep(2 * time.Millisecond)
+	timer.done("second")
+
+	require.Len(t, h.Samples["first"], 1)
+	require.Len(t, h.Samples["second"], 1)
+	require.GreaterOrEqual(t, h.Samples["first"][0], 20.0, "first stage covers its own sleep, in ms")
+	require.Less(t, h.Samples["second"][0], 20.0, "second stage must not include the first")
+}
+
+// TestStageTimerNopMetricsIsSilent guards the default: with NopMetrics the
+// stage timer costs two clock reads and records nothing.
+func TestStageTimerNopMetricsIsSilent(t *testing.T) {
+	timer := NopMetrics().startStages()
+	require.NotPanics(t, func() { timer.done("anything") })
+}

--- a/internal/state/nofsync_test.go
+++ b/internal/state/nofsync_test.go
@@ -1,0 +1,78 @@
+package state_test
+
+import (
+	"testing"
+
+	dbm "github.com/cometbft/cometbft-db"
+	"github.com/stretchr/testify/require"
+
+	abci "github.com/dashpay/tenderdash/abci/types"
+	sm "github.com/dashpay/tenderdash/internal/state"
+	"github.com/dashpay/tenderdash/internal/test/dbspy"
+	tmstate "github.com/dashpay/tenderdash/proto/tendermint/state"
+)
+
+func saveStateAndResponses(t *testing.T, store sm.Store) sm.State {
+	t.Helper()
+	state, _, _ := makeState(t, 1, 1)
+	require.NoError(t, store.Save(state))
+	require.NoError(t, store.SaveABCIResponses(1, tmstate.ABCIResponses{
+		ProcessProposal: &abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_ACCEPT},
+	}))
+	return state
+}
+
+// TestStateStoreWritesAreDurableByDefault pins the default: without options
+// the state and the ABCI responses are written with the syncing variants.
+func TestStateStoreWritesAreDurableByDefault(t *testing.T) {
+	db := dbspy.New(dbm.NewMemDB())
+	store := sm.NewStore(db)
+
+	state := saveStateAndResponses(t, store)
+
+	require.Equal(t, 1, db.SyncWrites, "Save must fsync by default")
+	require.Equal(t, 1, db.SyncSets, "SaveABCIResponses must fsync by default")
+	require.Zero(t, db.Writes)
+	require.Zero(t, db.Sets)
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	require.Equal(t, state.LastBlockHeight, loaded.LastBlockHeight)
+}
+
+// TestStateStoreUnsafeNoFsyncSkipsSync checks the benchmark switch selects the
+// non-syncing writes for both the batch and the single-key paths, stores the
+// same data, and applies only to the store it was passed to.
+func TestStateStoreUnsafeNoFsyncSkipsSync(t *testing.T) {
+	db := dbspy.New(dbm.NewMemDB())
+	store := sm.NewStore(db, sm.StoreWithUnsafeNoFsync())
+
+	state := saveStateAndResponses(t, store)
+
+	require.Equal(t, 1, db.Writes, "Save must not fsync with StoreWithUnsafeNoFsync")
+	require.Equal(t, 1, db.Sets, "SaveABCIResponses must not fsync with StoreWithUnsafeNoFsync")
+	require.Zero(t, db.SyncWrites)
+	require.Zero(t, db.SyncSets)
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	require.Equal(t, state.LastBlockHeight, loaded.LastBlockHeight)
+	resp, err := store.LoadABCIResponses(1)
+	require.NoError(t, err)
+	require.Equal(t, abci.ResponseProcessProposal_ACCEPT, resp.ProcessProposal.Status)
+
+	// another store over another DB keeps the default
+	other := dbspy.New(dbm.NewMemDB())
+	saveStateAndResponses(t, sm.NewStore(other))
+	require.Equal(t, 1, other.SyncWrites)
+	require.Equal(t, 1, other.SyncSets)
+	require.Zero(t, other.Writes)
+	require.Zero(t, other.Sets)
+}
+
+// TestNewStoreNilLoggerIsIgnored keeps the old contract that a nil logger
+// falls back to the nop logger rather than a nil dereference on first use.
+func TestNewStoreNilLoggerIsIgnored(t *testing.T) {
+	store := sm.NewStore(dbm.NewMemDB(), sm.StoreWithLogger(nil))
+	require.NotPanics(t, func() { _ = store.PruneStates(1) })
+}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -117,33 +117,61 @@ type Store interface {
 type dbStore struct {
 	db     dbm.DB
 	logger log.Logger
+
+	// unsafeNoFsync drops the fsync from every write. See StoreWithUnsafeNoFsync.
+	unsafeNoFsync bool
 }
 
 var _ Store = (*dbStore)(nil)
 
-// NewStore creates the dbStore of the state pkg.
-//
-// ## Parameters
-//
-//   - `db` - the database to use
-//   - `logger` - the logger to use; optional, defaults to a nop logger if not provided; if more than one is provided,
-//     it will panic
-//
-// ##Panics
-//
-// If more than one logger is provided.
-func NewStore(db dbm.DB, logger ...log.Logger) Store {
-	// To avoid changing the API, we use `logger ...log.Logger` in function signature, so that old code can
-	// provide only `db`. In this case, we use NopLogger.
-	if len(logger) == 0 || logger[0] == nil {
-		logger = []log.Logger{log.NewNopLogger()}
-	}
+// StoreOption configures the store returned by NewStore.
+type StoreOption func(*dbStore)
 
-	if len(logger) > 1 {
-		panic("NewStore(): maximum one logger is allowed")
+// StoreWithLogger sets the logger of the store. A nil logger is ignored.
+func StoreWithLogger(logger log.Logger) StoreOption {
+	return func(s *dbStore) {
+		if logger != nil {
+			s.logger = logger
+		}
 	}
+}
 
-	return dbStore{db, logger[0]}
+// StoreWithUnsafeNoFsync is the state-store half of the block store's
+// WithUnsafeNoFsync: writes return before they have reached the disk. It is a
+// benchmarking aid. Never use it on a node whose data matters: a power loss can
+// leave the state store behind the application.
+func StoreWithUnsafeNoFsync() StoreOption {
+	return func(s *dbStore) {
+		s.unsafeNoFsync = true
+	}
+}
+
+// NewStore creates the dbStore of the state pkg, backed by db. Without options
+// it logs nowhere and every write is durable.
+func NewStore(db dbm.DB, opts ...StoreOption) Store {
+	store := dbStore{db: db, logger: log.NewNopLogger()}
+	for _, opt := range opts {
+		opt(&store)
+	}
+	return store
+}
+
+// writeBatch commits a batch durably, unless the store was built with
+// StoreWithUnsafeNoFsync.
+func (store dbStore) writeBatch(batch dbm.Batch) error {
+	if store.unsafeNoFsync {
+		return batch.Write()
+	}
+	return batch.WriteSync()
+}
+
+// set writes a single key durably, unless the store was built with
+// StoreWithUnsafeNoFsync.
+func (store dbStore) set(key, value []byte) error {
+	if store.unsafeNoFsync {
+		return store.db.Set(key, value)
+	}
+	return store.db.SetSync(key, value)
 }
 
 // Load loads the State from the database.
@@ -217,7 +245,7 @@ func (store dbStore) save(state State, key []byte) error {
 		return err
 	}
 
-	return batch.WriteSync()
+	return store.writeBatch(batch)
 }
 
 // BootstrapState saves a new state, used e.g. by state sync when starting from non-zero height.
@@ -254,7 +282,7 @@ func (store dbStore) Bootstrap(state State) error {
 		return err
 	}
 
-	return batch.WriteSync()
+	return store.writeBatch(batch)
 }
 
 // PruneStates deletes states up to the height specified (exclusive). It is not
@@ -415,7 +443,7 @@ func (store dbStore) pruneRange(start []byte, end []byte) error {
 		}
 	}
 
-	return batch.WriteSync()
+	return store.writeBatch(batch)
 }
 
 // reverseBatchDelete runs a reverse iterator (from end to start) filling up a batch until either
@@ -497,7 +525,7 @@ func (store dbStore) saveABCIResponses(height int64, abciResponses tmstate.ABCIR
 	if err != nil {
 		return err
 	}
-	return store.db.SetSync(abciResponsesKey(height), bz)
+	return store.set(abciResponsesKey(height), bz)
 }
 
 // SaveValidatorSets is used to save the validator set over multiple heights.
@@ -515,7 +543,7 @@ func (store dbStore) SaveValidatorSets(lowerHeight, upperHeight int64, vals *typ
 		}
 	}
 
-	return batch.WriteSync()
+	return store.writeBatch(batch)
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -203,7 +203,7 @@ func TestStoreLoadValidatorsOnRotation(t *testing.T) {
 			uncommittedHeight := startHeight + rotations*int64(nVals)
 
 			stateDB := dbm.NewMemDB()
-			stateStore := sm.NewStore(stateDB, log.NewTestingLoggerWithLevel(t, log.LogLevelDebug))
+			stateStore := sm.NewStore(stateDB, sm.StoreWithLogger(log.NewTestingLoggerWithLevel(t, log.LogLevelDebug)))
 
 			validators := make([]*types.ValidatorSet, nValSets)
 			for i := int64(0); i < nValSets; i++ {

--- a/internal/store/nofsync_test.go
+++ b/internal/store/nofsync_test.go
@@ -1,0 +1,69 @@
+package store
+
+import (
+	"testing"
+
+	dbm "github.com/cometbft/cometbft-db"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dashpay/tenderdash/config"
+	sm "github.com/dashpay/tenderdash/internal/state"
+	"github.com/dashpay/tenderdash/internal/state/test/factory"
+	"github.com/dashpay/tenderdash/internal/test/dbspy"
+	"github.com/dashpay/tenderdash/types"
+)
+
+func saveOneBlock(t *testing.T, bs *BlockStore) *types.Block {
+	t.Helper()
+	cfg, err := config.ResetTestRoot(t.TempDir(), "nofsync_test")
+	require.NoError(t, err)
+	state, err := sm.MakeGenesisStateFromFile(cfg.GenesisFile())
+	require.NoError(t, err)
+	block, err := factory.MakeBlock(state, 1, new(types.Commit), 0)
+	require.NoError(t, err)
+	parts, err := block.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	bs.SaveBlock(block, parts, makeTestCommit(t, state, 1))
+	return block
+}
+
+// TestBlockStoreWritesAreDurableByDefault pins the default: a store built
+// without options commits every batch with WriteSync.
+func TestBlockStoreWritesAreDurableByDefault(t *testing.T) {
+	db := dbspy.New(dbm.NewMemDB())
+	bs := NewBlockStore(db)
+
+	block := saveOneBlock(t, bs)
+
+	require.Equal(t, 1, db.SyncWrites, "SaveBlock must fsync by default")
+	require.Zero(t, db.Writes)
+	require.False(t, bs.UnsafeNoFsync())
+	require.Equal(t, block.Hash(), bs.LoadBlock(1).Hash())
+}
+
+// TestBlockStoreUnsafeNoFsyncSkipsSync checks the benchmark switch selects the
+// non-syncing write and stores exactly the same data, and that it is a
+// property of the one store it was passed to, not of the process.
+func TestBlockStoreUnsafeNoFsyncSkipsSync(t *testing.T) {
+	db := dbspy.New(dbm.NewMemDB())
+	bs := NewBlockStore(db, WithUnsafeNoFsync())
+
+	block := saveOneBlock(t, bs)
+
+	require.True(t, bs.UnsafeNoFsync())
+	require.Equal(t, 1, db.Writes, "SaveBlock must not fsync with WithUnsafeNoFsync")
+	require.Zero(t, db.SyncWrites)
+	require.Equal(t, block.Hash(), bs.LoadBlock(1).Hash())
+
+	// deletions go through the same policy
+	_, err := bs.DeleteBlock(1)
+	require.NoError(t, err)
+	require.Equal(t, 2, db.Writes)
+	require.Zero(t, db.SyncWrites)
+
+	// another store over another DB is unaffected
+	other := dbspy.New(dbm.NewMemDB())
+	saveOneBlock(t, NewBlockStore(other))
+	require.Equal(t, 1, other.SyncWrites)
+	require.Zero(t, other.Writes)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -33,12 +33,51 @@ The store can be assumed to contain all contiguous blocks between base and heigh
 */
 type BlockStore struct {
 	db dbm.DB
+
+	// unsafeNoFsync drops the fsync from every write. See WithUnsafeNoFsync.
+	unsafeNoFsync bool
+}
+
+// Option configures a BlockStore at construction.
+type Option func(*BlockStore)
+
+// WithUnsafeNoFsync makes every write to the block store return before it has
+// reached the disk. It exists for benchmarking: on macOS Go's File.Sync issues
+// F_FULLFSYNC, which costs several milliseconds per call and swamps everything
+// else in a block sync profile, while on Linux the same call is a plain fsync
+// costing a fraction of that. Dropping it takes durability out of the
+// measurement.
+//
+// Never use it on a node whose data matters: a power loss can leave the block
+// store behind the application, which the replayer rejects with
+// ErrAppBlockHeightTooHigh.
+func WithUnsafeNoFsync() Option {
+	return func(bs *BlockStore) {
+		bs.unsafeNoFsync = true
+	}
 }
 
 // NewBlockStore returns a new BlockStore with the given DB,
 // initialized to the last height that was committed to the DB.
-func NewBlockStore(db dbm.DB) *BlockStore {
-	return &BlockStore{db}
+func NewBlockStore(db dbm.DB, opts ...Option) *BlockStore {
+	bs := &BlockStore{db: db}
+	for _, opt := range opts {
+		opt(bs)
+	}
+	return bs
+}
+
+// UnsafeNoFsync reports whether this store's writes skip the fsync. It exists
+// so callers that wire the store from config can assert what they built.
+func (bs *BlockStore) UnsafeNoFsync() bool { return bs.unsafeNoFsync }
+
+// writeBatch commits a batch durably, unless the store was built with
+// WithUnsafeNoFsync.
+func (bs *BlockStore) writeBatch(batch dbm.Batch) error {
+	if bs.unsafeNoFsync {
+		return batch.Write()
+	}
+	return batch.WriteSync()
 }
 
 // Base returns the first known contiguous block height, or 0 for empty block stores.
@@ -402,7 +441,7 @@ func (bs *BlockStore) DeleteBlock(height int64) (uint64, error) {
 	}
 
 	// Write all deletions atomically
-	if err := batch.WriteSync(); err != nil {
+	if err := bs.writeBatch(batch); err != nil {
 		return 0, fmt.Errorf("failed to write deletions for height %d: %w", height, err)
 	}
 
@@ -454,7 +493,7 @@ func (bs *BlockStore) pruneRange(
 	}
 
 	// once we looped over all keys we do a final flush to disk
-	if err := batch.WriteSync(); err != nil {
+	if err := bs.writeBatch(batch); err != nil {
 		return totalPruned, err
 	}
 	totalPruned += pruned
@@ -512,7 +551,7 @@ func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, s
 		panic(err)
 	}
 
-	if err := batch.WriteSync(); err != nil {
+	if err := bs.writeBatch(batch); err != nil {
 		panic(err)
 	}
 
@@ -640,7 +679,7 @@ func (bs *BlockStore) SaveSignedHeader(sh *types.SignedHeader, blockID types.Blo
 		return fmt.Errorf("unable to save commit: %w", err)
 	}
 
-	if err := batch.WriteSync(); err != nil {
+	if err := bs.writeBatch(batch); err != nil {
 		return err
 	}
 

--- a/internal/test/dbspy/dbspy.go
+++ b/internal/test/dbspy/dbspy.go
@@ -1,0 +1,42 @@
+// Package dbspy provides a dbm.DB wrapper that counts how each write was
+// committed, so a test can tell a durable write from one that skipped the
+// fsync.
+package dbspy
+
+import dbm "github.com/cometbft/cometbft-db"
+
+// DB counts the syncing and non-syncing writes made through it.
+type DB struct {
+	dbm.DB
+	Sets, SyncSets, Writes, SyncWrites int
+}
+
+// New wraps db.
+func New(db dbm.DB) *DB { return &DB{DB: db} }
+
+func (db *DB) Set(key, value []byte) error {
+	db.Sets++
+	return db.DB.Set(key, value)
+}
+
+func (db *DB) SetSync(key, value []byte) error {
+	db.SyncSets++
+	return db.DB.SetSync(key, value)
+}
+
+func (db *DB) NewBatch() dbm.Batch { return &batch{Batch: db.DB.NewBatch(), db: db} }
+
+type batch struct {
+	dbm.Batch
+	db *DB
+}
+
+func (b *batch) Write() error {
+	b.db.Writes++
+	return b.Batch.Write()
+}
+
+func (b *batch) WriteSync() error {
+	b.db.SyncWrites++
+	return b.Batch.WriteSync()
+}

--- a/internal/test/metricspy/histogram.go
+++ b/internal/test/metricspy/histogram.go
@@ -1,0 +1,33 @@
+// Package metricspy provides metrics fakes that record what was observed.
+package metricspy
+
+import "github.com/go-kit/kit/metrics"
+
+// Histogram records every observation under the value of one label, so a test
+// can check both which label value a sample was attributed to and how large it
+// was. Samples is shared by every histogram derived through With.
+type Histogram struct {
+	Samples map[string][]float64
+	label   string
+	key     string
+}
+
+// NewHistogram returns a histogram that groups observations by the value of
+// the named label. Observations made without that label land under "".
+func NewHistogram(label string) *Histogram {
+	return &Histogram{Samples: map[string][]float64{}, label: label}
+}
+
+func (h *Histogram) With(labelValues ...string) metrics.Histogram {
+	next := &Histogram{Samples: h.Samples, label: h.label, key: h.key}
+	for i := 0; i+1 < len(labelValues); i += 2 {
+		if labelValues[i] == h.label {
+			next.key = labelValues[i+1]
+		}
+	}
+	return next
+}
+
+func (h *Histogram) Observe(value float64) {
+	h.Samples[h.key] = append(h.Samples[h.key], value)
+}

--- a/node/node.go
+++ b/node/node.go
@@ -149,7 +149,16 @@ func makeNode(
 	}
 	closers = append(closers, dbCloser)
 
-	stateStore := sm.NewStore(stateDB, logger.With("module", "state_store"))
+	stateStoreOpts := []sm.StoreOption{sm.StoreWithLogger(logger.With("module", "state_store"))}
+	if cfg.UnsafeNoFsync {
+		// Here and in initDBs are the only places the policy is applied:
+		// tooling that opens the same databases (rollback, reindex, inspect)
+		// keeps durable writes.
+		stateStoreOpts = append(stateStoreOpts, sm.StoreWithUnsafeNoFsync())
+		logger.Error("unsafe-no-fsync is set: block store and state store writes are not durable; " +
+			"a power loss can leave this node unable to start. Never use this on a node whose data matters")
+	}
+	stateStore := sm.NewStore(stateDB, stateStoreOpts...)
 
 	genDoc, err := genesisDocProvider()
 	if err != nil {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1021,3 +1021,25 @@ func TestGetRouterConfigWiresMaxIncomingConnectionAttempts(t *testing.T) {
 	require.Equal(t, uint(7), opts.MaxIncomingConnectionAttempts,
 		"config max-incoming-connection-attempts must flow into RouterOptions")
 }
+
+// TestInitDBsAppliesUnsafeNoFsyncOnlyWhenConfigured pins where the no-fsync
+// policy enters the node: the block store built for the live node follows
+// the config flag, and nothing else. Other tooling that opens the same
+// databases builds its own stores and keeps durable writes.
+func TestInitDBsAppliesUnsafeNoFsyncOnlyWhenConfigured(t *testing.T) {
+	for _, unsafe := range []bool{false, true} {
+		t.Run(strconv.FormatBool(unsafe), func(t *testing.T) {
+			// the test root name feeds a temp dir pattern, so it cannot
+			// contain the "/" a subtest name has
+			cfg, err := config.ResetTestRoot(t.TempDir(), "TestInitDBsUnsafeNoFsync")
+			require.NoError(t, err)
+			cfg.UnsafeNoFsync = unsafe
+
+			blockStore, _, closer, err := initDBs(cfg, config.DefaultDBProvider)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = closer() })
+
+			require.Equal(t, unsafe, blockStore.UnsafeNoFsync())
+		})
+	}
+}

--- a/node/setup.go
+++ b/node/setup.go
@@ -94,7 +94,11 @@ func initDBs(
 		return nil, nil, func() error { return nil }, fmt.Errorf("unable to initialize blockstore: %w", err)
 	}
 	closers := []closer{}
-	blockStore := store.NewBlockStore(blockStoreDB)
+	var blockStoreOpts []store.Option
+	if cfg.UnsafeNoFsync {
+		blockStoreOpts = append(blockStoreOpts, store.WithUnsafeNoFsync())
+	}
+	blockStore := store.NewBlockStore(blockStoreDB, blockStoreOpts...)
 	closers = append(closers, blockStoreDB.Close)
 
 	stateDB, err := dbProvider(&config.DBContext{ID: "state", Config: cfg})


### PR DESCRIPTION
Block sync reports `partset`, `verify`, `save` and `exec` per block, but `exec` is a single number covering the two ABCI calls, our own durable writes, the mempool update and the event publish. That is most of a block, and it was opaque.

This adds two things. Both follow the patterns the codebase already uses, per review: the timing lands in the existing Prometheus metrics, and the no-fsync policy is a constructor option on the stores rather than a package global.

## Per-stage histograms

Two new histograms, labelled by `stage`, in milliseconds:

- `state_block_apply_stage_duration` on `state.Metrics`: each stage of `ProcessProposal` and `FinalizeBlock`, so the old `exec` number is split into the ABCI calls, `SaveABCIResponses`, the state store write, the mempool update, evidence pool, pruning and the event publish.
- `consensus_block_sync_apply_stage_duration` on `consensus.Metrics`, which the block sync applier already holds: `partset`, `verify_commit`, `verify_block`, `save`, `exec`, and `wait`, the idle time between one apply and the next.

They are no-ops with `NopMetrics`, so nothing changes for a node without Prometheus. Two findings that came out of the measurement:

**The `verify` stage is a single BLS threshold verification.** Splitting it:

```
verify_commit=1.896 ms   verify_block=0.009 ms
```

`ValidateBlock` is free; the whole stage is the signature. That is what #1427 and #1428 act on.

**A single peer costs a third of the sync.** `wait` is 2.2–3.5 ms/block with one peer and 0.003 ms with two: the applier is waiting on block fetch, not executing.

| peers | blocks/s | ms/block |
|---|---|---|
| 1 | 97.1 | 10.30 |
| 2 | 140.5 | 7.12 |

## `unsafe-no-fsync` config option

This is a benchmarking correction rather than a tuning knob.

Go's `os.File.Sync()` on darwin issues `F_FULLFSYNC`, not `fsync`. Measured on an M-series Mac:

```
go File.Sync mean ms: 6.776
plain fsync  mean ms: 0.231
```

Tenderdash does three synchronous writes per block during block sync, so on macOS it spends about 20 ms a block that a Linux node does not. Same binaries, same chain:

| | blocks/s | `verify` | `save` | `exec` |
|---|---|---|---|---|
| fsync | 34.6 | 4.20 | 5.42 | 19.55 |
| no fsync | 92.4 | 3.47 | 0.04 | 6.79 |

Leaving it on hides everything else in a profile taken on macOS.

How it is scoped:

- `store.NewBlockStore(db, store.WithUnsafeNoFsync())` and `state.NewStore(db, state.StoreWithUnsafeNoFsync())`. Without the option every write is `WriteSync`/`SetSync`, as before.
- `state.NewStore` takes `...StoreOption` now instead of the old `...log.Logger`; the logger moved to `StoreWithLogger`. Three callers passed a logger and were updated.
- The option is applied in exactly two places, `initDBs` and `makeNode`, and only when the config flag is set. Rollback, reindex and inspect build their own stores and keep durable writes.
- Setting it logs at error level on startup.

The name is deliberate. It removes durability: a power loss can leave the block store behind the application, which the replayer rejects with `ErrAppBlockHeightTooHigh`. Never set it on a node whose data matters.

## Tests

- `internal/store` and `internal/state`: a spy DB (`internal/test/dbspy`) counts syncing vs non-syncing writes, pinning the durable default on both the batch and single-key paths and the non-syncing selection with the option, with identical stored data.
- `internal/state`: the stage timer attributes each interval once, and is silent with `NopMetrics`.
- `internal/blocksync`: a successful apply records one sample per stage, `wait` only from the second block, and a failed commit check records `verify_commit` but not `verify_block`.
- `config`: the generated file renders the flag off with its warning.
- `node`: `initDBs` applies the policy only when configured.

Used throughout a full mainnet Platform replay, genesis to height 424,981, and for every A/B measurement behind #1427 and #1428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
