### PR TITLE
build(ci): make the local and CI quality gates actually check what they claim

### DIFF
--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -1,0 +1,47 @@
+---
+# Vet runs `go vet` over every package in the repository.
+#
+# The Test workflow builds only packages that have test files, so a package
+# without tests is never compiled or vetted there, and Lint reports findings
+# only on changed lines. A defect in an untested package therefore reaches
+# neither gate. This job has no trigger filter for that reason: it is bounded
+# by a compile the other workflows already perform, and the one thing a filter
+# could do for it is stop it running.
+
+name: Vet
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - v[0-9]+.[0-9]+-dev
+
+jobs:
+  vet:
+    name: go vet
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CGO_LDFLAGS: "-L/usr/local/lib -ldashbls -lrelic_s -lmimalloc-secure -lgmp"
+      CGO_CXXFLAGS: "-I/usr/local/include"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      # Pinned exactly rather than to a range: vet's diagnostics differ between
+      # toolchain releases, so a floating version would change what this gate
+      # enforces without anyone changing the repository.
+      - uses: actions/setup-go@v7.0.0
+        with:
+          go-version: "1.26.6"
+
+      # cmd/abcidump imports gopacket/pcap, which is cgo.
+      - name: Install libpcap
+        run: sudo apt-get update && sudo apt-get install --yes libpcap-dev
+
+      - uses: ./.github/actions/bls
+        name: Install BLS library
+
+      - name: Run go vet
+        run: make vet

--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,16 @@ lint-all:
 	$(GOLANGCI_LINT) run --timeout 10m
 .PHONY: lint-all
 
+# Covers every package, including those the Test workflow skips for having no
+# tests: `go test` vets only what it builds, so those are otherwise unchecked.
+# `go build` is deliberately absent -- vet typechecks in order to analyse, so it
+# reports compile errors too and adding build would only advertise coverage this
+# gate does not separately have.
+vet:
+	@echo "--> Running go vet"
+	go vet ./...
+.PHONY: vet
+
 vulncheck:
 	@echo "--> Running vulnerability scanner"
 	go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...

--- a/Makefile
+++ b/Makefile
@@ -276,30 +276,32 @@ format:
 # Kept in step with .github/workflows/lint.yml, which pins the same floating
 # minor so both always resolve to the latest patch of it.
 GOLANGCI_LINT_VERSION ?= v2.12
-GOLANGCI_LINT := go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+GOLANGCI_LINT := $(GO) run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
-# Ref that `make lint` reports new findings against; CI uses the pull request's
-# target branch. Override it when working off another release line:
-#   make lint LINT_BASE=origin/v1.6-dev
+# Use the newest fetched development branch by default. For another PR target,
+# override with: make lint LINT_BASE=origin/<target-branch>
 # Once the base advances past your branch point, its own commits enter the diff
 # and can raise findings you did not write. Rebase; changing the flag would make
 # this a different gate from the one CI enforces.
-LINT_BASE ?= origin/v1.7-dev
+LINT_BASE ?= $(shell git for-each-ref --sort=-version:refname --format='%(refname:short)' 'refs/remotes/origin/v[0-9]*-dev' | head -n 1)
 
 # What CI enforces: findings on lines this branch changed. The repository carries
 # several hundred pre-existing findings, so an unfiltered run can never exit 0 --
 # use `make lint-all` to see those.
 lint:
+	@test -n "$(LINT_BASE)" || { \
+		echo "make lint: no development branch found; run 'git fetch origin' or set LINT_BASE=origin/<branch>."; \
+		exit 1; }
 	@echo "--> Running linter (new findings vs $(LINT_BASE))"
-	@git rev-parse --verify --quiet $(LINT_BASE) >/dev/null || { \
+	@git rev-parse --verify --quiet "$(LINT_BASE)^{commit}" >/dev/null || { \
 		echo "make lint: base ref '$(LINT_BASE)' not found."; \
 		echo "  fetch it with 'git fetch origin', or pick another: make lint LINT_BASE=origin/<branch>"; \
 		exit 1; }
-	@git merge-base $(LINT_BASE) HEAD >/dev/null 2>&1 || { \
+	@git merge-base "$(LINT_BASE)" HEAD >/dev/null 2>&1 || { \
 		echo "make lint: no common history with '$(LINT_BASE)' -- shallow clone?"; \
 		echo "  deepen it with 'git fetch --unshallow'"; \
 		exit 1; }
-	$(GOLANGCI_LINT) run --timeout 10m --new-from-rev=$(LINT_BASE)
+	$(GOLANGCI_LINT) run --timeout 10m --new-from-rev="$(LINT_BASE)"
 .PHONY: lint
 
 lint-all:
@@ -314,7 +316,7 @@ lint-all:
 # gate does not separately have.
 vet:
 	@echo "--> Running go vet"
-	go vet ./...
+	$(GO) vet ./...
 .PHONY: vet
 
 vulncheck:

--- a/Makefile
+++ b/Makefile
@@ -274,10 +274,39 @@ format:
 	find . -name '*.go' -type f -not -path "*.git*"  -not -name '*.pb.go' -not -name '*pb_test.go' | xargs goimports -w -local ${REPO_NAME}
 .PHONY: format
 
+# Kept in step with .github/workflows/lint.yml, which pins the same floating
+# minor so both always resolve to the latest patch of it.
+GOLANGCI_LINT_VERSION ?= v2.12
+GOLANGCI_LINT := go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+# Ref that `make lint` reports new findings against; CI uses the pull request's
+# target branch. Override it when working off another release line:
+#   make lint LINT_BASE=origin/v1.6-dev
+# Once the base advances past your branch point, its own commits enter the diff
+# and can raise findings you did not write. Rebase; changing the flag would make
+# this a different gate from the one CI enforces.
+LINT_BASE ?= origin/v1.7-dev
+
+# What CI enforces: findings on lines this branch changed. The repository carries
+# several hundred pre-existing findings, so an unfiltered run can never exit 0 --
+# use `make lint-all` to see those.
 lint:
-	@echo "--> Running linter"
-	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8 run
+	@echo "--> Running linter (new findings vs $(LINT_BASE))"
+	@git rev-parse --verify --quiet $(LINT_BASE) >/dev/null || { \
+		echo "make lint: base ref '$(LINT_BASE)' not found."; \
+		echo "  fetch it with 'git fetch origin', or pick another: make lint LINT_BASE=origin/<branch>"; \
+		exit 1; }
+	@git merge-base $(LINT_BASE) HEAD >/dev/null 2>&1 || { \
+		echo "make lint: no common history with '$(LINT_BASE)' -- shallow clone?"; \
+		echo "  deepen it with 'git fetch --unshallow'"; \
+		exit 1; }
+	$(GOLANGCI_LINT) run --timeout 10m --new-from-rev=$(LINT_BASE)
 .PHONY: lint
+
+lint-all:
+	@echo "--> Running linter (whole repository, including pre-existing findings)"
+	$(GOLANGCI_LINT) run --timeout 10m
+.PHONY: lint-all
 
 vulncheck:
 	@echo "--> Running vulnerability scanner"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ endif
 BUILD_FLAGS = -mod=readonly -ldflags "$(LD_FLAGS)"
 HTTPS_GIT := https://${REPO_NAME}.git
 BUILD_IMAGE := ghcr.io/tendermint/docker-build-proto
-BASE_BRANCH ?= v0.8-dev
 DOCKER_PROTO := docker run -v $(shell pwd):/workspace --workdir /workspace $(BUILD_IMAGE)
 CGO_ENABLED ?= 1
 # Fix for a gogoproto bug

--- a/dash/quorum/nodeid_resolver.go
+++ b/dash/quorum/nodeid_resolver.go
@@ -3,6 +3,7 @@ package quorum
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/dashpay/tenderdash/internal/p2p"
@@ -37,7 +38,7 @@ func (resolver tcpNodeIDResolver) connect(host string, port uint16) (net.Conn, e
 	dialer := net.Dialer{
 		Timeout: resolver.DialerTimeout,
 	}
-	connection, err := dialer.Dial("tcp4", fmt.Sprintf("%s:%d", host, port))
+	connection, err := dialer.Dial("tcp4", net.JoinHostPort(host, strconv.Itoa(int(port))))
 	if err != nil {
 		return nil, fmt.Errorf("cannot lookup node ID: %w", err)
 	}

--- a/scripts/test-local-gates.sh
+++ b/scripts/test-local-gates.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT HUP INT TERM
+mkdir -p "$fixture/test" "$fixture/bin"
+cp "$repo_dir/Makefile" "$fixture/Makefile"
+touch "$fixture/test/Makefile"
+cd "$fixture"
+git init -q
+git -c user.name=Test -c user.email=test@example.invalid commit -qm initial --allow-empty
+
+# Exercise the real recipes without downloading tools or building native code.
+cat >bin/go <<'EOF'
+#!/bin/sh
+set -eu
+test "$CGO_ENABLED" = 1
+case "$CGO_CXXFLAGS" in *bls-signatures/src/include*) ;; *) exit 1 ;; esac
+case "$CGO_LDFLAGS" in *-ldashbls*) ;; *) exit 1 ;; esac
+printf '%s\n' "$*" >> "$GATE_LOG"
+EOF
+chmod +x bin/go
+PATH="$fixture/bin:$PATH"
+GATE_LOG="$fixture/gates.log"
+export PATH GATE_LOG
+unset LINT_BASE CGO_ENABLED CGO_CXXFLAGS CGO_LDFLAGS
+
+expect_lint_base() {
+	: > "$GATE_LOG"
+	make --no-print-directory lint "$@" > output.log 2>&1 || { cat output.log; return 1; }
+	grep -F -- "--new-from-rev=$expected_base" "$GATE_LOG"
+}
+
+expect_lint_failure() {
+	: > "$GATE_LOG"
+	if make --no-print-directory lint "$@" > output.log 2>&1; then
+		echo 'lint unexpectedly succeeded' >&2
+		exit 1
+	fi
+	test ! -s "$GATE_LOG"
+}
+
+git update-ref refs/remotes/origin/v1.9-dev HEAD
+git update-ref refs/remotes/origin/v1.10-dev HEAD
+expected_base=origin/v1.10-dev
+expect_lint_base
+
+git update-ref refs/remotes/origin/v2.0-dev HEAD
+expected_base=origin/v2.0-dev
+expect_lint_base
+
+expected_base=origin/v1.9-dev
+expect_lint_base LINT_BASE="$expected_base"
+LINT_BASE="$expected_base" expect_lint_base
+
+expect_lint_failure LINT_BASE=origin/missing
+grep -F 'not found' output.log
+expect_lint_failure LINT_BASE=
+
+unrelated=$(printf 'unrelated\n' | git -c user.name=Test -c user.email=test@example.invalid commit-tree 'HEAD^{tree}')
+git update-ref refs/remotes/origin/unrelated "$unrelated"
+expect_lint_failure LINT_BASE=origin/unrelated
+grep -F 'no common history' output.log
+
+git update-ref -d refs/remotes/origin/v1.9-dev
+git update-ref -d refs/remotes/origin/v1.10-dev
+git update-ref -d refs/remotes/origin/v2.0-dev
+expect_lint_failure
+grep -F 'no development branch found' output.log
+expected_base=HEAD
+expect_lint_base LINT_BASE=HEAD
+
+make --no-print-directory vet lint-all > output.log 2>&1
+grep -Fx 'vet ./...' "$GATE_LOG"
+grep -E 'golangci-lint@[^ ]+ run --timeout 10m$' "$GATE_LOG"
+echo 'Local quality gate tests passed'

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -382,7 +382,7 @@ func LoadTestnet(file string) (*Testnet, error) {
 	for heightStr := range manifest.ValidatorUpdates {
 		height, err := strconv.Atoi(heightStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid validator update height %q: %w", height, err)
+			return nil, fmt.Errorf("invalid validator update height %q: %w", heightStr, err)
 		}
 		heights = append(heights, height)
 	}
@@ -447,7 +447,7 @@ func LoadTestnet(file string) (*Testnet, error) {
 	for heightStr := range manifest.ChainLockUpdates {
 		height, err := strconv.Atoi(heightStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid validator update height %q: %w", height, err)
+			return nil, fmt.Errorf("invalid chain lock update height %q: %w", heightStr, err)
 		}
 		chainLockSetHeights = append(chainLockSetHeights, height)
 	}
@@ -465,7 +465,7 @@ func LoadTestnet(file string) (*Testnet, error) {
 	for heightStr, cpUpdate := range manifest.ConsensusVersionUpdates {
 		height, err := strconv.Atoi(heightStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid consensus version update height %q: %w", height, err)
+			return nil, fmt.Errorf("invalid consensus version update height %q: %w", heightStr, err)
 		}
 		testnet.ConsensusVersionUpdates[int64(height)] = cpUpdate
 	}


### PR DESCRIPTION
## The problem

Three of this repository's quality gates report success without checking what they appear to check. They were found while investigating an unrelated PR, by running each gate and comparing its result against what it claimed.

**`make lint` cannot exit 0.** It runs `golangci-lint` unfiltered across a repository carrying hundreds of pre-existing findings, so it exits 1 on a pristine `v1.8-dev` checkout — 180 issues at the version the `Makefile` pins today. Nobody can use it as a gate, and it also pins `@v2.8` while CI's `lint.yml` runs `v2.12`, so a clean local run was never evidence about CI in the first place.

**`go test ./...` cannot pass on the base branch.** Three `fmt.Errorf` calls in `test/e2e/pkg/testnet.go` fail the `vet` subset that `go test` runs before building. The lines date from 2020 and nobody noticed, because:

**No package without test files is ever built by CI.** `Makefile`'s shard list is `go list -f '{{ if (or .TestGoFiles .XTestGoFiles) }}...'`, so `test/e2e/pkg` — which has no `_test.go` — is filtered out and never compiled. 74 packages are in that category.

The three filters are individually defensible: a shard list should contain packages with tests; `--new-from-rev` should hide pre-existing findings from a review gate; `tests.yml` should not rebuild on documentation changes. **The defect fell through all three, and no layer was wrong.**

## What changed

**`fix(e2e)`** — the three `fmt.Errorf` calls report `height`, the result of a `strconv.Atoi` that just failed, so the message reads `invalid ... height "0"` for *any* malformed input and never shows the offending manifest key. The fix is the argument, not the verb: `heightStr` with `%q`, matching the six other sites in the repo that already do this. One message also named the wrong manifest section, sending a debugger to `validator_updates` for a `chain_lock_updates` failure. Clearing the vet failure is a consequence of fixing the diagnostic, not the goal.

**`build: make the lint target reproduce the CI gate`** — `make lint` now filters against a base ref, as CI does, and exits 0 on a clean tree. `make lint-all` preserves the unfiltered view under an honest name. The version is pinned to `v2.12` to match CI's floating-patch semantics, and `LINT_BASE` is overridable. Two preflight checks fail legibly before the linter runs when the base ref is missing or the clone is shallow, so nobody debugs a confusing lint result that is really a git problem.

**`build: drop the unused BASE_BRANCH variable`** — declared, read by nothing since the protobuf targets that used it were removed, and defaulting to `v0.8-dev`. Because it is `?=`, an exported value would silently take effect. It looks like the base-ref knob for the lint target while being wired to nothing, so someone adjusting it to fix a gate would watch the gate not change.

**`fix(dash)`** — `nodeid_resolver.go` formats a host/port pair with `fmt.Sprintf("%s:%d")`. `ValidatorAddress.String()` uses `net.JoinHostPort` on the same fields ten lines away, `internal/p2p` uses it at every equivalent site, and `validator_address_test.go` explicitly tests `tcp://[::1]:26656`, so a bare IPv6 literal is a supported state that the current code renders as the meaningless `::1:26656`. Output is byte-identical for IPv4. **This does not make IPv6 work** — the call dials hardcoded `"tcp4"`, which will still refuse the address; the improvement is a truthful error instead of a nonsense one. Whether node-ID resolution should support IPv6 is a connection-establishment question, deliberately left alone. It is fixed here because `go vet ./...` reports it, and a new gate shipping with a known finding inside it is not a gate.

**`ci: vet every package`** — a new `vet.yml` workflow running `make vet` (`go vet ./...`), covering all 176 packages including the 74 no workflow builds today.

Design decisions worth stating, because each looks like an oversight otherwise:

- **`go build` is deliberately absent.** Measured against the restored defect: `go build ./test/e2e/pkg/` exits **0** — it sails past the exact bug this PR exists to close — while `go vet` exits 1. Vet must typecheck to analyse, so it reports compile errors too. Build is strictly redundant, and including it would advertise coverage the gate does not have.
- **No trigger filter, deliberately.** Three filters hid the original defect; a fourth on the gate built to catch it would repeat the mistake knowingly. The cost is roughly a minute of runner time, dominated by fixed setup, in parallel with the six test shards.
- **`go-version` pinned exact, not `^`.** Vet's diagnostics vary by toolchain, so a floating version lets the gate change what it enforces with no change to this repository. An earlier revision of this description offered "a stricter newer vet started rejecting these lines" as the leading explanation for why 2020-era code began failing. **That has since been measured and refuted:** Go 1.26.5 flags all three `testnet.go` lines, so whatever changed predates the toolchain versions in play here. The pin stands on the general variance; the story it was originally justified with was wrong. The real cause is not established and is deliberately not chased — the gate's value does not depend on knowing it.
- **`libpcap-dev` is required, not copied.** `cmd/abcidump` imports `gopacket/pcap` via cgo, and it is one of the 74 packages CI does not build today.

## Verification

Every gate has a control proving it can fail, because a gate that only ever exits 0 has not been shown to be a gate.

| gate | clean tree | defect restored |
|---|---|---|
| `make lint` | exit 0, 0 issues | injected `S1025` → non-zero |
| `make vet` | exit 0, no findings | `testnet.go` defect → non-zero, naming line 385 |
| `make vet` | — | IPv6 finding → non-zero |

The lint control was run twice: the first injection was a compile error, which proves nothing since anything catches those. The second used a compile-clean style finding.

`go test -p 1 ./... -count=1` reaches **exit 0** on this branch — 176 packages, 0 failures. **No commit on `v1.8-dev` currently reaches that.** `go vet ./...` exits clean repo-wide after the IPv6 fix, so the new gate ships without an exception baked in. `gofmt` clean.

Caveats, stated rather than left for a reader to trip over: quoted lint timings are warm-cache and are not a contributor's first-run cost, which was not measured; `make lint-all` reports 197 capped and 414 uncapped, which are different measurements; and `internal/consensus` fails in CI at roughly 18% per run on `v1.8-dev` independently of this PR, so a single green suite run is not evidence that flake is absent.

A note on branch names, because this PR predates a rename: every measurement above was taken on this PR's base branch, which was called `v1.7-dev` when the work was done and is now `v1.8-dev`. The branch that carries the name `v1.7-dev` today is a different lineage (the 1.7.0 release line) and none of these numbers describe it. The text has been updated to the current names so a reader checking the figures runs them against the branch they were measured on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gAC8rAzQagn5sgDxUJNjj

