### PR TITLE
chore(deps): bump Go to 1.27.1

### DIFF
--- a/.github/actions/bls/action.yml
+++ b/.github/actions/bls/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v6
       with:
         submodules: true

--- a/.github/actions/bls/action.yml
+++ b/.github/actions/bls/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.26.6"
+        go-version: "1.27.1"
     - uses: actions/checkout@v6
       with:
         submodules: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6
         with:
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6
         with:
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.6"
+          go-version: "1.27.1"
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6
         with:
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.6"
+          go-version: "1.27.1"
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6
         with:
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.6"
+          go-version: "1.27.1"
       - uses: actions/checkout@v7
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - uses: actions/checkout@v7
 
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - uses: actions/checkout@v7
 

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.6"
+          go-version: "1.27.1"
 
       - uses: actions/checkout@v7
 
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.6"
+          go-version: "1.27.1"
 
       - uses: actions/checkout@v7
 

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -37,7 +37,7 @@ jobs:
           set -euo pipefail
 
 
-          readonly MOCKERY=3.7.0  # N.B. no leading "v"
+          readonly MOCKERY=3.7.4  # N.B. no leading "v"
           curl -sL "https://github.com/vektra/mockery/releases/download/v${MOCKERY}/mockery_${MOCKERY}_Linux_x86_64.tar.gz" | tar -C /usr/local/bin -xzf -
           make mockery 2>/dev/null
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.2.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.6"
+          go-version: "1.27.1"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.2.0

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - uses: actions/checkout@v7
 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.6"
+          go-version: "1.27.1"
 
       - uses: actions/checkout@v7
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-go@v7.0.0
         if: env.GIT_DIFF
         with:
-          go-version: "^1.26.5"
+          go-version: "^1.26.6"
 
       - name: Install dependencies
         if: env.GIT_DIFF

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,7 +61,7 @@ jobs:
           # Required: the version of golangci-lint is required and
           # must be specified without patch version: we always use the
           # latest patch version.
-          version: v2.12
+          version: v2.13
           # only-new-issues filters against a patch the action assembles itself,
           # which it fails to do for a branch with a large diff — it then falls
           # back to reporting every pre-existing issue in the repository. Ask

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-go@v7.0.0
         if: env.GIT_DIFF
         with:
-          go-version: "^1.26.6"
+          go-version: "^1.27.1"
 
       - name: Install dependencies
         if: env.GIT_DIFF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Build
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.6"
+          go-version: "1.27.1"
 
       - name: Build
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-go@v7.0.0
         if: env.GIT_DIFF
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Install libpcap
         if: env.GIT_DIFF

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-go@v7.0.0
         if: env.GIT_DIFF
         with:
-          go-version: "1.26.6"
+          go-version: "1.27.1"
 
       - name: Install libpcap
         if: env.GIT_DIFF

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -5,7 +5,7 @@
 # * image - creates final image of minimal size
 
 ARG ALPINE_VERSION=3.23
-ARG GOLANG_VERSION=1.26.5
+ARG GOLANG_VERSION=1.26.6
 #################################
 # STAGE 1: install dependencies #
 #################################

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -5,7 +5,7 @@
 # * image - creates final image of minimal size
 
 ARG ALPINE_VERSION=3.23
-ARG GOLANG_VERSION=1.26.6
+ARG GOLANG_VERSION=1.27.1
 #################################
 # STAGE 1: install dependencies #
 #################################

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ requirements if installing from source.
 
 | Requirement | Notes              |
 | ----------- | ------------------ |
-| Go version  | Go1.26.5 or higher |
+| Go version  | Go1.26.6 or higher |
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ requirements if installing from source.
 
 | Requirement | Notes              |
 | ----------- | ------------------ |
-| Go version  | Go1.26.6 or higher |
+| Go version  | Go1.27.1 or higher |
 
 ## Versioning
 

--- a/abci/client/mocks/client.go
+++ b/abci/client/mocks/client.go
@@ -74,7 +74,7 @@ type Client_ApplySnapshotChunk_Call struct {
 // ApplySnapshotChunk is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestApplySnapshotChunk *types.RequestApplySnapshotChunk
-func (_e *Client_Expecter) ApplySnapshotChunk(context1 interface{}, requestApplySnapshotChunk interface{}) *Client_ApplySnapshotChunk_Call {
+func (_e *Client_Expecter) ApplySnapshotChunk(context1 any, requestApplySnapshotChunk any) *Client_ApplySnapshotChunk_Call {
 	return &Client_ApplySnapshotChunk_Call{Call: _e.mock.On("ApplySnapshotChunk", context1, requestApplySnapshotChunk)}
 }
 
@@ -142,7 +142,7 @@ type Client_CheckTx_Call struct {
 // CheckTx is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestCheckTx *types.RequestCheckTx
-func (_e *Client_Expecter) CheckTx(context1 interface{}, requestCheckTx interface{}) *Client_CheckTx_Call {
+func (_e *Client_Expecter) CheckTx(context1 any, requestCheckTx any) *Client_CheckTx_Call {
 	return &Client_CheckTx_Call{Call: _e.mock.On("CheckTx", context1, requestCheckTx)}
 }
 
@@ -210,7 +210,7 @@ type Client_Echo_Call struct {
 // Echo is a helper method to define mock.On call
 //   - context1 context.Context
 //   - s string
-func (_e *Client_Expecter) Echo(context1 interface{}, s interface{}) *Client_Echo_Call {
+func (_e *Client_Expecter) Echo(context1 any, s any) *Client_Echo_Call {
 	return &Client_Echo_Call{Call: _e.mock.On("Echo", context1, s)}
 }
 
@@ -322,7 +322,7 @@ type Client_ExtendVote_Call struct {
 // ExtendVote is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestExtendVote *types.RequestExtendVote
-func (_e *Client_Expecter) ExtendVote(context1 interface{}, requestExtendVote interface{}) *Client_ExtendVote_Call {
+func (_e *Client_Expecter) ExtendVote(context1 any, requestExtendVote any) *Client_ExtendVote_Call {
 	return &Client_ExtendVote_Call{Call: _e.mock.On("ExtendVote", context1, requestExtendVote)}
 }
 
@@ -390,7 +390,7 @@ type Client_FinalizeBlock_Call struct {
 // FinalizeBlock is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestFinalizeBlock *types.RequestFinalizeBlock
-func (_e *Client_Expecter) FinalizeBlock(context1 interface{}, requestFinalizeBlock interface{}) *Client_FinalizeBlock_Call {
+func (_e *Client_Expecter) FinalizeBlock(context1 any, requestFinalizeBlock any) *Client_FinalizeBlock_Call {
 	return &Client_FinalizeBlock_Call{Call: _e.mock.On("FinalizeBlock", context1, requestFinalizeBlock)}
 }
 
@@ -446,7 +446,7 @@ type Client_Flush_Call struct {
 
 // Flush is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *Client_Expecter) Flush(context1 interface{}) *Client_Flush_Call {
+func (_e *Client_Expecter) Flush(context1 any) *Client_Flush_Call {
 	return &Client_Flush_Call{Call: _e.mock.On("Flush", context1)}
 }
 
@@ -509,7 +509,7 @@ type Client_Info_Call struct {
 // Info is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestInfo *types.RequestInfo
-func (_e *Client_Expecter) Info(context1 interface{}, requestInfo interface{}) *Client_Info_Call {
+func (_e *Client_Expecter) Info(context1 any, requestInfo any) *Client_Info_Call {
 	return &Client_Info_Call{Call: _e.mock.On("Info", context1, requestInfo)}
 }
 
@@ -577,7 +577,7 @@ type Client_InitChain_Call struct {
 // InitChain is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestInitChain *types.RequestInitChain
-func (_e *Client_Expecter) InitChain(context1 interface{}, requestInitChain interface{}) *Client_InitChain_Call {
+func (_e *Client_Expecter) InitChain(context1 any, requestInitChain any) *Client_InitChain_Call {
 	return &Client_InitChain_Call{Call: _e.mock.On("InitChain", context1, requestInitChain)}
 }
 
@@ -689,7 +689,7 @@ type Client_ListSnapshots_Call struct {
 // ListSnapshots is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestListSnapshots *types.RequestListSnapshots
-func (_e *Client_Expecter) ListSnapshots(context1 interface{}, requestListSnapshots interface{}) *Client_ListSnapshots_Call {
+func (_e *Client_Expecter) ListSnapshots(context1 any, requestListSnapshots any) *Client_ListSnapshots_Call {
 	return &Client_ListSnapshots_Call{Call: _e.mock.On("ListSnapshots", context1, requestListSnapshots)}
 }
 
@@ -757,7 +757,7 @@ type Client_LoadSnapshotChunk_Call struct {
 // LoadSnapshotChunk is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestLoadSnapshotChunk *types.RequestLoadSnapshotChunk
-func (_e *Client_Expecter) LoadSnapshotChunk(context1 interface{}, requestLoadSnapshotChunk interface{}) *Client_LoadSnapshotChunk_Call {
+func (_e *Client_Expecter) LoadSnapshotChunk(context1 any, requestLoadSnapshotChunk any) *Client_LoadSnapshotChunk_Call {
 	return &Client_LoadSnapshotChunk_Call{Call: _e.mock.On("LoadSnapshotChunk", context1, requestLoadSnapshotChunk)}
 }
 
@@ -825,7 +825,7 @@ type Client_OfferSnapshot_Call struct {
 // OfferSnapshot is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestOfferSnapshot *types.RequestOfferSnapshot
-func (_e *Client_Expecter) OfferSnapshot(context1 interface{}, requestOfferSnapshot interface{}) *Client_OfferSnapshot_Call {
+func (_e *Client_Expecter) OfferSnapshot(context1 any, requestOfferSnapshot any) *Client_OfferSnapshot_Call {
 	return &Client_OfferSnapshot_Call{Call: _e.mock.On("OfferSnapshot", context1, requestOfferSnapshot)}
 }
 
@@ -893,7 +893,7 @@ type Client_PrepareProposal_Call struct {
 // PrepareProposal is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestPrepareProposal *types.RequestPrepareProposal
-func (_e *Client_Expecter) PrepareProposal(context1 interface{}, requestPrepareProposal interface{}) *Client_PrepareProposal_Call {
+func (_e *Client_Expecter) PrepareProposal(context1 any, requestPrepareProposal any) *Client_PrepareProposal_Call {
 	return &Client_PrepareProposal_Call{Call: _e.mock.On("PrepareProposal", context1, requestPrepareProposal)}
 }
 
@@ -961,7 +961,7 @@ type Client_ProcessProposal_Call struct {
 // ProcessProposal is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestProcessProposal *types.RequestProcessProposal
-func (_e *Client_Expecter) ProcessProposal(context1 interface{}, requestProcessProposal interface{}) *Client_ProcessProposal_Call {
+func (_e *Client_Expecter) ProcessProposal(context1 any, requestProcessProposal any) *Client_ProcessProposal_Call {
 	return &Client_ProcessProposal_Call{Call: _e.mock.On("ProcessProposal", context1, requestProcessProposal)}
 }
 
@@ -1029,7 +1029,7 @@ type Client_Query_Call struct {
 // Query is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestQuery *types.RequestQuery
-func (_e *Client_Expecter) Query(context1 interface{}, requestQuery interface{}) *Client_Query_Call {
+func (_e *Client_Expecter) Query(context1 any, requestQuery any) *Client_Query_Call {
 	return &Client_Query_Call{Call: _e.mock.On("Query", context1, requestQuery)}
 }
 
@@ -1085,7 +1085,7 @@ type Client_Start_Call struct {
 
 // Start is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *Client_Expecter) Start(context1 interface{}) *Client_Start_Call {
+func (_e *Client_Expecter) Start(context1 any) *Client_Start_Call {
 	return &Client_Start_Call{Call: _e.mock.On("Start", context1)}
 }
 
@@ -1148,7 +1148,7 @@ type Client_VerifyVoteExtension_Call struct {
 // VerifyVoteExtension is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestVerifyVoteExtension *types.RequestVerifyVoteExtension
-func (_e *Client_Expecter) VerifyVoteExtension(context1 interface{}, requestVerifyVoteExtension interface{}) *Client_VerifyVoteExtension_Call {
+func (_e *Client_Expecter) VerifyVoteExtension(context1 any, requestVerifyVoteExtension any) *Client_VerifyVoteExtension_Call {
 	return &Client_VerifyVoteExtension_Call{Call: _e.mock.On("VerifyVoteExtension", context1, requestVerifyVoteExtension)}
 }
 

--- a/abci/types/mocks/application.go
+++ b/abci/types/mocks/application.go
@@ -74,7 +74,7 @@ type Application_ApplySnapshotChunk_Call struct {
 // ApplySnapshotChunk is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestApplySnapshotChunk *types.RequestApplySnapshotChunk
-func (_e *Application_Expecter) ApplySnapshotChunk(context1 interface{}, requestApplySnapshotChunk interface{}) *Application_ApplySnapshotChunk_Call {
+func (_e *Application_Expecter) ApplySnapshotChunk(context1 any, requestApplySnapshotChunk any) *Application_ApplySnapshotChunk_Call {
 	return &Application_ApplySnapshotChunk_Call{Call: _e.mock.On("ApplySnapshotChunk", context1, requestApplySnapshotChunk)}
 }
 
@@ -142,7 +142,7 @@ type Application_CheckTx_Call struct {
 // CheckTx is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestCheckTx *types.RequestCheckTx
-func (_e *Application_Expecter) CheckTx(context1 interface{}, requestCheckTx interface{}) *Application_CheckTx_Call {
+func (_e *Application_Expecter) CheckTx(context1 any, requestCheckTx any) *Application_CheckTx_Call {
 	return &Application_CheckTx_Call{Call: _e.mock.On("CheckTx", context1, requestCheckTx)}
 }
 
@@ -210,7 +210,7 @@ type Application_ExtendVote_Call struct {
 // ExtendVote is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestExtendVote *types.RequestExtendVote
-func (_e *Application_Expecter) ExtendVote(context1 interface{}, requestExtendVote interface{}) *Application_ExtendVote_Call {
+func (_e *Application_Expecter) ExtendVote(context1 any, requestExtendVote any) *Application_ExtendVote_Call {
 	return &Application_ExtendVote_Call{Call: _e.mock.On("ExtendVote", context1, requestExtendVote)}
 }
 
@@ -278,7 +278,7 @@ type Application_FinalizeBlock_Call struct {
 // FinalizeBlock is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestFinalizeBlock *types.RequestFinalizeBlock
-func (_e *Application_Expecter) FinalizeBlock(context1 interface{}, requestFinalizeBlock interface{}) *Application_FinalizeBlock_Call {
+func (_e *Application_Expecter) FinalizeBlock(context1 any, requestFinalizeBlock any) *Application_FinalizeBlock_Call {
 	return &Application_FinalizeBlock_Call{Call: _e.mock.On("FinalizeBlock", context1, requestFinalizeBlock)}
 }
 
@@ -346,7 +346,7 @@ type Application_Info_Call struct {
 // Info is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestInfo *types.RequestInfo
-func (_e *Application_Expecter) Info(context1 interface{}, requestInfo interface{}) *Application_Info_Call {
+func (_e *Application_Expecter) Info(context1 any, requestInfo any) *Application_Info_Call {
 	return &Application_Info_Call{Call: _e.mock.On("Info", context1, requestInfo)}
 }
 
@@ -414,7 +414,7 @@ type Application_InitChain_Call struct {
 // InitChain is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestInitChain *types.RequestInitChain
-func (_e *Application_Expecter) InitChain(context1 interface{}, requestInitChain interface{}) *Application_InitChain_Call {
+func (_e *Application_Expecter) InitChain(context1 any, requestInitChain any) *Application_InitChain_Call {
 	return &Application_InitChain_Call{Call: _e.mock.On("InitChain", context1, requestInitChain)}
 }
 
@@ -482,7 +482,7 @@ type Application_ListSnapshots_Call struct {
 // ListSnapshots is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestListSnapshots *types.RequestListSnapshots
-func (_e *Application_Expecter) ListSnapshots(context1 interface{}, requestListSnapshots interface{}) *Application_ListSnapshots_Call {
+func (_e *Application_Expecter) ListSnapshots(context1 any, requestListSnapshots any) *Application_ListSnapshots_Call {
 	return &Application_ListSnapshots_Call{Call: _e.mock.On("ListSnapshots", context1, requestListSnapshots)}
 }
 
@@ -550,7 +550,7 @@ type Application_LoadSnapshotChunk_Call struct {
 // LoadSnapshotChunk is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestLoadSnapshotChunk *types.RequestLoadSnapshotChunk
-func (_e *Application_Expecter) LoadSnapshotChunk(context1 interface{}, requestLoadSnapshotChunk interface{}) *Application_LoadSnapshotChunk_Call {
+func (_e *Application_Expecter) LoadSnapshotChunk(context1 any, requestLoadSnapshotChunk any) *Application_LoadSnapshotChunk_Call {
 	return &Application_LoadSnapshotChunk_Call{Call: _e.mock.On("LoadSnapshotChunk", context1, requestLoadSnapshotChunk)}
 }
 
@@ -618,7 +618,7 @@ type Application_OfferSnapshot_Call struct {
 // OfferSnapshot is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestOfferSnapshot *types.RequestOfferSnapshot
-func (_e *Application_Expecter) OfferSnapshot(context1 interface{}, requestOfferSnapshot interface{}) *Application_OfferSnapshot_Call {
+func (_e *Application_Expecter) OfferSnapshot(context1 any, requestOfferSnapshot any) *Application_OfferSnapshot_Call {
 	return &Application_OfferSnapshot_Call{Call: _e.mock.On("OfferSnapshot", context1, requestOfferSnapshot)}
 }
 
@@ -686,7 +686,7 @@ type Application_PrepareProposal_Call struct {
 // PrepareProposal is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestPrepareProposal *types.RequestPrepareProposal
-func (_e *Application_Expecter) PrepareProposal(context1 interface{}, requestPrepareProposal interface{}) *Application_PrepareProposal_Call {
+func (_e *Application_Expecter) PrepareProposal(context1 any, requestPrepareProposal any) *Application_PrepareProposal_Call {
 	return &Application_PrepareProposal_Call{Call: _e.mock.On("PrepareProposal", context1, requestPrepareProposal)}
 }
 
@@ -754,7 +754,7 @@ type Application_ProcessProposal_Call struct {
 // ProcessProposal is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestProcessProposal *types.RequestProcessProposal
-func (_e *Application_Expecter) ProcessProposal(context1 interface{}, requestProcessProposal interface{}) *Application_ProcessProposal_Call {
+func (_e *Application_Expecter) ProcessProposal(context1 any, requestProcessProposal any) *Application_ProcessProposal_Call {
 	return &Application_ProcessProposal_Call{Call: _e.mock.On("ProcessProposal", context1, requestProcessProposal)}
 }
 
@@ -822,7 +822,7 @@ type Application_Query_Call struct {
 // Query is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestQuery *types.RequestQuery
-func (_e *Application_Expecter) Query(context1 interface{}, requestQuery interface{}) *Application_Query_Call {
+func (_e *Application_Expecter) Query(context1 any, requestQuery any) *Application_Query_Call {
 	return &Application_Query_Call{Call: _e.mock.On("Query", context1, requestQuery)}
 }
 
@@ -890,7 +890,7 @@ type Application_VerifyVoteExtension_Call struct {
 // VerifyVoteExtension is a helper method to define mock.On call
 //   - context1 context.Context
 //   - requestVerifyVoteExtension *types.RequestVerifyVoteExtension
-func (_e *Application_Expecter) VerifyVoteExtension(context1 interface{}, requestVerifyVoteExtension interface{}) *Application_VerifyVoteExtension_Call {
+func (_e *Application_Expecter) VerifyVoteExtension(context1 any, requestVerifyVoteExtension any) *Application_VerifyVoteExtension_Call {
 	return &Application_VerifyVoteExtension_Call{Call: _e.mock.On("VerifyVoteExtension", context1, requestVerifyVoteExtension)}
 }
 

--- a/dash/core/mocks/client.go
+++ b/dash/core/mocks/client.go
@@ -172,7 +172,7 @@ type Client_MasternodeListJSON_Call struct {
 
 // MasternodeListJSON is a helper method to define mock.On call
 //   - filter string
-func (_e *Client_Expecter) MasternodeListJSON(filter interface{}) *Client_MasternodeListJSON_Call {
+func (_e *Client_Expecter) MasternodeListJSON(filter any) *Client_MasternodeListJSON_Call {
 	return &Client_MasternodeListJSON_Call{Call: _e.mock.On("MasternodeListJSON", filter)}
 }
 
@@ -334,7 +334,7 @@ type Client_QuorumInfo_Call struct {
 // QuorumInfo is a helper method to define mock.On call
 //   - quorumType btcjson.LLMQType
 //   - quorumHash crypto.QuorumHash
-func (_e *Client_Expecter) QuorumInfo(quorumType interface{}, quorumHash interface{}) *Client_QuorumInfo_Call {
+func (_e *Client_Expecter) QuorumInfo(quorumType any, quorumHash any) *Client_QuorumInfo_Call {
 	return &Client_QuorumInfo_Call{Call: _e.mock.On("QuorumInfo", quorumType, quorumHash)}
 }
 
@@ -404,7 +404,7 @@ type Client_QuorumSign_Call struct {
 //   - requestID bytes.HexBytes
 //   - messageHash bytes.HexBytes
 //   - quorumHash bytes.HexBytes
-func (_e *Client_Expecter) QuorumSign(quorumType interface{}, requestID interface{}, messageHash interface{}, quorumHash interface{}) *Client_QuorumSign_Call {
+func (_e *Client_Expecter) QuorumSign(quorumType any, requestID any, messageHash any, quorumHash any) *Client_QuorumSign_Call {
 	return &Client_QuorumSign_Call{Call: _e.mock.On("QuorumSign", quorumType, requestID, messageHash, quorumHash)}
 }
 
@@ -483,7 +483,7 @@ type Client_QuorumVerify_Call struct {
 //   - messageHash bytes.HexBytes
 //   - signature bytes.HexBytes
 //   - quorumHash bytes.HexBytes
-func (_e *Client_Expecter) QuorumVerify(quorumType interface{}, requestID interface{}, messageHash interface{}, signature interface{}, quorumHash interface{}) *Client_QuorumVerify_Call {
+func (_e *Client_Expecter) QuorumVerify(quorumType any, requestID any, messageHash any, signature any, quorumHash any) *Client_QuorumVerify_Call {
 	return &Client_QuorumVerify_Call{Call: _e.mock.On("QuorumVerify", quorumType, requestID, messageHash, signature, quorumHash)}
 }
 

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -596,7 +596,7 @@ This will populate the `go.mod` with a release number followed by a hash for Ten
 ```go
 module github.com/<username>/kvstore
 
-go 1.26.5
+go 1.26.6
 
 require (
  github.com/dgraph-io/badger/v3 v3.2103.2

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -596,7 +596,7 @@ This will populate the `go.mod` with a release number followed by a hash for Ten
 ```go
 module github.com/<username>/kvstore
 
-go 1.26.6
+go 1.27.1
 
 require (
  github.com/dgraph-io/badger/v3 v3.2103.2

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -447,7 +447,7 @@ This will populate the `go.mod` with a release number followed by a hash for Ten
 ```go
 module github.com/<username>/kvstore
 
-go 1.26.5
+go 1.26.6
 
 require (
  github.com/dgraph-io/badger/v3 v3.2103.2

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -447,7 +447,7 @@ This will populate the `go.mod` with a release number followed by a hash for Ten
 ```go
 module github.com/<username>/kvstore
 
-go 1.26.6
+go 1.27.1
 
 require (
  github.com/dgraph-io/badger/v3 v3.2103.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dashpay/tenderdash
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dashpay/tenderdash
 
-go 1.26.6
+go 1.27.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/internal/consensus/mocks/gossiper.go
+++ b/internal/consensus/mocks/gossiper.go
@@ -53,7 +53,7 @@ type Gossiper_GossipBlockPartsForCatchup_Call struct {
 //   - ctx context.Context
 //   - rs types.RoundState
 //   - prs *types.PeerRoundState
-func (_e *Gossiper_Expecter) GossipBlockPartsForCatchup(ctx interface{}, rs interface{}, prs interface{}) *Gossiper_GossipBlockPartsForCatchup_Call {
+func (_e *Gossiper_Expecter) GossipBlockPartsForCatchup(ctx any, rs any, prs any) *Gossiper_GossipBlockPartsForCatchup_Call {
 	return &Gossiper_GossipBlockPartsForCatchup_Call{Call: _e.mock.On("GossipBlockPartsForCatchup", ctx, rs, prs)}
 }
 
@@ -105,7 +105,7 @@ type Gossiper_GossipCommit_Call struct {
 //   - ctx context.Context
 //   - rs types.RoundState
 //   - prs *types.PeerRoundState
-func (_e *Gossiper_Expecter) GossipCommit(ctx interface{}, rs interface{}, prs interface{}) *Gossiper_GossipCommit_Call {
+func (_e *Gossiper_Expecter) GossipCommit(ctx any, rs any, prs any) *Gossiper_GossipCommit_Call {
 	return &Gossiper_GossipCommit_Call{Call: _e.mock.On("GossipCommit", ctx, rs, prs)}
 }
 
@@ -157,7 +157,7 @@ type Gossiper_GossipProposal_Call struct {
 //   - ctx context.Context
 //   - rs types.RoundState
 //   - prs *types.PeerRoundState
-func (_e *Gossiper_Expecter) GossipProposal(ctx interface{}, rs interface{}, prs interface{}) *Gossiper_GossipProposal_Call {
+func (_e *Gossiper_Expecter) GossipProposal(ctx any, rs any, prs any) *Gossiper_GossipProposal_Call {
 	return &Gossiper_GossipProposal_Call{Call: _e.mock.On("GossipProposal", ctx, rs, prs)}
 }
 
@@ -209,7 +209,7 @@ type Gossiper_GossipProposalBlockParts_Call struct {
 //   - ctx context.Context
 //   - rs types.RoundState
 //   - prs *types.PeerRoundState
-func (_e *Gossiper_Expecter) GossipProposalBlockParts(ctx interface{}, rs interface{}, prs interface{}) *Gossiper_GossipProposalBlockParts_Call {
+func (_e *Gossiper_Expecter) GossipProposalBlockParts(ctx any, rs any, prs any) *Gossiper_GossipProposalBlockParts_Call {
 	return &Gossiper_GossipProposalBlockParts_Call{Call: _e.mock.On("GossipProposalBlockParts", ctx, rs, prs)}
 }
 
@@ -261,7 +261,7 @@ type Gossiper_GossipVote_Call struct {
 //   - ctx context.Context
 //   - rs types.RoundState
 //   - prs *types.PeerRoundState
-func (_e *Gossiper_Expecter) GossipVote(ctx interface{}, rs interface{}, prs interface{}) *Gossiper_GossipVote_Call {
+func (_e *Gossiper_Expecter) GossipVote(ctx any, rs any, prs any) *Gossiper_GossipVote_Call {
 	return &Gossiper_GossipVote_Call{Call: _e.mock.On("GossipVote", ctx, rs, prs)}
 }
 
@@ -313,7 +313,7 @@ type Gossiper_GossipVoteSetMaj23_Call struct {
 //   - ctx context.Context
 //   - rs types.RoundState
 //   - prs *types.PeerRoundState
-func (_e *Gossiper_Expecter) GossipVoteSetMaj23(ctx interface{}, rs interface{}, prs interface{}) *Gossiper_GossipVoteSetMaj23_Call {
+func (_e *Gossiper_Expecter) GossipVoteSetMaj23(ctx any, rs any, prs any) *Gossiper_GossipVoteSetMaj23_Call {
 	return &Gossiper_GossipVoteSetMaj23_Call{Call: _e.mock.On("GossipVoteSetMaj23", ctx, rs, prs)}
 }
 

--- a/internal/consensus/versioned/selectproposer/mocks/proposerselector.go
+++ b/internal/consensus/versioned/selectproposer/mocks/proposerselector.go
@@ -119,7 +119,7 @@ type ProposerSelector_GetProposer_Call struct {
 // GetProposer is a helper method to define mock.On call
 //   - height int64
 //   - round int32
-func (_e *ProposerSelector_Expecter) GetProposer(height interface{}, round interface{}) *ProposerSelector_GetProposer_Call {
+func (_e *ProposerSelector_Expecter) GetProposer(height any, round any) *ProposerSelector_GetProposer_Call {
 	return &ProposerSelector_GetProposer_Call{Call: _e.mock.On("GetProposer", height, round)}
 }
 
@@ -178,7 +178,7 @@ type ProposerSelector_MustGetProposer_Call struct {
 // MustGetProposer is a helper method to define mock.On call
 //   - height int64
 //   - round int32
-func (_e *ProposerSelector_Expecter) MustGetProposer(height interface{}, round interface{}) *ProposerSelector_MustGetProposer_Call {
+func (_e *ProposerSelector_Expecter) MustGetProposer(height any, round any) *ProposerSelector_MustGetProposer_Call {
 	return &ProposerSelector_MustGetProposer_Call{Call: _e.mock.On("MustGetProposer", height, round)}
 }
 
@@ -235,7 +235,7 @@ type ProposerSelector_UpdateHeightRound_Call struct {
 // UpdateHeightRound is a helper method to define mock.On call
 //   - height int64
 //   - round int32
-func (_e *ProposerSelector_Expecter) UpdateHeightRound(height interface{}, round interface{}) *ProposerSelector_UpdateHeightRound_Call {
+func (_e *ProposerSelector_Expecter) UpdateHeightRound(height any, round any) *ProposerSelector_UpdateHeightRound_Call {
 	return &ProposerSelector_UpdateHeightRound_Call{Call: _e.mock.On("UpdateHeightRound", height, round)}
 }
 

--- a/internal/evidence/mocks/blockstore.go
+++ b/internal/evidence/mocks/blockstore.go
@@ -150,7 +150,7 @@ type BlockStore_LoadBlockCommit_Call struct {
 
 // LoadBlockCommit is a helper method to define mock.On call
 //   - height int64
-func (_e *BlockStore_Expecter) LoadBlockCommit(height interface{}) *BlockStore_LoadBlockCommit_Call {
+func (_e *BlockStore_Expecter) LoadBlockCommit(height any) *BlockStore_LoadBlockCommit_Call {
 	return &BlockStore_LoadBlockCommit_Call{Call: _e.mock.On("LoadBlockCommit", height)}
 }
 
@@ -203,7 +203,7 @@ type BlockStore_LoadBlockMeta_Call struct {
 
 // LoadBlockMeta is a helper method to define mock.On call
 //   - height int64
-func (_e *BlockStore_Expecter) LoadBlockMeta(height interface{}) *BlockStore_LoadBlockMeta_Call {
+func (_e *BlockStore_Expecter) LoadBlockMeta(height any) *BlockStore_LoadBlockMeta_Call {
 	return &BlockStore_LoadBlockMeta_Call{Call: _e.mock.On("LoadBlockMeta", height)}
 }
 

--- a/internal/mempool/mocks/mempool.go
+++ b/internal/mempool/mocks/mempool.go
@@ -67,7 +67,7 @@ type Mempool_CheckTx_Call struct {
 //   - tx types.Tx
 //   - cb func(*types0.ResponseCheckTx)
 //   - txInfo mempool.TxInfo
-func (_e *Mempool_Expecter) CheckTx(ctx interface{}, tx interface{}, cb interface{}, txInfo interface{}) *Mempool_CheckTx_Call {
+func (_e *Mempool_Expecter) CheckTx(ctx any, tx any, cb any, txInfo any) *Mempool_CheckTx_Call {
 	return &Mempool_CheckTx_Call{Call: _e.mock.On("CheckTx", ctx, tx, cb, txInfo)}
 }
 
@@ -199,7 +199,7 @@ type Mempool_FlushAppConn_Call struct {
 
 // FlushAppConn is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *Mempool_Expecter) FlushAppConn(context1 interface{}) *Mempool_FlushAppConn_Call {
+func (_e *Mempool_Expecter) FlushAppConn(context1 any) *Mempool_FlushAppConn_Call {
 	return &Mempool_FlushAppConn_Call{Call: _e.mock.On("FlushAppConn", context1)}
 }
 
@@ -252,7 +252,7 @@ type Mempool_GetTxByHash_Call struct {
 
 // GetTxByHash is a helper method to define mock.On call
 //   - txHash types.TxKey
-func (_e *Mempool_Expecter) GetTxByHash(txHash interface{}) *Mempool_GetTxByHash_Call {
+func (_e *Mempool_Expecter) GetTxByHash(txHash any) *Mempool_GetTxByHash_Call {
 	return &Mempool_GetTxByHash_Call{Call: _e.mock.On("GetTxByHash", txHash)}
 }
 
@@ -339,7 +339,7 @@ type Mempool_ReapMaxBytesMaxGas_Call struct {
 // ReapMaxBytesMaxGas is a helper method to define mock.On call
 //   - maxBytes int64
 //   - maxGas int64
-func (_e *Mempool_Expecter) ReapMaxBytesMaxGas(maxBytes interface{}, maxGas interface{}) *Mempool_ReapMaxBytesMaxGas_Call {
+func (_e *Mempool_Expecter) ReapMaxBytesMaxGas(maxBytes any, maxGas any) *Mempool_ReapMaxBytesMaxGas_Call {
 	return &Mempool_ReapMaxBytesMaxGas_Call{Call: _e.mock.On("ReapMaxBytesMaxGas", maxBytes, maxGas)}
 }
 
@@ -397,7 +397,7 @@ type Mempool_ReapMaxTxs_Call struct {
 
 // ReapMaxTxs is a helper method to define mock.On call
 //   - max int
-func (_e *Mempool_Expecter) ReapMaxTxs(max interface{}) *Mempool_ReapMaxTxs_Call {
+func (_e *Mempool_Expecter) ReapMaxTxs(max any) *Mempool_ReapMaxTxs_Call {
 	return &Mempool_ReapMaxTxs_Call{Call: _e.mock.On("ReapMaxTxs", max)}
 }
 
@@ -448,7 +448,7 @@ type Mempool_RemoveTxByKey_Call struct {
 
 // RemoveTxByKey is a helper method to define mock.On call
 //   - txKey types.TxKey
-func (_e *Mempool_Expecter) RemoveTxByKey(txKey interface{}) *Mempool_RemoveTxByKey_Call {
+func (_e *Mempool_Expecter) RemoveTxByKey(txKey any) *Mempool_RemoveTxByKey_Call {
 	return &Mempool_RemoveTxByKey_Call{Call: _e.mock.On("RemoveTxByKey", txKey)}
 }
 
@@ -672,7 +672,7 @@ type Mempool_Update_Call struct {
 //   - newPreFn mempool.PreCheckFunc
 //   - newPostFn mempool.PostCheckFunc
 //   - recheck bool
-func (_e *Mempool_Expecter) Update(ctx interface{}, blockHeight interface{}, blockTxs interface{}, txResults interface{}, newPreFn interface{}, newPostFn interface{}, recheck interface{}) *Mempool_Update_Call {
+func (_e *Mempool_Expecter) Update(ctx any, blockHeight any, blockTxs any, txResults any, newPreFn any, newPostFn any, recheck any) *Mempool_Update_Call {
 	return &Mempool_Update_Call{Call: _e.mock.On("Update", ctx, blockHeight, blockTxs, txResults, newPreFn, newPostFn, recheck)}
 }
 

--- a/internal/p2p/client/mocks/blockclient.go
+++ b/internal/p2p/client/mocks/blockclient.go
@@ -77,7 +77,7 @@ type BlockClient_GetBlock_Call struct {
 //   - ctx context.Context
 //   - height int64
 //   - peerID types.NodeID
-func (_e *BlockClient_Expecter) GetBlock(ctx interface{}, height interface{}, peerID interface{}) *BlockClient_GetBlock_Call {
+func (_e *BlockClient_Expecter) GetBlock(ctx any, height any, peerID any) *BlockClient_GetBlock_Call {
 	return &BlockClient_GetBlock_Call{Call: _e.mock.On("GetBlock", ctx, height, peerID)}
 }
 
@@ -138,7 +138,7 @@ type BlockClient_GetSyncStatus_Call struct {
 
 // GetSyncStatus is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *BlockClient_Expecter) GetSyncStatus(ctx interface{}) *BlockClient_GetSyncStatus_Call {
+func (_e *BlockClient_Expecter) GetSyncStatus(ctx any) *BlockClient_GetSyncStatus_Call {
 	return &BlockClient_GetSyncStatus_Call{Call: _e.mock.On("GetSyncStatus", ctx)}
 }
 
@@ -190,7 +190,7 @@ type BlockClient_Send_Call struct {
 // Send is a helper method to define mock.On call
 //   - ctx context.Context
 //   - msg any
-func (_e *BlockClient_Expecter) Send(ctx interface{}, msg interface{}) *BlockClient_Send_Call {
+func (_e *BlockClient_Expecter) Send(ctx any, msg any) *BlockClient_Send_Call {
 	return &BlockClient_Send_Call{Call: _e.mock.On("Send", ctx, msg)}
 }
 

--- a/internal/p2p/client/mocks/snapshotclient.go
+++ b/internal/p2p/client/mocks/snapshotclient.go
@@ -79,7 +79,7 @@ type SnapshotClient_GetChunk_Call struct {
 //   - height uint64
 //   - format uint32
 //   - index uint32
-func (_e *SnapshotClient_Expecter) GetChunk(ctx interface{}, peerID interface{}, height interface{}, format interface{}, index interface{}) *SnapshotClient_GetChunk_Call {
+func (_e *SnapshotClient_Expecter) GetChunk(ctx any, peerID any, height any, format any, index any) *SnapshotClient_GetChunk_Call {
 	return &SnapshotClient_GetChunk_Call{Call: _e.mock.On("GetChunk", ctx, peerID, height, format, index)}
 }
 
@@ -163,7 +163,7 @@ type SnapshotClient_GetLightBlock_Call struct {
 //   - ctx context.Context
 //   - peerID types.NodeID
 //   - height uint64
-func (_e *SnapshotClient_Expecter) GetLightBlock(ctx interface{}, peerID interface{}, height interface{}) *SnapshotClient_GetLightBlock_Call {
+func (_e *SnapshotClient_Expecter) GetLightBlock(ctx any, peerID any, height any) *SnapshotClient_GetLightBlock_Call {
 	return &SnapshotClient_GetLightBlock_Call{Call: _e.mock.On("GetLightBlock", ctx, peerID, height)}
 }
 
@@ -237,7 +237,7 @@ type SnapshotClient_GetParams_Call struct {
 //   - ctx context.Context
 //   - peerID types.NodeID
 //   - height uint64
-func (_e *SnapshotClient_Expecter) GetParams(ctx interface{}, peerID interface{}, height interface{}) *SnapshotClient_GetParams_Call {
+func (_e *SnapshotClient_Expecter) GetParams(ctx any, peerID any, height any) *SnapshotClient_GetParams_Call {
 	return &SnapshotClient_GetParams_Call{Call: _e.mock.On("GetParams", ctx, peerID, height)}
 }
 
@@ -299,7 +299,7 @@ type SnapshotClient_GetSnapshots_Call struct {
 // GetSnapshots is a helper method to define mock.On call
 //   - ctx context.Context
 //   - peerID types.NodeID
-func (_e *SnapshotClient_Expecter) GetSnapshots(ctx interface{}, peerID interface{}) *SnapshotClient_GetSnapshots_Call {
+func (_e *SnapshotClient_Expecter) GetSnapshots(ctx any, peerID any) *SnapshotClient_GetSnapshots_Call {
 	return &SnapshotClient_GetSnapshots_Call{Call: _e.mock.On("GetSnapshots", ctx, peerID)}
 }
 

--- a/internal/p2p/mocks/channel.go
+++ b/internal/p2p/mocks/channel.go
@@ -108,7 +108,7 @@ type Channel_Receive_Call struct {
 
 // Receive is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *Channel_Expecter) Receive(context1 interface{}) *Channel_Receive_Call {
+func (_e *Channel_Expecter) Receive(context1 any) *Channel_Receive_Call {
 	return &Channel_Receive_Call{Call: _e.mock.On("Receive", context1)}
 }
 
@@ -160,7 +160,7 @@ type Channel_Send_Call struct {
 // Send is a helper method to define mock.On call
 //   - context1 context.Context
 //   - envelope p2p.Envelope
-func (_e *Channel_Expecter) Send(context1 interface{}, envelope interface{}) *Channel_Send_Call {
+func (_e *Channel_Expecter) Send(context1 any, envelope any) *Channel_Send_Call {
 	return &Channel_Send_Call{Call: _e.mock.On("Send", context1, envelope)}
 }
 
@@ -217,7 +217,7 @@ type Channel_SendError_Call struct {
 // SendError is a helper method to define mock.On call
 //   - context1 context.Context
 //   - peerError p2p.PeerError
-func (_e *Channel_Expecter) SendError(context1 interface{}, peerError interface{}) *Channel_SendError_Call {
+func (_e *Channel_Expecter) SendError(context1 any, peerError any) *Channel_SendError_Call {
 	return &Channel_SendError_Call{Call: _e.mock.On("SendError", context1, peerError)}
 }
 

--- a/internal/p2p/mocks/connection.go
+++ b/internal/p2p/mocks/connection.go
@@ -129,7 +129,7 @@ type Connection_Handshake_Call struct {
 //   - duration time.Duration
 //   - nodeInfo types.NodeInfo
 //   - privKey crypto.PrivKey
-func (_e *Connection_Expecter) Handshake(context1 interface{}, duration interface{}, nodeInfo interface{}, privKey interface{}) *Connection_Handshake_Call {
+func (_e *Connection_Expecter) Handshake(context1 any, duration any, nodeInfo any, privKey any) *Connection_Handshake_Call {
 	return &Connection_Handshake_Call{Call: _e.mock.On("Handshake", context1, duration, nodeInfo, privKey)}
 }
 
@@ -256,7 +256,7 @@ type Connection_ReceiveMessage_Call struct {
 
 // ReceiveMessage is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *Connection_Expecter) ReceiveMessage(context1 interface{}) *Connection_ReceiveMessage_Call {
+func (_e *Connection_Expecter) ReceiveMessage(context1 any) *Connection_ReceiveMessage_Call {
 	return &Connection_ReceiveMessage_Call{Call: _e.mock.On("ReceiveMessage", context1)}
 }
 
@@ -273,8 +273,8 @@ func (_c *Connection_ReceiveMessage_Call) Run(run func(context1 context.Context)
 	return _c
 }
 
-func (_c *Connection_ReceiveMessage_Call) Return(v p2p.ChannelID, bytes []byte, err error) *Connection_ReceiveMessage_Call {
-	_c.Call.Return(v, bytes, err)
+func (_c *Connection_ReceiveMessage_Call) Return(channelID p2p.ChannelID, bytes []byte, err error) *Connection_ReceiveMessage_Call {
+	_c.Call.Return(channelID, bytes, err)
 	return _c
 }
 
@@ -328,8 +328,8 @@ func (_c *Connection_RemoteEndpoint_Call) RunAndReturn(run func() p2p.Endpoint) 
 }
 
 // SendMessage provides a mock function for the type Connection
-func (_mock *Connection) SendMessage(context1 context.Context, v p2p.ChannelID, bytes []byte) error {
-	ret := _mock.Called(context1, v, bytes)
+func (_mock *Connection) SendMessage(context1 context.Context, channelID p2p.ChannelID, bytes []byte) error {
+	ret := _mock.Called(context1, channelID, bytes)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendMessage")
@@ -337,7 +337,7 @@ func (_mock *Connection) SendMessage(context1 context.Context, v p2p.ChannelID, 
 
 	var r0 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, p2p.ChannelID, []byte) error); ok {
-		r0 = returnFunc(context1, v, bytes)
+		r0 = returnFunc(context1, channelID, bytes)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -351,13 +351,13 @@ type Connection_SendMessage_Call struct {
 
 // SendMessage is a helper method to define mock.On call
 //   - context1 context.Context
-//   - v p2p.ChannelID
+//   - channelID p2p.ChannelID
 //   - bytes []byte
-func (_e *Connection_Expecter) SendMessage(context1 interface{}, v interface{}, bytes interface{}) *Connection_SendMessage_Call {
-	return &Connection_SendMessage_Call{Call: _e.mock.On("SendMessage", context1, v, bytes)}
+func (_e *Connection_Expecter) SendMessage(context1 any, channelID any, bytes any) *Connection_SendMessage_Call {
+	return &Connection_SendMessage_Call{Call: _e.mock.On("SendMessage", context1, channelID, bytes)}
 }
 
-func (_c *Connection_SendMessage_Call) Run(run func(context1 context.Context, v p2p.ChannelID, bytes []byte)) *Connection_SendMessage_Call {
+func (_c *Connection_SendMessage_Call) Run(run func(context1 context.Context, channelID p2p.ChannelID, bytes []byte)) *Connection_SendMessage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -385,7 +385,7 @@ func (_c *Connection_SendMessage_Call) Return(err error) *Connection_SendMessage
 	return _c
 }
 
-func (_c *Connection_SendMessage_Call) RunAndReturn(run func(context1 context.Context, v p2p.ChannelID, bytes []byte) error) *Connection_SendMessage_Call {
+func (_c *Connection_SendMessage_Call) RunAndReturn(run func(context1 context.Context, channelID p2p.ChannelID, bytes []byte) error) *Connection_SendMessage_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/p2p/mocks/transport.go
+++ b/internal/p2p/mocks/transport.go
@@ -73,7 +73,7 @@ type Transport_Accept_Call struct {
 
 // Accept is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *Transport_Expecter) Accept(context1 interface{}) *Transport_Accept_Call {
+func (_e *Transport_Expecter) Accept(context1 any) *Transport_Accept_Call {
 	return &Transport_Accept_Call{Call: _e.mock.On("Accept", context1)}
 }
 
@@ -101,8 +101,8 @@ func (_c *Transport_Accept_Call) RunAndReturn(run func(context1 context.Context)
 }
 
 // AddChannelDescriptors provides a mock function for the type Transport
-func (_mock *Transport) AddChannelDescriptors(vs []*p2p.ChannelDescriptor) {
-	_mock.Called(vs)
+func (_mock *Transport) AddChannelDescriptors(channelDescriptors []*p2p.ChannelDescriptor) {
+	_mock.Called(channelDescriptors)
 	return
 }
 
@@ -112,12 +112,12 @@ type Transport_AddChannelDescriptors_Call struct {
 }
 
 // AddChannelDescriptors is a helper method to define mock.On call
-//   - vs []*p2p.ChannelDescriptor
-func (_e *Transport_Expecter) AddChannelDescriptors(vs interface{}) *Transport_AddChannelDescriptors_Call {
-	return &Transport_AddChannelDescriptors_Call{Call: _e.mock.On("AddChannelDescriptors", vs)}
+//   - channelDescriptors []*p2p.ChannelDescriptor
+func (_e *Transport_Expecter) AddChannelDescriptors(channelDescriptors any) *Transport_AddChannelDescriptors_Call {
+	return &Transport_AddChannelDescriptors_Call{Call: _e.mock.On("AddChannelDescriptors", channelDescriptors)}
 }
 
-func (_c *Transport_AddChannelDescriptors_Call) Run(run func(vs []*p2p.ChannelDescriptor)) *Transport_AddChannelDescriptors_Call {
+func (_c *Transport_AddChannelDescriptors_Call) Run(run func(channelDescriptors []*p2p.ChannelDescriptor)) *Transport_AddChannelDescriptors_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 []*p2p.ChannelDescriptor
 		if args[0] != nil {
@@ -135,7 +135,7 @@ func (_c *Transport_AddChannelDescriptors_Call) Return() *Transport_AddChannelDe
 	return _c
 }
 
-func (_c *Transport_AddChannelDescriptors_Call) RunAndReturn(run func(vs []*p2p.ChannelDescriptor)) *Transport_AddChannelDescriptors_Call {
+func (_c *Transport_AddChannelDescriptors_Call) RunAndReturn(run func(channelDescriptors []*p2p.ChannelDescriptor)) *Transport_AddChannelDescriptors_Call {
 	_c.Run(run)
 	return _c
 }
@@ -220,7 +220,7 @@ type Transport_Dial_Call struct {
 // Dial is a helper method to define mock.On call
 //   - context1 context.Context
 //   - endpoint *p2p.Endpoint
-func (_e *Transport_Expecter) Dial(context1 interface{}, endpoint interface{}) *Transport_Dial_Call {
+func (_e *Transport_Expecter) Dial(context1 any, endpoint any) *Transport_Dial_Call {
 	return &Transport_Dial_Call{Call: _e.mock.On("Dial", context1, endpoint)}
 }
 
@@ -331,7 +331,7 @@ type Transport_Listen_Call struct {
 
 // Listen is a helper method to define mock.On call
 //   - endpoint *p2p.Endpoint
-func (_e *Transport_Expecter) Listen(endpoint interface{}) *Transport_Listen_Call {
+func (_e *Transport_Expecter) Listen(endpoint any) *Transport_Listen_Call {
 	return &Transport_Listen_Call{Call: _e.mock.On("Listen", endpoint)}
 }
 

--- a/internal/rpc/core/mempool.go
+++ b/internal/rpc/core/mempool.go
@@ -146,10 +146,10 @@ func (env *Environment) BroadcastTxCommit(ctx context.Context, req *coretypes.Re
 					"duration", time.Since(startAt),
 					"err", err)
 				return &coretypes.ResultBroadcastTxCommit{
-						CheckTx: *r,
-						Hash:    req.Tx.Hash(),
-					}, fmt.Errorf("timeout waiting for commit of tx %s (%s)",
-						req.Tx.Hash(), time.Since(startAt))
+					CheckTx: *r,
+					Hash:    req.Tx.Hash(),
+				}, fmt.Errorf("timeout waiting for commit of tx %s (%s)",
+					req.Tx.Hash(), time.Since(startAt))
 			case <-timer.C:
 				txres, err := env.Tx(ctx, &coretypes.RequestTx{
 					Hash:  req.Tx.Hash(),

--- a/internal/state/indexer/mocks/eventsink.go
+++ b/internal/state/indexer/mocks/eventsink.go
@@ -76,7 +76,7 @@ type EventSink_GetTxByHash_Call struct {
 
 // GetTxByHash is a helper method to define mock.On call
 //   - bytes []byte
-func (_e *EventSink_Expecter) GetTxByHash(bytes interface{}) *EventSink_GetTxByHash_Call {
+func (_e *EventSink_Expecter) GetTxByHash(bytes any) *EventSink_GetTxByHash_Call {
 	return &EventSink_GetTxByHash_Call{Call: _e.mock.On("GetTxByHash", bytes)}
 }
 
@@ -136,7 +136,7 @@ type EventSink_HasBlock_Call struct {
 
 // HasBlock is a helper method to define mock.On call
 //   - n int64
-func (_e *EventSink_Expecter) HasBlock(n interface{}) *EventSink_HasBlock_Call {
+func (_e *EventSink_Expecter) HasBlock(n any) *EventSink_HasBlock_Call {
 	return &EventSink_HasBlock_Call{Call: _e.mock.On("HasBlock", n)}
 }
 
@@ -187,7 +187,7 @@ type EventSink_IndexBlockEvents_Call struct {
 
 // IndexBlockEvents is a helper method to define mock.On call
 //   - eventDataNewBlockHeader types0.EventDataNewBlockHeader
-func (_e *EventSink_Expecter) IndexBlockEvents(eventDataNewBlockHeader interface{}) *EventSink_IndexBlockEvents_Call {
+func (_e *EventSink_Expecter) IndexBlockEvents(eventDataNewBlockHeader any) *EventSink_IndexBlockEvents_Call {
 	return &EventSink_IndexBlockEvents_Call{Call: _e.mock.On("IndexBlockEvents", eventDataNewBlockHeader)}
 }
 
@@ -238,7 +238,7 @@ type EventSink_IndexTxEvents_Call struct {
 
 // IndexTxEvents is a helper method to define mock.On call
 //   - txResults []*types.TxResult
-func (_e *EventSink_Expecter) IndexTxEvents(txResults interface{}) *EventSink_IndexTxEvents_Call {
+func (_e *EventSink_Expecter) IndexTxEvents(txResults any) *EventSink_IndexTxEvents_Call {
 	return &EventSink_IndexTxEvents_Call{Call: _e.mock.On("IndexTxEvents", txResults)}
 }
 
@@ -301,7 +301,7 @@ type EventSink_SearchBlockEvents_Call struct {
 // SearchBlockEvents is a helper method to define mock.On call
 //   - context1 context.Context
 //   - query1 *query.Query
-func (_e *EventSink_Expecter) SearchBlockEvents(context1 interface{}, query1 interface{}) *EventSink_SearchBlockEvents_Call {
+func (_e *EventSink_Expecter) SearchBlockEvents(context1 any, query1 any) *EventSink_SearchBlockEvents_Call {
 	return &EventSink_SearchBlockEvents_Call{Call: _e.mock.On("SearchBlockEvents", context1, query1)}
 }
 
@@ -369,7 +369,7 @@ type EventSink_SearchTxEvents_Call struct {
 // SearchTxEvents is a helper method to define mock.On call
 //   - context1 context.Context
 //   - query1 *query.Query
-func (_e *EventSink_Expecter) SearchTxEvents(context1 interface{}, query1 interface{}) *EventSink_SearchTxEvents_Call {
+func (_e *EventSink_Expecter) SearchTxEvents(context1 any, query1 any) *EventSink_SearchTxEvents_Call {
 	return &EventSink_SearchTxEvents_Call{Call: _e.mock.On("SearchTxEvents", context1, query1)}
 }
 

--- a/internal/state/mocks/blockstore.go
+++ b/internal/state/mocks/blockstore.go
@@ -240,7 +240,7 @@ type BlockStore_LoadBlock_Call struct {
 
 // LoadBlock is a helper method to define mock.On call
 //   - height int64
-func (_e *BlockStore_Expecter) LoadBlock(height interface{}) *BlockStore_LoadBlock_Call {
+func (_e *BlockStore_Expecter) LoadBlock(height any) *BlockStore_LoadBlock_Call {
 	return &BlockStore_LoadBlock_Call{Call: _e.mock.On("LoadBlock", height)}
 }
 
@@ -293,7 +293,7 @@ type BlockStore_LoadBlockByHash_Call struct {
 
 // LoadBlockByHash is a helper method to define mock.On call
 //   - hash []byte
-func (_e *BlockStore_Expecter) LoadBlockByHash(hash interface{}) *BlockStore_LoadBlockByHash_Call {
+func (_e *BlockStore_Expecter) LoadBlockByHash(hash any) *BlockStore_LoadBlockByHash_Call {
 	return &BlockStore_LoadBlockByHash_Call{Call: _e.mock.On("LoadBlockByHash", hash)}
 }
 
@@ -346,7 +346,7 @@ type BlockStore_LoadBlockCommit_Call struct {
 
 // LoadBlockCommit is a helper method to define mock.On call
 //   - height int64
-func (_e *BlockStore_Expecter) LoadBlockCommit(height interface{}) *BlockStore_LoadBlockCommit_Call {
+func (_e *BlockStore_Expecter) LoadBlockCommit(height any) *BlockStore_LoadBlockCommit_Call {
 	return &BlockStore_LoadBlockCommit_Call{Call: _e.mock.On("LoadBlockCommit", height)}
 }
 
@@ -399,7 +399,7 @@ type BlockStore_LoadBlockMeta_Call struct {
 
 // LoadBlockMeta is a helper method to define mock.On call
 //   - height int64
-func (_e *BlockStore_Expecter) LoadBlockMeta(height interface{}) *BlockStore_LoadBlockMeta_Call {
+func (_e *BlockStore_Expecter) LoadBlockMeta(height any) *BlockStore_LoadBlockMeta_Call {
 	return &BlockStore_LoadBlockMeta_Call{Call: _e.mock.On("LoadBlockMeta", height)}
 }
 
@@ -452,7 +452,7 @@ type BlockStore_LoadBlockMetaByHash_Call struct {
 
 // LoadBlockMetaByHash is a helper method to define mock.On call
 //   - hash []byte
-func (_e *BlockStore_Expecter) LoadBlockMetaByHash(hash interface{}) *BlockStore_LoadBlockMetaByHash_Call {
+func (_e *BlockStore_Expecter) LoadBlockMetaByHash(hash any) *BlockStore_LoadBlockMetaByHash_Call {
 	return &BlockStore_LoadBlockMetaByHash_Call{Call: _e.mock.On("LoadBlockMetaByHash", hash)}
 }
 
@@ -506,7 +506,7 @@ type BlockStore_LoadBlockPart_Call struct {
 // LoadBlockPart is a helper method to define mock.On call
 //   - height int64
 //   - index int
-func (_e *BlockStore_Expecter) LoadBlockPart(height interface{}, index interface{}) *BlockStore_LoadBlockPart_Call {
+func (_e *BlockStore_Expecter) LoadBlockPart(height any, index any) *BlockStore_LoadBlockPart_Call {
 	return &BlockStore_LoadBlockPart_Call{Call: _e.mock.On("LoadBlockPart", height, index)}
 }
 
@@ -610,7 +610,7 @@ type BlockStore_LoadSeenCommitAt_Call struct {
 
 // LoadSeenCommitAt is a helper method to define mock.On call
 //   - height int64
-func (_e *BlockStore_Expecter) LoadSeenCommitAt(height interface{}) *BlockStore_LoadSeenCommitAt_Call {
+func (_e *BlockStore_Expecter) LoadSeenCommitAt(height any) *BlockStore_LoadSeenCommitAt_Call {
 	return &BlockStore_LoadSeenCommitAt_Call{Call: _e.mock.On("LoadSeenCommitAt", height)}
 }
 
@@ -670,7 +670,7 @@ type BlockStore_PruneBlocks_Call struct {
 
 // PruneBlocks is a helper method to define mock.On call
 //   - height int64
-func (_e *BlockStore_Expecter) PruneBlocks(height interface{}) *BlockStore_PruneBlocks_Call {
+func (_e *BlockStore_Expecter) PruneBlocks(height any) *BlockStore_PruneBlocks_Call {
 	return &BlockStore_PruneBlocks_Call{Call: _e.mock.On("PruneBlocks", height)}
 }
 
@@ -712,7 +712,7 @@ type BlockStore_SaveBlock_Call struct {
 //   - block *types.Block
 //   - blockParts *types.PartSet
 //   - seenCommit *types.Commit
-func (_e *BlockStore_Expecter) SaveBlock(block interface{}, blockParts interface{}, seenCommit interface{}) *BlockStore_SaveBlock_Call {
+func (_e *BlockStore_Expecter) SaveBlock(block any, blockParts any, seenCommit any) *BlockStore_SaveBlock_Call {
 	return &BlockStore_SaveBlock_Call{Call: _e.mock.On("SaveBlock", block, blockParts, seenCommit)}
 }
 

--- a/internal/state/mocks/evidencepool.go
+++ b/internal/state/mocks/evidencepool.go
@@ -64,7 +64,7 @@ type EvidencePool_AddEvidence_Call struct {
 // AddEvidence is a helper method to define mock.On call
 //   - context1 context.Context
 //   - evidence types.Evidence
-func (_e *EvidencePool_Expecter) AddEvidence(context1 interface{}, evidence interface{}) *EvidencePool_AddEvidence_Call {
+func (_e *EvidencePool_Expecter) AddEvidence(context1 any, evidence any) *EvidencePool_AddEvidence_Call {
 	return &EvidencePool_AddEvidence_Call{Call: _e.mock.On("AddEvidence", context1, evidence)}
 }
 
@@ -121,7 +121,7 @@ type EvidencePool_CheckEvidence_Call struct {
 // CheckEvidence is a helper method to define mock.On call
 //   - context1 context.Context
 //   - evidenceList types.EvidenceList
-func (_e *EvidencePool_Expecter) CheckEvidence(context1 interface{}, evidenceList interface{}) *EvidencePool_CheckEvidence_Call {
+func (_e *EvidencePool_Expecter) CheckEvidence(context1 any, evidenceList any) *EvidencePool_CheckEvidence_Call {
 	return &EvidencePool_CheckEvidence_Call{Call: _e.mock.On("CheckEvidence", context1, evidenceList)}
 }
 
@@ -188,7 +188,7 @@ type EvidencePool_PendingEvidence_Call struct {
 
 // PendingEvidence is a helper method to define mock.On call
 //   - maxBytes int64
-func (_e *EvidencePool_Expecter) PendingEvidence(maxBytes interface{}) *EvidencePool_PendingEvidence_Call {
+func (_e *EvidencePool_Expecter) PendingEvidence(maxBytes any) *EvidencePool_PendingEvidence_Call {
 	return &EvidencePool_PendingEvidence_Call{Call: _e.mock.On("PendingEvidence", maxBytes)}
 }
 
@@ -230,7 +230,7 @@ type EvidencePool_Update_Call struct {
 //   - context1 context.Context
 //   - state1 state.State
 //   - evidenceList types.EvidenceList
-func (_e *EvidencePool_Expecter) Update(context1 interface{}, state1 interface{}, evidenceList interface{}) *EvidencePool_Update_Call {
+func (_e *EvidencePool_Expecter) Update(context1 any, state1 any, evidenceList any) *EvidencePool_Update_Call {
 	return &EvidencePool_Update_Call{Call: _e.mock.On("Update", context1, state1, evidenceList)}
 }
 

--- a/internal/state/mocks/executor.go
+++ b/internal/state/mocks/executor.go
@@ -76,7 +76,7 @@ type Executor_ApplyBlock_Call struct {
 //   - blockID types.BlockID
 //   - block *types.Block
 //   - commit *types.Commit
-func (_e *Executor_Expecter) ApplyBlock(ctx interface{}, state1 interface{}, blockID interface{}, block interface{}, commit interface{}) *Executor_ApplyBlock_Call {
+func (_e *Executor_Expecter) ApplyBlock(ctx any, state1 any, blockID any, block any, commit any) *Executor_ApplyBlock_Call {
 	return &Executor_ApplyBlock_Call{Call: _e.mock.On("ApplyBlock", ctx, state1, blockID, block, commit)}
 }
 
@@ -170,7 +170,7 @@ type Executor_CreateProposalBlock_Call struct {
 //   - commit *types.Commit
 //   - proposerProTxHash []byte
 //   - proposedAppVersion uint64
-func (_e *Executor_Expecter) CreateProposalBlock(ctx interface{}, height interface{}, round interface{}, state1 interface{}, commit interface{}, proposerProTxHash interface{}, proposedAppVersion interface{}) *Executor_CreateProposalBlock_Call {
+func (_e *Executor_Expecter) CreateProposalBlock(ctx any, height any, round any, state1 any, commit any, proposerProTxHash any, proposedAppVersion any) *Executor_CreateProposalBlock_Call {
 	return &Executor_CreateProposalBlock_Call{Call: _e.mock.On("CreateProposalBlock", ctx, height, round, state1, commit, proposerProTxHash, proposedAppVersion)}
 }
 
@@ -241,7 +241,7 @@ type Executor_ExtendVote_Call struct {
 // ExtendVote is a helper method to define mock.On call
 //   - ctx context.Context
 //   - vote *types.Vote
-func (_e *Executor_Expecter) ExtendVote(ctx interface{}, vote interface{}) *Executor_ExtendVote_Call {
+func (_e *Executor_Expecter) ExtendVote(ctx any, vote any) *Executor_ExtendVote_Call {
 	return &Executor_ExtendVote_Call{Call: _e.mock.On("ExtendVote", ctx, vote)}
 }
 
@@ -311,7 +311,7 @@ type Executor_FinalizeBlock_Call struct {
 //   - blockID types.BlockID
 //   - block *types.Block
 //   - commit *types.Commit
-func (_e *Executor_Expecter) FinalizeBlock(ctx interface{}, state1 interface{}, uncommittedState interface{}, blockID interface{}, block interface{}, commit interface{}) *Executor_FinalizeBlock_Call {
+func (_e *Executor_Expecter) FinalizeBlock(ctx any, state1 any, uncommittedState any, blockID any, block any, commit any) *Executor_FinalizeBlock_Call {
 	return &Executor_FinalizeBlock_Call{Call: _e.mock.On("FinalizeBlock", ctx, state1, uncommittedState, blockID, block, commit)}
 }
 
@@ -400,7 +400,7 @@ type Executor_ProcessProposal_Call struct {
 //   - round int32
 //   - state1 state.State
 //   - verify bool
-func (_e *Executor_Expecter) ProcessProposal(ctx interface{}, block interface{}, round interface{}, state1 interface{}, verify interface{}) *Executor_ProcessProposal_Call {
+func (_e *Executor_Expecter) ProcessProposal(ctx any, block any, round any, state1 any, verify any) *Executor_ProcessProposal_Call {
 	return &Executor_ProcessProposal_Call{Call: _e.mock.On("ProcessProposal", ctx, block, round, state1, verify)}
 }
 
@@ -473,7 +473,7 @@ type Executor_ValidateBlock_Call struct {
 //   - ctx context.Context
 //   - state1 state.State
 //   - block *types.Block
-func (_e *Executor_Expecter) ValidateBlock(ctx interface{}, state1 interface{}, block interface{}) *Executor_ValidateBlock_Call {
+func (_e *Executor_Expecter) ValidateBlock(ctx any, state1 any, block any) *Executor_ValidateBlock_Call {
 	return &Executor_ValidateBlock_Call{Call: _e.mock.On("ValidateBlock", ctx, state1, block)}
 }
 
@@ -537,7 +537,7 @@ type Executor_ValidateBlockWithRoundState_Call struct {
 //   - state1 state.State
 //   - uncommittedState state.CurrentRoundState
 //   - block *types.Block
-func (_e *Executor_Expecter) ValidateBlockWithRoundState(ctx interface{}, state1 interface{}, uncommittedState interface{}, block interface{}) *Executor_ValidateBlockWithRoundState_Call {
+func (_e *Executor_Expecter) ValidateBlockWithRoundState(ctx any, state1 any, uncommittedState any, block any) *Executor_ValidateBlockWithRoundState_Call {
 	return &Executor_ValidateBlockWithRoundState_Call{Call: _e.mock.On("ValidateBlockWithRoundState", ctx, state1, uncommittedState, block)}
 }
 
@@ -604,7 +604,7 @@ type Executor_VerifyVoteExtension_Call struct {
 // VerifyVoteExtension is a helper method to define mock.On call
 //   - ctx context.Context
 //   - vote *types.Vote
-func (_e *Executor_Expecter) VerifyVoteExtension(ctx interface{}, vote interface{}) *Executor_VerifyVoteExtension_Call {
+func (_e *Executor_Expecter) VerifyVoteExtension(ctx any, vote any) *Executor_VerifyVoteExtension_Call {
 	return &Executor_VerifyVoteExtension_Call{Call: _e.mock.On("VerifyVoteExtension", ctx, vote)}
 }
 

--- a/internal/state/mocks/store.go
+++ b/internal/state/mocks/store.go
@@ -63,7 +63,7 @@ type Store_Bootstrap_Call struct {
 
 // Bootstrap is a helper method to define mock.On call
 //   - state1 state.State
-func (_e *Store_Expecter) Bootstrap(state1 interface{}) *Store_Bootstrap_Call {
+func (_e *Store_Expecter) Bootstrap(state1 any) *Store_Bootstrap_Call {
 	return &Store_Bootstrap_Call{Call: _e.mock.On("Bootstrap", state1)}
 }
 
@@ -222,7 +222,7 @@ type Store_LoadABCIResponses_Call struct {
 
 // LoadABCIResponses is a helper method to define mock.On call
 //   - n int64
-func (_e *Store_Expecter) LoadABCIResponses(n interface{}) *Store_LoadABCIResponses_Call {
+func (_e *Store_Expecter) LoadABCIResponses(n any) *Store_LoadABCIResponses_Call {
 	return &Store_LoadABCIResponses_Call{Call: _e.mock.On("LoadABCIResponses", n)}
 }
 
@@ -282,7 +282,7 @@ type Store_LoadConsensusParams_Call struct {
 
 // LoadConsensusParams is a helper method to define mock.On call
 //   - n int64
-func (_e *Store_Expecter) LoadConsensusParams(n interface{}) *Store_LoadConsensusParams_Call {
+func (_e *Store_Expecter) LoadConsensusParams(n any) *Store_LoadConsensusParams_Call {
 	return &Store_LoadConsensusParams_Call{Call: _e.mock.On("LoadConsensusParams", n)}
 }
 
@@ -345,7 +345,7 @@ type Store_LoadValidators_Call struct {
 // LoadValidators is a helper method to define mock.On call
 //   - n int64
 //   - blockStore selectproposer.BlockStore
-func (_e *Store_Expecter) LoadValidators(n interface{}, blockStore interface{}) *Store_LoadValidators_Call {
+func (_e *Store_Expecter) LoadValidators(n any, blockStore any) *Store_LoadValidators_Call {
 	return &Store_LoadValidators_Call{Call: _e.mock.On("LoadValidators", n, blockStore)}
 }
 
@@ -401,7 +401,7 @@ type Store_PruneStates_Call struct {
 
 // PruneStates is a helper method to define mock.On call
 //   - n int64
-func (_e *Store_Expecter) PruneStates(n interface{}) *Store_PruneStates_Call {
+func (_e *Store_Expecter) PruneStates(n any) *Store_PruneStates_Call {
 	return &Store_PruneStates_Call{Call: _e.mock.On("PruneStates", n)}
 }
 
@@ -452,7 +452,7 @@ type Store_Save_Call struct {
 
 // Save is a helper method to define mock.On call
 //   - state1 state.State
-func (_e *Store_Expecter) Save(state1 interface{}) *Store_Save_Call {
+func (_e *Store_Expecter) Save(state1 any) *Store_Save_Call {
 	return &Store_Save_Call{Call: _e.mock.On("Save", state1)}
 }
 
@@ -504,7 +504,7 @@ type Store_SaveABCIResponses_Call struct {
 // SaveABCIResponses is a helper method to define mock.On call
 //   - n int64
 //   - aBCIResponses state0.ABCIResponses
-func (_e *Store_Expecter) SaveABCIResponses(n interface{}, aBCIResponses interface{}) *Store_SaveABCIResponses_Call {
+func (_e *Store_Expecter) SaveABCIResponses(n any, aBCIResponses any) *Store_SaveABCIResponses_Call {
 	return &Store_SaveABCIResponses_Call{Call: _e.mock.On("SaveABCIResponses", n, aBCIResponses)}
 }
 
@@ -562,7 +562,7 @@ type Store_SaveValidatorSets_Call struct {
 //   - n int64
 //   - n1 int64
 //   - validatorSet *types.ValidatorSet
-func (_e *Store_Expecter) SaveValidatorSets(n interface{}, n1 interface{}, validatorSet interface{}) *Store_SaveValidatorSets_Call {
+func (_e *Store_Expecter) SaveValidatorSets(n any, n1 any, validatorSet any) *Store_SaveValidatorSets_Call {
 	return &Store_SaveValidatorSets_Call{Call: _e.mock.On("SaveValidatorSets", n, n1, validatorSet)}
 }
 

--- a/internal/statesync/mocks/consensusstateprovider.go
+++ b/internal/statesync/mocks/consensusstateprovider.go
@@ -104,7 +104,7 @@ type ConsensusStateProvider_PublishCommitEvent_Call struct {
 
 // PublishCommitEvent is a helper method to define mock.On call
 //   - commit *types.Commit
-func (_e *ConsensusStateProvider_Expecter) PublishCommitEvent(commit interface{}) *ConsensusStateProvider_PublishCommitEvent_Call {
+func (_e *ConsensusStateProvider_Expecter) PublishCommitEvent(commit any) *ConsensusStateProvider_PublishCommitEvent_Call {
 	return &ConsensusStateProvider_PublishCommitEvent_Call{Call: _e.mock.On("PublishCommitEvent", commit)}
 }
 

--- a/internal/statesync/mocks/stateprovider.go
+++ b/internal/statesync/mocks/stateprovider.go
@@ -76,7 +76,7 @@ type StateProvider_AppHash_Call struct {
 // AppHash is a helper method to define mock.On call
 //   - ctx context.Context
 //   - height uint64
-func (_e *StateProvider_Expecter) AppHash(ctx interface{}, height interface{}) *StateProvider_AppHash_Call {
+func (_e *StateProvider_Expecter) AppHash(ctx any, height any) *StateProvider_AppHash_Call {
 	return &StateProvider_AppHash_Call{Call: _e.mock.On("AppHash", ctx, height)}
 }
 
@@ -144,7 +144,7 @@ type StateProvider_Commit_Call struct {
 // Commit is a helper method to define mock.On call
 //   - ctx context.Context
 //   - height uint64
-func (_e *StateProvider_Expecter) Commit(ctx interface{}, height interface{}) *StateProvider_Commit_Call {
+func (_e *StateProvider_Expecter) Commit(ctx any, height any) *StateProvider_Commit_Call {
 	return &StateProvider_Commit_Call{Call: _e.mock.On("Commit", ctx, height)}
 }
 
@@ -210,7 +210,7 @@ type StateProvider_State_Call struct {
 // State is a helper method to define mock.On call
 //   - ctx context.Context
 //   - height uint64
-func (_e *StateProvider_Expecter) State(ctx interface{}, height interface{}) *StateProvider_State_Call {
+func (_e *StateProvider_Expecter) State(ctx any, height any) *StateProvider_State_Call {
 	return &StateProvider_State_Call{Call: _e.mock.On("State", ctx, height)}
 }
 

--- a/libs/store/mocks/store.go
+++ b/libs/store/mocks/store.go
@@ -95,7 +95,7 @@ type Store_Delete_Call[K comparable, V any] struct {
 
 // Delete is a helper method to define mock.On call
 //   - key K
-func (_e *Store_Expecter[K, V]) Delete(key interface{}) *Store_Delete_Call[K, V] {
+func (_e *Store_Expecter[K, V]) Delete(key any) *Store_Delete_Call[K, V] {
 	return &Store_Delete_Call[K, V]{Call: _e.mock.On("Delete", key)}
 }
 
@@ -157,7 +157,7 @@ type Store_Get_Call[K comparable, V any] struct {
 
 // Get is a helper method to define mock.On call
 //   - key K
-func (_e *Store_Expecter[K, V]) Get(key interface{}) *Store_Get_Call[K, V] {
+func (_e *Store_Expecter[K, V]) Get(key any) *Store_Get_Call[K, V] {
 	return &Store_Get_Call[K, V]{Call: _e.mock.On("Get", key)}
 }
 
@@ -219,7 +219,7 @@ type Store_GetAndDelete_Call[K comparable, V any] struct {
 
 // GetAndDelete is a helper method to define mock.On call
 //   - key K
-func (_e *Store_Expecter[K, V]) GetAndDelete(key interface{}) *Store_GetAndDelete_Call[K, V] {
+func (_e *Store_Expecter[K, V]) GetAndDelete(key any) *Store_GetAndDelete_Call[K, V] {
 	return &Store_GetAndDelete_Call[K, V]{Call: _e.mock.On("GetAndDelete", key)}
 }
 
@@ -348,7 +348,7 @@ type Store_Put_Call[K comparable, V any] struct {
 // Put is a helper method to define mock.On call
 //   - key K
 //   - data V
-func (_e *Store_Expecter[K, V]) Put(key interface{}, data interface{}) *Store_Put_Call[K, V] {
+func (_e *Store_Expecter[K, V]) Put(key any, data any) *Store_Put_Call[K, V] {
 	return &Store_Put_Call[K, V]{Call: _e.mock.On("Put", key, data)}
 }
 
@@ -407,7 +407,7 @@ type Store_Query_Call[K comparable, V any] struct {
 // Query is a helper method to define mock.On call
 //   - spec store.QueryFunc[K, V]
 //   - limit int
-func (_e *Store_Expecter[K, V]) Query(spec interface{}, limit interface{}) *Store_Query_Call[K, V] {
+func (_e *Store_Expecter[K, V]) Query(spec any, limit any) *Store_Query_Call[K, V] {
 	return &Store_Query_Call[K, V]{Call: _e.mock.On("Query", spec, limit)}
 }
 
@@ -458,9 +458,9 @@ type Store_Update_Call[K comparable, V any] struct {
 // Update is a helper method to define mock.On call
 //   - key K
 //   - updates ...store.UpdateFunc[K, V]
-func (_e *Store_Expecter[K, V]) Update(key interface{}, updates ...interface{}) *Store_Update_Call[K, V] {
+func (_e *Store_Expecter[K, V]) Update(key any, updates ...any) *Store_Update_Call[K, V] {
 	return &Store_Update_Call[K, V]{Call: _e.mock.On("Update",
-		append([]interface{}{key}, updates...)...)}
+		append([]any{key}, updates...)...)}
 }
 
 func (_c *Store_Update_Call[K, V]) Run(run func(key K, updates ...store.UpdateFunc[K, V])) *Store_Update_Call[K, V] {

--- a/light/provider/mocks/provider.go
+++ b/light/provider/mocks/provider.go
@@ -118,7 +118,7 @@ type Provider_LightBlock_Call struct {
 // LightBlock is a helper method to define mock.On call
 //   - ctx context.Context
 //   - height int64
-func (_e *Provider_Expecter) LightBlock(ctx interface{}, height interface{}) *Provider_LightBlock_Call {
+func (_e *Provider_Expecter) LightBlock(ctx any, height any) *Provider_LightBlock_Call {
 	return &Provider_LightBlock_Call{Call: _e.mock.On("LightBlock", ctx, height)}
 }
 
@@ -175,7 +175,7 @@ type Provider_ReportEvidence_Call struct {
 // ReportEvidence is a helper method to define mock.On call
 //   - context1 context.Context
 //   - evidence types.Evidence
-func (_e *Provider_Expecter) ReportEvidence(context1 interface{}, evidence interface{}) *Provider_ReportEvidence_Call {
+func (_e *Provider_Expecter) ReportEvidence(context1 any, evidence any) *Provider_ReportEvidence_Call {
 	return &Provider_ReportEvidence_Call{Call: _e.mock.On("ReportEvidence", context1, evidence)}
 }
 

--- a/light/rpc/mocks/lightclient.go
+++ b/light/rpc/mocks/lightclient.go
@@ -109,7 +109,7 @@ type LightClient_Status_Call struct {
 
 // Status is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *LightClient_Expecter) Status(ctx interface{}) *LightClient_Status_Call {
+func (_e *LightClient_Expecter) Status(ctx any) *LightClient_Status_Call {
 	return &LightClient_Status_Call{Call: _e.mock.On("Status", ctx)}
 }
 
@@ -171,7 +171,7 @@ type LightClient_TrustedLightBlock_Call struct {
 
 // TrustedLightBlock is a helper method to define mock.On call
 //   - height int64
-func (_e *LightClient_Expecter) TrustedLightBlock(height interface{}) *LightClient_TrustedLightBlock_Call {
+func (_e *LightClient_Expecter) TrustedLightBlock(height any) *LightClient_TrustedLightBlock_Call {
 	return &LightClient_TrustedLightBlock_Call{Call: _e.mock.On("TrustedLightBlock", height)}
 }
 
@@ -234,7 +234,7 @@ type LightClient_Update_Call struct {
 // Update is a helper method to define mock.On call
 //   - ctx context.Context
 //   - now time.Time
-func (_e *LightClient_Expecter) Update(ctx interface{}, now interface{}) *LightClient_Update_Call {
+func (_e *LightClient_Expecter) Update(ctx any, now any) *LightClient_Update_Call {
 	return &LightClient_Update_Call{Call: _e.mock.On("Update", ctx, now)}
 }
 
@@ -303,7 +303,7 @@ type LightClient_VerifyLightBlockAtHeight_Call struct {
 //   - ctx context.Context
 //   - height int64
 //   - now time.Time
-func (_e *LightClient_Expecter) VerifyLightBlockAtHeight(ctx interface{}, height interface{}, now interface{}) *LightClient_VerifyLightBlockAtHeight_Call {
+func (_e *LightClient_Expecter) VerifyLightBlockAtHeight(ctx any, height any, now any) *LightClient_VerifyLightBlockAtHeight_Call {
 	return &LightClient_VerifyLightBlockAtHeight_Call{Call: _e.mock.On("VerifyLightBlockAtHeight", ctx, height, now)}
 }
 

--- a/rpc/client/mocks/remoteclient.go
+++ b/rpc/client/mocks/remoteclient.go
@@ -76,7 +76,7 @@ type RemoteClient_ABCIInfo_Call struct {
 
 // ABCIInfo is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *RemoteClient_Expecter) ABCIInfo(context1 interface{}) *RemoteClient_ABCIInfo_Call {
+func (_e *RemoteClient_Expecter) ABCIInfo(context1 any) *RemoteClient_ABCIInfo_Call {
 	return &RemoteClient_ABCIInfo_Call{Call: _e.mock.On("ABCIInfo", context1)}
 }
 
@@ -140,7 +140,7 @@ type RemoteClient_ABCIQuery_Call struct {
 //   - ctx context.Context
 //   - path string
 //   - data bytes.HexBytes
-func (_e *RemoteClient_Expecter) ABCIQuery(ctx interface{}, path interface{}, data interface{}) *RemoteClient_ABCIQuery_Call {
+func (_e *RemoteClient_Expecter) ABCIQuery(ctx any, path any, data any) *RemoteClient_ABCIQuery_Call {
 	return &RemoteClient_ABCIQuery_Call{Call: _e.mock.On("ABCIQuery", ctx, path, data)}
 }
 
@@ -215,7 +215,7 @@ type RemoteClient_ABCIQueryWithOptions_Call struct {
 //   - path string
 //   - data bytes.HexBytes
 //   - opts client.ABCIQueryOptions
-func (_e *RemoteClient_Expecter) ABCIQueryWithOptions(ctx interface{}, path interface{}, data interface{}, opts interface{}) *RemoteClient_ABCIQueryWithOptions_Call {
+func (_e *RemoteClient_Expecter) ABCIQueryWithOptions(ctx any, path any, data any, opts any) *RemoteClient_ABCIQueryWithOptions_Call {
 	return &RemoteClient_ABCIQueryWithOptions_Call{Call: _e.mock.On("ABCIQueryWithOptions", ctx, path, data, opts)}
 }
 
@@ -293,7 +293,7 @@ type RemoteClient_Block_Call struct {
 // Block is a helper method to define mock.On call
 //   - ctx context.Context
 //   - height *int64
-func (_e *RemoteClient_Expecter) Block(ctx interface{}, height interface{}) *RemoteClient_Block_Call {
+func (_e *RemoteClient_Expecter) Block(ctx any, height any) *RemoteClient_Block_Call {
 	return &RemoteClient_Block_Call{Call: _e.mock.On("Block", ctx, height)}
 }
 
@@ -361,7 +361,7 @@ type RemoteClient_BlockByHash_Call struct {
 // BlockByHash is a helper method to define mock.On call
 //   - ctx context.Context
 //   - hash bytes.HexBytes
-func (_e *RemoteClient_Expecter) BlockByHash(ctx interface{}, hash interface{}) *RemoteClient_BlockByHash_Call {
+func (_e *RemoteClient_Expecter) BlockByHash(ctx any, hash any) *RemoteClient_BlockByHash_Call {
 	return &RemoteClient_BlockByHash_Call{Call: _e.mock.On("BlockByHash", ctx, hash)}
 }
 
@@ -429,7 +429,7 @@ type RemoteClient_BlockResults_Call struct {
 // BlockResults is a helper method to define mock.On call
 //   - ctx context.Context
 //   - height *int64
-func (_e *RemoteClient_Expecter) BlockResults(ctx interface{}, height interface{}) *RemoteClient_BlockResults_Call {
+func (_e *RemoteClient_Expecter) BlockResults(ctx any, height any) *RemoteClient_BlockResults_Call {
 	return &RemoteClient_BlockResults_Call{Call: _e.mock.On("BlockResults", ctx, height)}
 }
 
@@ -500,7 +500,7 @@ type RemoteClient_BlockSearch_Call struct {
 //   - page *int
 //   - perPage *int
 //   - orderBy string
-func (_e *RemoteClient_Expecter) BlockSearch(ctx interface{}, query interface{}, page interface{}, perPage interface{}, orderBy interface{}) *RemoteClient_BlockSearch_Call {
+func (_e *RemoteClient_Expecter) BlockSearch(ctx any, query any, page any, perPage any, orderBy any) *RemoteClient_BlockSearch_Call {
 	return &RemoteClient_BlockSearch_Call{Call: _e.mock.On("BlockSearch", ctx, query, page, perPage, orderBy)}
 }
 
@@ -584,7 +584,7 @@ type RemoteClient_BlockchainInfo_Call struct {
 //   - ctx context.Context
 //   - minHeight int64
 //   - maxHeight int64
-func (_e *RemoteClient_Expecter) BlockchainInfo(ctx interface{}, minHeight interface{}, maxHeight interface{}) *RemoteClient_BlockchainInfo_Call {
+func (_e *RemoteClient_Expecter) BlockchainInfo(ctx any, minHeight any, maxHeight any) *RemoteClient_BlockchainInfo_Call {
 	return &RemoteClient_BlockchainInfo_Call{Call: _e.mock.On("BlockchainInfo", ctx, minHeight, maxHeight)}
 }
 
@@ -657,7 +657,7 @@ type RemoteClient_BroadcastEvidence_Call struct {
 // BroadcastEvidence is a helper method to define mock.On call
 //   - context1 context.Context
 //   - evidence types.Evidence
-func (_e *RemoteClient_Expecter) BroadcastEvidence(context1 interface{}, evidence interface{}) *RemoteClient_BroadcastEvidence_Call {
+func (_e *RemoteClient_Expecter) BroadcastEvidence(context1 any, evidence any) *RemoteClient_BroadcastEvidence_Call {
 	return &RemoteClient_BroadcastEvidence_Call{Call: _e.mock.On("BroadcastEvidence", context1, evidence)}
 }
 
@@ -725,7 +725,7 @@ type RemoteClient_BroadcastTx_Call struct {
 // BroadcastTx is a helper method to define mock.On call
 //   - context1 context.Context
 //   - tx types.Tx
-func (_e *RemoteClient_Expecter) BroadcastTx(context1 interface{}, tx interface{}) *RemoteClient_BroadcastTx_Call {
+func (_e *RemoteClient_Expecter) BroadcastTx(context1 any, tx any) *RemoteClient_BroadcastTx_Call {
 	return &RemoteClient_BroadcastTx_Call{Call: _e.mock.On("BroadcastTx", context1, tx)}
 }
 
@@ -793,7 +793,7 @@ type RemoteClient_BroadcastTxAsync_Call struct {
 // BroadcastTxAsync is a helper method to define mock.On call
 //   - context1 context.Context
 //   - tx types.Tx
-func (_e *RemoteClient_Expecter) BroadcastTxAsync(context1 interface{}, tx interface{}) *RemoteClient_BroadcastTxAsync_Call {
+func (_e *RemoteClient_Expecter) BroadcastTxAsync(context1 any, tx any) *RemoteClient_BroadcastTxAsync_Call {
 	return &RemoteClient_BroadcastTxAsync_Call{Call: _e.mock.On("BroadcastTxAsync", context1, tx)}
 }
 
@@ -861,7 +861,7 @@ type RemoteClient_BroadcastTxCommit_Call struct {
 // BroadcastTxCommit is a helper method to define mock.On call
 //   - context1 context.Context
 //   - tx types.Tx
-func (_e *RemoteClient_Expecter) BroadcastTxCommit(context1 interface{}, tx interface{}) *RemoteClient_BroadcastTxCommit_Call {
+func (_e *RemoteClient_Expecter) BroadcastTxCommit(context1 any, tx any) *RemoteClient_BroadcastTxCommit_Call {
 	return &RemoteClient_BroadcastTxCommit_Call{Call: _e.mock.On("BroadcastTxCommit", context1, tx)}
 }
 
@@ -929,7 +929,7 @@ type RemoteClient_BroadcastTxSync_Call struct {
 // BroadcastTxSync is a helper method to define mock.On call
 //   - context1 context.Context
 //   - tx types.Tx
-func (_e *RemoteClient_Expecter) BroadcastTxSync(context1 interface{}, tx interface{}) *RemoteClient_BroadcastTxSync_Call {
+func (_e *RemoteClient_Expecter) BroadcastTxSync(context1 any, tx any) *RemoteClient_BroadcastTxSync_Call {
 	return &RemoteClient_BroadcastTxSync_Call{Call: _e.mock.On("BroadcastTxSync", context1, tx)}
 }
 
@@ -997,7 +997,7 @@ type RemoteClient_CheckTx_Call struct {
 // CheckTx is a helper method to define mock.On call
 //   - context1 context.Context
 //   - tx types.Tx
-func (_e *RemoteClient_Expecter) CheckTx(context1 interface{}, tx interface{}) *RemoteClient_CheckTx_Call {
+func (_e *RemoteClient_Expecter) CheckTx(context1 any, tx any) *RemoteClient_CheckTx_Call {
 	return &RemoteClient_CheckTx_Call{Call: _e.mock.On("CheckTx", context1, tx)}
 }
 
@@ -1065,7 +1065,7 @@ type RemoteClient_Commit_Call struct {
 // Commit is a helper method to define mock.On call
 //   - ctx context.Context
 //   - height *int64
-func (_e *RemoteClient_Expecter) Commit(ctx interface{}, height interface{}) *RemoteClient_Commit_Call {
+func (_e *RemoteClient_Expecter) Commit(ctx any, height any) *RemoteClient_Commit_Call {
 	return &RemoteClient_Commit_Call{Call: _e.mock.On("Commit", ctx, height)}
 }
 
@@ -1133,7 +1133,7 @@ type RemoteClient_ConsensusParams_Call struct {
 // ConsensusParams is a helper method to define mock.On call
 //   - ctx context.Context
 //   - height *int64
-func (_e *RemoteClient_Expecter) ConsensusParams(ctx interface{}, height interface{}) *RemoteClient_ConsensusParams_Call {
+func (_e *RemoteClient_Expecter) ConsensusParams(ctx any, height any) *RemoteClient_ConsensusParams_Call {
 	return &RemoteClient_ConsensusParams_Call{Call: _e.mock.On("ConsensusParams", ctx, height)}
 }
 
@@ -1200,7 +1200,7 @@ type RemoteClient_ConsensusState_Call struct {
 
 // ConsensusState is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *RemoteClient_Expecter) ConsensusState(context1 interface{}) *RemoteClient_ConsensusState_Call {
+func (_e *RemoteClient_Expecter) ConsensusState(context1 any) *RemoteClient_ConsensusState_Call {
 	return &RemoteClient_ConsensusState_Call{Call: _e.mock.On("ConsensusState", context1)}
 }
 
@@ -1262,7 +1262,7 @@ type RemoteClient_DumpConsensusState_Call struct {
 
 // DumpConsensusState is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *RemoteClient_Expecter) DumpConsensusState(context1 interface{}) *RemoteClient_DumpConsensusState_Call {
+func (_e *RemoteClient_Expecter) DumpConsensusState(context1 any) *RemoteClient_DumpConsensusState_Call {
 	return &RemoteClient_DumpConsensusState_Call{Call: _e.mock.On("DumpConsensusState", context1)}
 }
 
@@ -1325,7 +1325,7 @@ type RemoteClient_Events_Call struct {
 // Events is a helper method to define mock.On call
 //   - ctx context.Context
 //   - req *coretypes.RequestEvents
-func (_e *RemoteClient_Expecter) Events(ctx interface{}, req interface{}) *RemoteClient_Events_Call {
+func (_e *RemoteClient_Expecter) Events(ctx any, req any) *RemoteClient_Events_Call {
 	return &RemoteClient_Events_Call{Call: _e.mock.On("Events", ctx, req)}
 }
 
@@ -1392,7 +1392,7 @@ type RemoteClient_Genesis_Call struct {
 
 // Genesis is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *RemoteClient_Expecter) Genesis(context1 interface{}) *RemoteClient_Genesis_Call {
+func (_e *RemoteClient_Expecter) Genesis(context1 any) *RemoteClient_Genesis_Call {
 	return &RemoteClient_Genesis_Call{Call: _e.mock.On("Genesis", context1)}
 }
 
@@ -1455,7 +1455,7 @@ type RemoteClient_GenesisChunked_Call struct {
 // GenesisChunked is a helper method to define mock.On call
 //   - context1 context.Context
 //   - v uint
-func (_e *RemoteClient_Expecter) GenesisChunked(context1 interface{}, v interface{}) *RemoteClient_GenesisChunked_Call {
+func (_e *RemoteClient_Expecter) GenesisChunked(context1 any, v any) *RemoteClient_GenesisChunked_Call {
 	return &RemoteClient_GenesisChunked_Call{Call: _e.mock.On("GenesisChunked", context1, v)}
 }
 
@@ -1523,7 +1523,7 @@ type RemoteClient_Header_Call struct {
 // Header is a helper method to define mock.On call
 //   - ctx context.Context
 //   - height *int64
-func (_e *RemoteClient_Expecter) Header(ctx interface{}, height interface{}) *RemoteClient_Header_Call {
+func (_e *RemoteClient_Expecter) Header(ctx any, height any) *RemoteClient_Header_Call {
 	return &RemoteClient_Header_Call{Call: _e.mock.On("Header", ctx, height)}
 }
 
@@ -1591,7 +1591,7 @@ type RemoteClient_HeaderByHash_Call struct {
 // HeaderByHash is a helper method to define mock.On call
 //   - ctx context.Context
 //   - hash bytes.HexBytes
-func (_e *RemoteClient_Expecter) HeaderByHash(ctx interface{}, hash interface{}) *RemoteClient_HeaderByHash_Call {
+func (_e *RemoteClient_Expecter) HeaderByHash(ctx any, hash any) *RemoteClient_HeaderByHash_Call {
 	return &RemoteClient_HeaderByHash_Call{Call: _e.mock.On("HeaderByHash", ctx, hash)}
 }
 
@@ -1658,7 +1658,7 @@ type RemoteClient_Health_Call struct {
 
 // Health is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *RemoteClient_Expecter) Health(context1 interface{}) *RemoteClient_Health_Call {
+func (_e *RemoteClient_Expecter) Health(context1 any) *RemoteClient_Health_Call {
 	return &RemoteClient_Health_Call{Call: _e.mock.On("Health", context1)}
 }
 
@@ -1720,7 +1720,7 @@ type RemoteClient_NetInfo_Call struct {
 
 // NetInfo is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *RemoteClient_Expecter) NetInfo(context1 interface{}) *RemoteClient_NetInfo_Call {
+func (_e *RemoteClient_Expecter) NetInfo(context1 any) *RemoteClient_NetInfo_Call {
 	return &RemoteClient_NetInfo_Call{Call: _e.mock.On("NetInfo", context1)}
 }
 
@@ -1782,7 +1782,7 @@ type RemoteClient_NumUnconfirmedTxs_Call struct {
 
 // NumUnconfirmedTxs is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *RemoteClient_Expecter) NumUnconfirmedTxs(context1 interface{}) *RemoteClient_NumUnconfirmedTxs_Call {
+func (_e *RemoteClient_Expecter) NumUnconfirmedTxs(context1 any) *RemoteClient_NumUnconfirmedTxs_Call {
 	return &RemoteClient_NumUnconfirmedTxs_Call{Call: _e.mock.On("NumUnconfirmedTxs", context1)}
 }
 
@@ -1878,7 +1878,7 @@ type RemoteClient_RemoveTx_Call struct {
 // RemoveTx is a helper method to define mock.On call
 //   - context1 context.Context
 //   - txKey types.TxKey
-func (_e *RemoteClient_Expecter) RemoveTx(context1 interface{}, txKey interface{}) *RemoteClient_RemoveTx_Call {
+func (_e *RemoteClient_Expecter) RemoveTx(context1 any, txKey any) *RemoteClient_RemoveTx_Call {
 	return &RemoteClient_RemoveTx_Call{Call: _e.mock.On("RemoveTx", context1, txKey)}
 }
 
@@ -1934,7 +1934,7 @@ type RemoteClient_Start_Call struct {
 
 // Start is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *RemoteClient_Expecter) Start(context1 interface{}) *RemoteClient_Start_Call {
+func (_e *RemoteClient_Expecter) Start(context1 any) *RemoteClient_Start_Call {
 	return &RemoteClient_Start_Call{Call: _e.mock.On("Start", context1)}
 }
 
@@ -1996,7 +1996,7 @@ type RemoteClient_Status_Call struct {
 
 // Status is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *RemoteClient_Expecter) Status(context1 interface{}) *RemoteClient_Status_Call {
+func (_e *RemoteClient_Expecter) Status(context1 any) *RemoteClient_Status_Call {
 	return &RemoteClient_Status_Call{Call: _e.mock.On("Status", context1)}
 }
 
@@ -2067,9 +2067,9 @@ type RemoteClient_Subscribe_Call struct {
 //   - subscriber string
 //   - query string
 //   - outCapacity ...int
-func (_e *RemoteClient_Expecter) Subscribe(ctx interface{}, subscriber interface{}, query interface{}, outCapacity ...interface{}) *RemoteClient_Subscribe_Call {
+func (_e *RemoteClient_Expecter) Subscribe(ctx any, subscriber any, query any, outCapacity ...any) *RemoteClient_Subscribe_Call {
 	return &RemoteClient_Subscribe_Call{Call: _e.mock.On("Subscribe",
-		append([]interface{}{ctx, subscriber, query}, outCapacity...)...)}
+		append([]any{ctx, subscriber, query}, outCapacity...)...)}
 }
 
 func (_c *RemoteClient_Subscribe_Call) Run(run func(ctx context.Context, subscriber string, query string, outCapacity ...int)) *RemoteClient_Subscribe_Call {
@@ -2149,7 +2149,7 @@ type RemoteClient_Tx_Call struct {
 //   - ctx context.Context
 //   - hash bytes.HexBytes
 //   - prove bool
-func (_e *RemoteClient_Expecter) Tx(ctx interface{}, hash interface{}, prove interface{}) *RemoteClient_Tx_Call {
+func (_e *RemoteClient_Expecter) Tx(ctx any, hash any, prove any) *RemoteClient_Tx_Call {
 	return &RemoteClient_Tx_Call{Call: _e.mock.On("Tx", ctx, hash, prove)}
 }
 
@@ -2226,7 +2226,7 @@ type RemoteClient_TxSearch_Call struct {
 //   - page *int
 //   - perPage *int
 //   - orderBy string
-func (_e *RemoteClient_Expecter) TxSearch(ctx interface{}, query interface{}, prove interface{}, page interface{}, perPage interface{}, orderBy interface{}) *RemoteClient_TxSearch_Call {
+func (_e *RemoteClient_Expecter) TxSearch(ctx any, query any, prove any, page any, perPage any, orderBy any) *RemoteClient_TxSearch_Call {
 	return &RemoteClient_TxSearch_Call{Call: _e.mock.On("TxSearch", ctx, query, prove, page, perPage, orderBy)}
 }
 
@@ -2314,7 +2314,7 @@ type RemoteClient_UnconfirmedTx_Call struct {
 // UnconfirmedTx is a helper method to define mock.On call
 //   - ctx context.Context
 //   - txHash []byte
-func (_e *RemoteClient_Expecter) UnconfirmedTx(ctx interface{}, txHash interface{}) *RemoteClient_UnconfirmedTx_Call {
+func (_e *RemoteClient_Expecter) UnconfirmedTx(ctx any, txHash any) *RemoteClient_UnconfirmedTx_Call {
 	return &RemoteClient_UnconfirmedTx_Call{Call: _e.mock.On("UnconfirmedTx", ctx, txHash)}
 }
 
@@ -2383,7 +2383,7 @@ type RemoteClient_UnconfirmedTxs_Call struct {
 //   - ctx context.Context
 //   - page *int
 //   - perPage *int
-func (_e *RemoteClient_Expecter) UnconfirmedTxs(ctx interface{}, page interface{}, perPage interface{}) *RemoteClient_UnconfirmedTxs_Call {
+func (_e *RemoteClient_Expecter) UnconfirmedTxs(ctx any, page any, perPage any) *RemoteClient_UnconfirmedTxs_Call {
 	return &RemoteClient_UnconfirmedTxs_Call{Call: _e.mock.On("UnconfirmedTxs", ctx, page, perPage)}
 }
 
@@ -2446,7 +2446,7 @@ type RemoteClient_Unsubscribe_Call struct {
 //   - ctx context.Context
 //   - subscriber string
 //   - query string
-func (_e *RemoteClient_Expecter) Unsubscribe(ctx interface{}, subscriber interface{}, query interface{}) *RemoteClient_Unsubscribe_Call {
+func (_e *RemoteClient_Expecter) Unsubscribe(ctx any, subscriber any, query any) *RemoteClient_Unsubscribe_Call {
 	return &RemoteClient_Unsubscribe_Call{Call: _e.mock.On("Unsubscribe", ctx, subscriber, query)}
 }
 
@@ -2508,7 +2508,7 @@ type RemoteClient_UnsubscribeAll_Call struct {
 // UnsubscribeAll is a helper method to define mock.On call
 //   - ctx context.Context
 //   - subscriber string
-func (_e *RemoteClient_Expecter) UnsubscribeAll(ctx interface{}, subscriber interface{}) *RemoteClient_UnsubscribeAll_Call {
+func (_e *RemoteClient_Expecter) UnsubscribeAll(ctx any, subscriber any) *RemoteClient_UnsubscribeAll_Call {
 	return &RemoteClient_UnsubscribeAll_Call{Call: _e.mock.On("UnsubscribeAll", ctx, subscriber)}
 }
 
@@ -2579,7 +2579,7 @@ type RemoteClient_Validators_Call struct {
 //   - page *int
 //   - perPage *int
 //   - requestQuorumInfo *bool
-func (_e *RemoteClient_Expecter) Validators(ctx interface{}, height interface{}, page interface{}, perPage interface{}, requestQuorumInfo interface{}) *RemoteClient_Validators_Call {
+func (_e *RemoteClient_Expecter) Validators(ctx any, height any, page any, perPage any, requestQuorumInfo any) *RemoteClient_Validators_Call {
 	return &RemoteClient_Validators_Call{Call: _e.mock.On("Validators", ctx, height, page, perPage, requestQuorumInfo)}
 }
 

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -53,7 +53,11 @@ func TestRPCParams(t *testing.T) {
 		// id not captured in JSON parsing failures
 		{`{"method": "c", "id": "0", "params": a}`, "invalid character", ""},
 		{`{"method": "c", "id": "0", "params": ["a"]}`, "got 1", `"0"`},
-		{`{"method": "c", "id": "0", "params": ["a", "b"]}`, "invalid number", `"0"`},
+		// The stdlib's exact wording for a malformed json.Number changed
+		// between Go versions (e.g. "invalid number literal" vs "invalid
+		// syntax"); assert on our own error family instead of stdlib
+		// phrasing that Data merely happens to carry.
+		{`{"method": "c", "id": "0", "params": ["a", "b"]}`, "Invalid params", `"0"`},
 		{`{"method": "c", "id": "0", "params": [1, 1]}`, "of type string", `"0"`},
 
 		// no ID - notification

--- a/rpc/jsonrpc/server/http_server_test.go
+++ b/rpc/jsonrpc/server/http_server_test.go
@@ -54,15 +54,17 @@ func TestMaxOpenConnections(t *testing.T) {
 
 	go Serve(ctx, l, mux, logger, config) //nolint:errcheck // ignore for tests
 
-	// Make N GET calls to the server.
+	// Make N GET calls to the server. Share one Client (safe for concurrent
+	// use) across all goroutines so its idle connections can be closed in
+	// one place once the calls are done, below.
 	attempts := max * 2
+	c := http.Client{Timeout: 3 * time.Second}
 	var wg sync.WaitGroup
 	var failed int32
 	for i := 0; i < attempts; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			c := http.Client{Timeout: 3 * time.Second}
 			r, err := c.Get("http://" + l.Addr().String())
 			if err != nil {
 				atomic.AddInt32(&failed, 1)
@@ -72,6 +74,15 @@ func TestMaxOpenConnections(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+
+	// Since Go 1.27, Response.Body.Close() drains and reuses the underlying
+	// connection instead of closing it outright (see the Go 1.27 release
+	// notes for net/http). This test never reads the response body, so the
+	// requests above leave healthy, idle keep-alive connections in the
+	// Client's pool. Close them explicitly so the server-side handler
+	// goroutines they'd otherwise keep parked in a read wait don't trip the
+	// leaktest check registered above.
+	c.CloseIdleConnections()
 
 	// We expect some Gets to fail as the server's accept queue is filled,
 	// but most should succeed.

--- a/rpc/jsonrpc/server/parse_test.go
+++ b/rpc/jsonrpc/server/parse_test.go
@@ -290,14 +290,18 @@ func TestParseURI(t *testing.T) {
 				},
 			},
 			{
+				// The stdlib's exact wording for a malformed json.Number
+				// changed between Go versions; assert on our own error
+				// family (see RPCError, CodeInvalidParams) instead of
+				// stdlib phrasing that Data merely happens to carry.
 				name: "invalid quoted number",
 				url:  `http://localhost?height="-xx"`,
-				fail: "invalid number literal",
+				fail: "Invalid params",
 			},
 			{
 				name: "invalid unquoted number",
 				url:  `http://localhost?height=25*q`,
-				fail: "invalid number literal",
+				fail: "Invalid params",
 			},
 			{
 				name: "invalid boolean",

--- a/scripts/mockery_generate.sh
+++ b/scripts/mockery_generate.sh
@@ -6,7 +6,7 @@
 # runs the published Docker container. This legerdemain is so that the CI build
 # and a local build can work off the same script.
 #
-VERSION=v3.7.0
+VERSION=v3.7.4
 
 if [ "$(mockery version)" != "$VERSION" ]; then
   echo "Please install mockery $VERSION, example for Linux x86_64:"

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5
+FROM golang:1.26.6
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.6
+FROM golang:1.27.1
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,6 +1,6 @@
 ## Stage 1 and 2 is copied from /DOCKER/Dockerfile
 ARG ALIPNE_VERSION=3.23
-ARG GOLANG_VERSION=1.26.5
+ARG GOLANG_VERSION=1.26.6
 #################################
 # STAGE 1: install dependencies #
 #################################

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,6 +1,6 @@
 ## Stage 1 and 2 is copied from /DOCKER/Dockerfile
 ARG ALIPNE_VERSION=3.23
-ARG GOLANG_VERSION=1.26.6
+ARG GOLANG_VERSION=1.27.1
 #################################
 # STAGE 1: install dependencies #
 #################################

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -1,7 +1,7 @@
 # fuzz
 
 Fuzzing for various packages in Tendermint using the fuzzing infrastructure included in
-Go 1.26.5.
+Go 1.26.6.
 
 Inputs:
 

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -1,7 +1,7 @@
 # fuzz
 
 Fuzzing for various packages in Tendermint using the fuzzing infrastructure included in
-Go 1.26.6.
+Go 1.27.1.
 
 Inputs:
 

--- a/types/mocks/blockeventpublisher.go
+++ b/types/mocks/blockeventpublisher.go
@@ -60,7 +60,7 @@ type BlockEventPublisher_PublishEventNewBlock_Call struct {
 
 // PublishEventNewBlock is a helper method to define mock.On call
 //   - eventDataNewBlock types.EventDataNewBlock
-func (_e *BlockEventPublisher_Expecter) PublishEventNewBlock(eventDataNewBlock interface{}) *BlockEventPublisher_PublishEventNewBlock_Call {
+func (_e *BlockEventPublisher_Expecter) PublishEventNewBlock(eventDataNewBlock any) *BlockEventPublisher_PublishEventNewBlock_Call {
 	return &BlockEventPublisher_PublishEventNewBlock_Call{Call: _e.mock.On("PublishEventNewBlock", eventDataNewBlock)}
 }
 
@@ -111,7 +111,7 @@ type BlockEventPublisher_PublishEventNewBlockHeader_Call struct {
 
 // PublishEventNewBlockHeader is a helper method to define mock.On call
 //   - eventDataNewBlockHeader types.EventDataNewBlockHeader
-func (_e *BlockEventPublisher_Expecter) PublishEventNewBlockHeader(eventDataNewBlockHeader interface{}) *BlockEventPublisher_PublishEventNewBlockHeader_Call {
+func (_e *BlockEventPublisher_Expecter) PublishEventNewBlockHeader(eventDataNewBlockHeader any) *BlockEventPublisher_PublishEventNewBlockHeader_Call {
 	return &BlockEventPublisher_PublishEventNewBlockHeader_Call{Call: _e.mock.On("PublishEventNewBlockHeader", eventDataNewBlockHeader)}
 }
 
@@ -162,7 +162,7 @@ type BlockEventPublisher_PublishEventNewEvidence_Call struct {
 
 // PublishEventNewEvidence is a helper method to define mock.On call
 //   - eventDataNewEvidence types.EventDataNewEvidence
-func (_e *BlockEventPublisher_Expecter) PublishEventNewEvidence(eventDataNewEvidence interface{}) *BlockEventPublisher_PublishEventNewEvidence_Call {
+func (_e *BlockEventPublisher_Expecter) PublishEventNewEvidence(eventDataNewEvidence any) *BlockEventPublisher_PublishEventNewEvidence_Call {
 	return &BlockEventPublisher_PublishEventNewEvidence_Call{Call: _e.mock.On("PublishEventNewEvidence", eventDataNewEvidence)}
 }
 
@@ -213,7 +213,7 @@ type BlockEventPublisher_PublishEventTx_Call struct {
 
 // PublishEventTx is a helper method to define mock.On call
 //   - eventDataTx types.EventDataTx
-func (_e *BlockEventPublisher_Expecter) PublishEventTx(eventDataTx interface{}) *BlockEventPublisher_PublishEventTx_Call {
+func (_e *BlockEventPublisher_Expecter) PublishEventTx(eventDataTx any) *BlockEventPublisher_PublishEventTx_Call {
 	return &BlockEventPublisher_PublishEventTx_Call{Call: _e.mock.On("PublishEventTx", eventDataTx)}
 }
 
@@ -264,7 +264,7 @@ type BlockEventPublisher_PublishEventValidatorSetUpdates_Call struct {
 
 // PublishEventValidatorSetUpdates is a helper method to define mock.On call
 //   - eventDataValidatorSetUpdate types.EventDataValidatorSetUpdate
-func (_e *BlockEventPublisher_Expecter) PublishEventValidatorSetUpdates(eventDataValidatorSetUpdate interface{}) *BlockEventPublisher_PublishEventValidatorSetUpdates_Call {
+func (_e *BlockEventPublisher_Expecter) PublishEventValidatorSetUpdates(eventDataValidatorSetUpdate any) *BlockEventPublisher_PublishEventValidatorSetUpdates_Call {
 	return &BlockEventPublisher_PublishEventValidatorSetUpdates_Call{Call: _e.mock.On("PublishEventValidatorSetUpdates", eventDataValidatorSetUpdate)}
 }
 

--- a/types/mocks/privvalidator.go
+++ b/types/mocks/privvalidator.go
@@ -70,7 +70,7 @@ type PrivValidator_ExtractIntoValidator_Call struct {
 // ExtractIntoValidator is a helper method to define mock.On call
 //   - ctx context.Context
 //   - quorumHash crypto.QuorumHash
-func (_e *PrivValidator_Expecter) ExtractIntoValidator(ctx interface{}, quorumHash interface{}) *PrivValidator_ExtractIntoValidator_Call {
+func (_e *PrivValidator_Expecter) ExtractIntoValidator(ctx any, quorumHash any) *PrivValidator_ExtractIntoValidator_Call {
 	return &PrivValidator_ExtractIntoValidator_Call{Call: _e.mock.On("ExtractIntoValidator", ctx, quorumHash)}
 }
 
@@ -137,7 +137,7 @@ type PrivValidator_GetFirstQuorumHash_Call struct {
 
 // GetFirstQuorumHash is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *PrivValidator_Expecter) GetFirstQuorumHash(context1 interface{}) *PrivValidator_GetFirstQuorumHash_Call {
+func (_e *PrivValidator_Expecter) GetFirstQuorumHash(context1 any) *PrivValidator_GetFirstQuorumHash_Call {
 	return &PrivValidator_GetFirstQuorumHash_Call{Call: _e.mock.On("GetFirstQuorumHash", context1)}
 }
 
@@ -154,8 +154,8 @@ func (_c *PrivValidator_GetFirstQuorumHash_Call) Run(run func(context1 context.C
 	return _c
 }
 
-func (_c *PrivValidator_GetFirstQuorumHash_Call) Return(v crypto.QuorumHash, err error) *PrivValidator_GetFirstQuorumHash_Call {
-	_c.Call.Return(v, err)
+func (_c *PrivValidator_GetFirstQuorumHash_Call) Return(quorumHash crypto.QuorumHash, err error) *PrivValidator_GetFirstQuorumHash_Call {
+	_c.Call.Return(quorumHash, err)
 	return _c
 }
 
@@ -198,7 +198,7 @@ type PrivValidator_GetHeight_Call struct {
 // GetHeight is a helper method to define mock.On call
 //   - ctx context.Context
 //   - quorumHash crypto.QuorumHash
-func (_e *PrivValidator_Expecter) GetHeight(ctx interface{}, quorumHash interface{}) *PrivValidator_GetHeight_Call {
+func (_e *PrivValidator_Expecter) GetHeight(ctx any, quorumHash any) *PrivValidator_GetHeight_Call {
 	return &PrivValidator_GetHeight_Call{Call: _e.mock.On("GetHeight", ctx, quorumHash)}
 }
 
@@ -266,7 +266,7 @@ type PrivValidator_GetPrivateKey_Call struct {
 // GetPrivateKey is a helper method to define mock.On call
 //   - ctx context.Context
 //   - quorumHash crypto.QuorumHash
-func (_e *PrivValidator_Expecter) GetPrivateKey(ctx interface{}, quorumHash interface{}) *PrivValidator_GetPrivateKey_Call {
+func (_e *PrivValidator_Expecter) GetPrivateKey(ctx any, quorumHash any) *PrivValidator_GetPrivateKey_Call {
 	return &PrivValidator_GetPrivateKey_Call{Call: _e.mock.On("GetPrivateKey", ctx, quorumHash)}
 }
 
@@ -333,7 +333,7 @@ type PrivValidator_GetProTxHash_Call struct {
 
 // GetProTxHash is a helper method to define mock.On call
 //   - context1 context.Context
-func (_e *PrivValidator_Expecter) GetProTxHash(context1 interface{}) *PrivValidator_GetProTxHash_Call {
+func (_e *PrivValidator_Expecter) GetProTxHash(context1 any) *PrivValidator_GetProTxHash_Call {
 	return &PrivValidator_GetProTxHash_Call{Call: _e.mock.On("GetProTxHash", context1)}
 }
 
@@ -350,8 +350,8 @@ func (_c *PrivValidator_GetProTxHash_Call) Run(run func(context1 context.Context
 	return _c
 }
 
-func (_c *PrivValidator_GetProTxHash_Call) Return(v crypto.ProTxHash, err error) *PrivValidator_GetProTxHash_Call {
-	_c.Call.Return(v, err)
+func (_c *PrivValidator_GetProTxHash_Call) Return(proTxHash crypto.ProTxHash, err error) *PrivValidator_GetProTxHash_Call {
+	_c.Call.Return(proTxHash, err)
 	return _c
 }
 
@@ -396,7 +396,7 @@ type PrivValidator_GetPubKey_Call struct {
 // GetPubKey is a helper method to define mock.On call
 //   - ctx context.Context
 //   - quorumHash crypto.QuorumHash
-func (_e *PrivValidator_Expecter) GetPubKey(ctx interface{}, quorumHash interface{}) *PrivValidator_GetPubKey_Call {
+func (_e *PrivValidator_Expecter) GetPubKey(ctx any, quorumHash any) *PrivValidator_GetPubKey_Call {
 	return &PrivValidator_GetPubKey_Call{Call: _e.mock.On("GetPubKey", ctx, quorumHash)}
 }
 
@@ -464,7 +464,7 @@ type PrivValidator_GetThresholdPublicKey_Call struct {
 // GetThresholdPublicKey is a helper method to define mock.On call
 //   - ctx context.Context
 //   - quorumHash crypto.QuorumHash
-func (_e *PrivValidator_Expecter) GetThresholdPublicKey(ctx interface{}, quorumHash interface{}) *PrivValidator_GetThresholdPublicKey_Call {
+func (_e *PrivValidator_Expecter) GetThresholdPublicKey(ctx any, quorumHash any) *PrivValidator_GetThresholdPublicKey_Call {
 	return &PrivValidator_GetThresholdPublicKey_Call{Call: _e.mock.On("GetThresholdPublicKey", ctx, quorumHash)}
 }
 
@@ -535,7 +535,7 @@ type PrivValidator_SignProposal_Call struct {
 //   - quorumType btcjson.LLMQType
 //   - quorumHash crypto.QuorumHash
 //   - proposal *types0.Proposal
-func (_e *PrivValidator_Expecter) SignProposal(ctx interface{}, chainID interface{}, quorumType interface{}, quorumHash interface{}, proposal interface{}) *PrivValidator_SignProposal_Call {
+func (_e *PrivValidator_Expecter) SignProposal(ctx any, chainID any, quorumType any, quorumHash any, proposal any) *PrivValidator_SignProposal_Call {
 	return &PrivValidator_SignProposal_Call{Call: _e.mock.On("SignProposal", ctx, chainID, quorumType, quorumHash, proposal)}
 }
 
@@ -611,7 +611,7 @@ type PrivValidator_SignVote_Call struct {
 //   - quorumHash crypto.QuorumHash
 //   - vote *types0.Vote
 //   - logger log.Logger
-func (_e *PrivValidator_Expecter) SignVote(ctx interface{}, chainID interface{}, quorumType interface{}, quorumHash interface{}, vote interface{}, logger interface{}) *PrivValidator_SignVote_Call {
+func (_e *PrivValidator_Expecter) SignVote(ctx any, chainID any, quorumType any, quorumHash any, vote any, logger any) *PrivValidator_SignVote_Call {
 	return &PrivValidator_SignVote_Call{Call: _e.mock.On("SignVote", ctx, chainID, quorumType, quorumHash, vote, logger)}
 }
 
@@ -680,7 +680,7 @@ type PrivValidator_UpdatePrivateKey_Call struct {
 //   - quorumHash crypto.QuorumHash
 //   - thresholdPublicKey crypto.PubKey
 //   - height int64
-func (_e *PrivValidator_Expecter) UpdatePrivateKey(ctx interface{}, privateKey interface{}, quorumHash interface{}, thresholdPublicKey interface{}, height interface{}) *PrivValidator_UpdatePrivateKey_Call {
+func (_e *PrivValidator_Expecter) UpdatePrivateKey(ctx any, privateKey any, quorumHash any, thresholdPublicKey any, height any) *PrivValidator_UpdatePrivateKey_Call {
 	return &PrivValidator_UpdatePrivateKey_Call{Call: _e.mock.On("UpdatePrivateKey", ctx, privateKey, quorumHash, thresholdPublicKey, height)}
 }
 


### PR DESCRIPTION
Takes the 1.7 line to Go **1.27.1**, in four commits ordered so that every intermediate state is coherent.

```
chore(deps): bump Go to 1.26.6 (#1417)             cherry-pick of the fix that never reached 1.7
ci(lint): bump golangci-lint from v2.12 to v2.13   must precede the toolchain bump
chore(mockery): bump to v3.7.4 and regenerate      must precede the toolchain bump
test(rpc): close idle client connections ...       must precede the toolchain bump
test(rpc): assert on our own error family ...      must precede the toolchain bump
chore(deps): bump Go to 1.27.1
style: reformat mempool.go for Go 1.27's gofmt
```

**Two tools in this repository are older than Go 1.27 and break under it, and two tests depend on Go 1.26 behaviour that 1.27 changed.** All four were found by running the gates rather than by reading release notes. Every one of them is ordered ahead of the toolchain bump, and each passes at **both** 1.26.6 and 1.27.1 — so no commit in this stack leaves a gate red or a test failing, in either direction.

## Why the first commit exists at all

`govulncheck` fails on `v1.7-dev` HEAD itself — not only on PR branches — with six Go **standard-library** advisories, all `Found in: go1.26.5 / Fixed in: go1.26.6`: `GO-2026-6218` (net/url), `GO-2026-6091` (html/template), `GO-2026-6090` (crypto/tls), `GO-2026-6089` (net/http, ×2), `GO-2026-5972` (encoding/asn1). #1417 closed these on the branch now called `v1.8-dev` and never reached 1.7. It is cherry-picked here with its provenance intact rather than rewritten, so the port is verifiable by diff.

## Why the lint bump must come second

**`golangci-lint v2.12.2` does not report new findings under Go 1.27.1 — it crashes.** `buildir` panics inside staticcheck's SSA/IR builder (`honnef.co/go/tools@v0.7.0`) while analysing the *standard library* package `internal/poll`:

```
buildir: panic during analysis: unexpected expr: *ast.KeyValueExpr
can't run linter goanalysis_metalinter: ... package "poll"
```

Deterministic, reproduced twice, and not a stale-binary artefact — golangci-lint was rebuilt with the 1.27.1 toolchain and panics identically. `lint.yml`'s `version: v2.12` selector resolves to the newest 2.12.x, which is v2.12.2, so **merging the toolchain bump without this commit would leave the lint job unable to run at all.**

v2.12.2 is from May; **v2.13.0 shipped on 2026-08-19, the same day as Go 1.27.0.** The 2.13 line is the Go 1.27-aware one.

Measured at both toolchains rather than assumed:

| golangci-lint v2.13.2 | filtered (`--new-from-rev`) | unfiltered |
|---|---|---|
| under go1.26.6 | 0 issues, no panic | 199 |
| under go1.27.1 | 0 issues, no panic | 200 |

**The two changes are therefore independent** — v2.13.2 is clean at both versions, so the lint bump is safe on its own and could have shipped separately. It is ordered first here so that no commit in this stack leaves the tree in a state where the lint job cannot run: a bisect, or a revert of the top commits, never lands on a broken gate.

**Disabling staticcheck was considered and rejected.** It is the linter that catches the `QF1008` class this branch's other work depends on; turning it off to make a version bump land would trade a working gate for a green tick.

## Why the mockery bump must come third

`check-mocks` passes at the 1.26.6 commit and fails at the 1.27.1 one. The failure is not in this repository's source:

```
internal error: package ".../libs/ds" without types was imported from ".../libs/store"
```

mockery's `go/packages` loader fails to attach type information to a transitively imported package when driven by the go1.27.1 toolchain. **`check-generated.yml` pinned `MOCKERY=3.7.0`, released 2026-03-06 — five months before Go 1.27.0. `v3.7.4` shipped 2026-08-23, four days after it.** The same relationship as the linter, found the same way.

**The CI logs cannot show this.** The step runs `make mockery 2>/dev/null`, so stderr is discarded and the job reports only `exit code 2`. The error had to be reproduced locally under CI-matching conditions (`GOTOOLCHAIN=local`, a real 1.27.1 binary, and the BLS cgo flags — without those a different and misleading error about `encoding/hex` appears instead).

The commit bumps both pin sites — `check-generated.yml` and `scripts/mockery_generate.sh` — and commits the regenerated mocks. **It has to do both**: the gate is `git diff --exit-code` *after* regenerating, so bumping the pin without regenerating and regenerating without bumping the pin each leave the job red.

**25 mock files change, 192 insertions / 192 deletions, and the change is cosmetic**: `interface{}` → `any` (173 occurrences, an identical type since Go 1.18) and generated parameter names recovering their real source names in place of `v`/`vs` placeholders. No method set changes, no altered mock behaviour. That was verified by building and running the consensus suite against the regenerated mocks rather than by reading the diff — generated code that compiles and whose consumers still pass is a check reading cannot give.

**v3.7.4 produces byte-identical output under both go1.26.6 and go1.27.1**, so the 25-file diff comes from mockery's own codegen version and not from the toolchain. This commit therefore stands on its own and could ship independently, exactly like the lint bump.

The gate itself was simulated at the final head — regenerate with v3.7.4 under go1.27.1, then `git diff --exit-code` — and exits 0 with zero drift.

## Why the two test commits come next

`tests (05)` fails at the 1.27.1 commit and passes at 1.26.6. Three failures in `rpc/jsonrpc/server`, of two different kinds.

**Two are assertions on standard-library wording.** Go 1.27's `encoding/json` changed how it reports a malformed `json.Number`:

```
1.26:  ... invalid number literal ...
1.27:  json: cannot unmarshal string "-xx" into Go value of type json.Number: invalid syntax
```

`TestRPCParams` matched on `"invalid number"`, `TestParseURI/Decode` on `"invalid number literal"`. **The behaviour did not change** — the input is still rejected as `-32602 Invalid params`. Only the sentence moved.

The fix is **not** to substitute the new phrase, which would swap one version-specific assertion for another and break for anyone on 1.26. `RPCFunc.parseParams` routes every decode failure through `invalidParamsError`, which sets `Message` to our own `CodeInvalidParams.String()` — literally `"Invalid params"` — and puts the standard library's text only in `Data`. The tests now assert on that. Checked against the sibling rows in the same tables: `"Method not found"` and the malformed-JSON row use different codes and different messages, so widening these two rows matches nothing it should not. This is stricter than what it replaces — the old substring could match any error whose text happened to contain the phrase, while the new one names the error family.

**One is a real behaviour change with a documented mechanism.** `TestMaxOpenConnections` failed 5/5 at 1.27.1 and passed 5/5 at 1.26.6, deterministically, leaking two `net/http` server goroutines parked in `bufio.Reader.Peek` — idle keep-alive connections.

Go 1.27's release notes name the cause: HTTP/1 `Response.Body` now **automatically drains unread content on Close, to allow connection reuse**. The test never reads the response bodies. Under 1.26 closing an unread body poisoned the connection, so the transport closed the socket and the server goroutine exited; under 1.27 the connection is healthy, returns to the idle pool, and both ends stay open.

**Reading the body explicitly does not fix it** — that was measured, not assumed: patching the test to drain before `Close` still leaks 3/3, because 1.27 already drains. The connection *surviving* is the cause, not its being dirty. The fix hoists a single shared `http.Client` and calls `CloseIdleConnections()` after the wait group. Verified the assertion is not weakened by sharing: instrumenting the handler shows peak concurrent connections is still exactly the configured maximum, since concurrent in-flight requests each need their own connection and pooling only governs what happens after they go idle. `-race` clean.

Both commits pass at 1.26.6 and at 1.27.1, which is what allows them to sit ahead of the toolchain bump.

## The toolchain bump

Sixteen files: `go.mod`, eight CI workflow pins, three Dockerfiles, four documentation references. The documentation sites matter — they are what a contributor reads to decide which toolchain to install, and omitting them would leave CI and the setup instructions disagreeing, a divergence no gate detects.

Measured across the change:

- **`go vet ./...` — byte-identical before and after**, diffed to zero output. The same four pre-existing findings (three `fmt.Errorf` in `test/e2e/pkg/testnet.go`, one address format in `dash/quorum/nodeid_resolver.go`). **No new vet strictness appeared**, which was the leading risk of crossing a minor version.
- **`govulncheck ./...` — identical sets on both sides.** 0 standard-library vulnerabilities affecting this code, and the same four dependency-only findings (`GO-2026-6355`, `6354`, `6303`, `5932`) unchanged. 1.27.1 neither opens nor closes anything here relative to 1.26.6.
- `go build ./...` clean; `go test ./internal/consensus/... -count=1` green on both required runs of the final stack.

All of it ran under a genuine go1.27.1: `GOTOOLCHAIN=auto` resolves from the module's own `go` line, so the commands executed against the version this PR pins rather than whatever is on `PATH`.

**One unresolved observation, stated rather than omitted.** During measurement — not in the two required runs — `TestPoC_HeightVoteSet_UnboundedRoundAllocation` failed once on a memory-accounting margin. It then passed 5/5 in isolation at 1.27.1 and 3/3 at 1.26.6. **No version claim is made**: the 1.26.6 baseline never ran it under equivalent full-package load, so the two are not comparable. It is recorded as unresolved.

## The formatting commit

**Go 1.27's `gofmt` reindents a multi-value `return` containing a composite literal inside a `select`/`case` block differently from Go 1.26's.** One file in the repository is affected, found by a full `gofmt -l -s` sweep under 1.27.1 using `make format`'s own exclusions — not by fixing only the file the filtered lint run happened to name. The diff is four lines of pure reindentation; `-s` produces an identical result to plain `gofmt`, so no simplification is smuggled in.

This is **not** a fix for a red gate. `.golangci.yml`'s `formatters.enable` list does include `gofmt` — a separate section from `linters.enable` in golangci-lint v2's schema, so it is an active check — but its one finding falls on a line no diff in this branch touches, so `--new-from-rev` filters it and nothing fails. The commit removes the drift **before** it matters: the filter stops covering those lines the moment anyone edits near them, and they would then fail on formatting they did not introduce, under a toolchain this branch pinned.

**Known asymmetry, confirmed in both directions:** after the reformat, `gofmt -l -s` is clean under go1.27.1 and **go1.26.6's `gofmt` now wants those lines back the other way.** Anyone building this file with a local Go 1.26.x and running `make format` will see a diff. That is inherent to the two versions disagreeing on this construct, and this branch is pinned to 1.27.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gAC8rAzQagn5sgDxUJNjj
