### PR TITLE
fix(consensus): block ID validation and proposal handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Bug Fixes
+
+- Check complete block IDs before applying commits and validate proposals arriving after their blocks (#1439).
+
 ## [1.7.0] - 2026-08-17
 
 ### Bug Fixes

--- a/config/config.go
+++ b/config/config.go
@@ -1113,7 +1113,14 @@ type ConsensusConfig struct {
 	// has to be manual (useful for tests)
 	DontAutoPropose bool `mapstructure:"dont-auto-propose'"`
 
-	// Reactor sleep duration parameters
+	// Reactor sleep duration parameters. PeerGossipSleepDuration also sets the
+	// gossip tick a lagging peer's catch-up part-set replay is metered against
+	// (internal/consensus/gossiper.go's catchupResendInterval, currently a fixed
+	// 500ms quiet gap between passes that does NOT scale with this value):
+	// raising this past that value disables the throttle entirely, since every
+	// tick then already exceeds the gap it is meant to enforce. Lowering it
+	// does not shrink the gap — it only fits more ticks (and so more sends of
+	// a multi-part block) into that same fixed window before it applies.
 	PeerGossipSleepDuration     time.Duration `mapstructure:"peer-gossip-sleep-duration"`
 	PeerQueryMaj23SleepDuration time.Duration `mapstructure:"peer-query-maj23-sleep-duration"`
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -546,7 +546,10 @@ double-sign-check-height = {{ .Consensus.DoubleSignCheckHeight }}
 create-empty-blocks = {{ .Consensus.CreateEmptyBlocks }}
 create-empty-blocks-interval = "{{ .Consensus.CreateEmptyBlocksInterval }}"
 
-# Reactor sleep duration parameters
+# Reactor sleep duration parameters. peer-gossip-sleep-duration also sets the
+# tick rate a lagging peer's catch-up block-part replay is metered against
+# (a fixed 500ms internal throttle): raising this above 500ms disables that
+# throttle.
 peer-gossip-sleep-duration = "{{ .Consensus.PeerGossipSleepDuration }}"
 peer-query-maj23-sleep-duration = "{{ .Consensus.PeerQueryMaj23SleepDuration }}"
 

--- a/internal/consensus/commit_block_id_test.go
+++ b/internal/consensus/commit_block_id_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dashpay/tenderdash/abci/example/kvstore"
 	"github.com/dashpay/tenderdash/dash"
 	cstypes "github.com/dashpay/tenderdash/internal/consensus/types"
+	sf "github.com/dashpay/tenderdash/internal/state/test/factory"
 	"github.com/dashpay/tenderdash/internal/test/factory"
 	"github.com/dashpay/tenderdash/libs/log"
 	"github.com/dashpay/tenderdash/types"
@@ -72,10 +74,7 @@ func TestCommitIsCheckedAgainstEveryFieldOfTheBlockID(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// blockExec is deliberately nil: every rejection under test must be
-			// reached before the block is handed to the application, so a test that
-			// starts passing by reaching it would panic rather than pass quietly.
-			action := &TryAddCommitAction{logger: log.NewNopLogger()}
+			logger := log.NewNopLogger()
 			stateData := StateData{
 				logger: log.NewNopLogger(),
 				RoundState: cstypes.RoundState{
@@ -86,12 +85,70 @@ func TestCommitIsCheckedAgainstEveryFieldOfTheBlockID(t *testing.T) {
 			}
 			commit := &types.Commit{Height: 10, Round: 0, BlockID: tc.blockID()}
 
-			verified, err := action.verifyCommitBlock(ctx, &stateData, commit)
+			verified, err := verifyCommitBlock(ctx, logger, &stateData, commit)
 
 			assert.False(t, verified, "a commit whose block ID misdescribes the block must not be applied")
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantErr,
 				"the operator must be told which field disagreed")
+		})
+	}
+}
+
+func TestParkedCommitChecksStateIDBeforeSavingBlock(t *testing.T) {
+	chainID := t.Name()
+	for _, mismatch := range []bool{false, true} {
+		name := "matching state ID"
+		if mismatch {
+			name = "different state ID"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			css := makeConsensusState(ctx, t, configSetup(t), 2, chainID, newTickerFunc())
+			privVals := make([]types.PrivValidator, 0, len(css))
+			for _, node := range css {
+				privVals = append(privVals, node.privValidator.PrivValidator)
+			}
+			proposer := css[0].GetStateData()
+			node := css[1]
+			stateData := node.GetStateData()
+			ctx = dash.ContextWithProTxHash(ctx, node.privValidator.ProTxHash)
+			block, err := sf.MakeBlock(proposer.state, 1, &types.Commit{}, kvstore.ProtocolVersion)
+			require.NoError(t, err)
+			block.CoreChainLockedHeight = 1
+			parts, err := block.MakePartSet(types.BlockPartSizeBytes)
+			require.NoError(t, err)
+			blockID := block.BlockID(parts)
+			if mismatch {
+				blockID = forgeField(t, blockID, "state_id")
+			}
+			commit, err := factory.MakeCommit(ctx, blockID, block.Height, 0,
+				proposer.Votes.Precommits(0), proposer.Validators, privVals)
+			require.NoError(t, err)
+			peerID := proposer.Validators.Proposer().NodeAddress.NodeID
+			stateData.updateRoundStep(0, cstypes.RoundStepPrevote)
+			commitCtx := msgInfoWithCtx(ctx, msgInfo{Msg: &CommitMessage{commit}, PeerID: peerID})
+			require.NoError(t, node.ctrl.Dispatch(commitCtx,
+				&TryAddCommitEvent{Commit: commit, PeerID: peerID}, &stateData))
+			require.NotNil(t, stateData.Commit, "a signed commit is parked before its block arrives")
+			for i := 0; i < int(parts.Total()); i++ {
+				msg := &BlockPartMessage{Height: block.Height, Round: 0, Part: parts.GetPart(i)}
+				partCtx := msgInfoWithCtx(ctx, msgInfo{Msg: msg, PeerID: peerID})
+				err = node.ctrl.Dispatch(partCtx, &AddProposalBlockPartEvent{Msg: msg, PeerID: peerID}, &stateData)
+				if mismatch && i == int(parts.Total())-1 {
+					require.ErrorContains(t, err, "state ID does not match")
+				} else {
+					require.NoError(t, err)
+				}
+			}
+			if mismatch {
+				assert.Equal(t, block.Height, stateData.Height)
+				assert.Zero(t, node.blockStore.Height(), "a mismatching commit must never be persisted")
+			} else {
+				assert.Equal(t, block.Height+1, stateData.Height)
+				assert.True(t, stateData.state.LastBlockID.Equals(blockID))
+			}
 		})
 	}
 }

--- a/internal/consensus/commit_block_id_test.go
+++ b/internal/consensus/commit_block_id_test.go
@@ -1,0 +1,97 @@
+package consensus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dashpay/tenderdash/dash"
+	cstypes "github.com/dashpay/tenderdash/internal/consensus/types"
+	"github.com/dashpay/tenderdash/internal/test/factory"
+	"github.com/dashpay/tenderdash/libs/log"
+	"github.com/dashpay/tenderdash/types"
+)
+
+// TestCommitIsCheckedAgainstEveryFieldOfTheBlockID covers the route into a
+// permanent halt that involves no proposal at all. A commit names a block by
+// hash, part set header and state ID. The first two are compared against the
+// block this round holds; the third was not, so a commit agreeing on both while
+// naming a different state ID was applied against this block and then recorded
+// with its own BlockID. The next height compares that record against the state
+// the block produced, they disagree, and no proposer at any round can satisfy
+// both -- the disagreement is sealed by a threshold signature over a finalized
+// height on one side and persisted state on the other.
+//
+// Each field is asked separately so an operator is told which one disagreed.
+func TestCommitIsCheckedAgainstEveryFieldOfTheBlockID(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = dash.ContextWithProTxHash(ctx, make(types.ProTxHash, 32))
+
+	block := &types.Block{
+		Header:     *factory.MakeHeader(t, &types.Header{Height: 10}),
+		LastCommit: &types.Commit{},
+	}
+	parts, err := block.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	honest := block.BlockID(parts)
+	require.NotEmpty(t, honest.StateID)
+
+	otherParts, err := (&types.Block{
+		Header:     *factory.MakeHeader(t, &types.Header{Height: 10, CoreChainLockedHeight: 9}),
+		LastCommit: &types.Commit{},
+	}).MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name    string
+		blockID func() types.BlockID
+		wantErr string
+	}{
+		{
+			name:    "disagrees on the state ID",
+			blockID: func() types.BlockID { return forgeField(t, honest, "state_id") },
+			wantErr: "state ID does not match",
+		},
+		{
+			name:    "disagrees on the hash",
+			blockID: func() types.BlockID { return forgeField(t, honest, "hash") },
+			wantErr: "does not hash to commit hash",
+		},
+		{
+			name: "disagrees on the part set header",
+			blockID: func() types.BlockID {
+				forged := honest
+				forged.PartSetHeader = otherParts.Header()
+				return forged
+			},
+			wantErr: "ProposalBlockParts header",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// blockExec is deliberately nil: every rejection under test must be
+			// reached before the block is handed to the application, so a test that
+			// starts passing by reaching it would panic rather than pass quietly.
+			action := &TryAddCommitAction{logger: log.NewNopLogger()}
+			stateData := StateData{
+				logger: log.NewNopLogger(),
+				RoundState: cstypes.RoundState{
+					Height:             10,
+					ProposalBlock:      block,
+					ProposalBlockParts: parts,
+				},
+			}
+			commit := &types.Commit{Height: 10, Round: 0, BlockID: tc.blockID()}
+
+			verified, err := action.verifyCommitBlock(ctx, &stateData, commit)
+
+			assert.False(t, verified, "a commit whose block ID misdescribes the block must not be applied")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr,
+				"the operator must be told which field disagreed")
+		})
+	}
+}

--- a/internal/consensus/gossip_handlers.go
+++ b/internal/consensus/gossip_handlers.go
@@ -73,7 +73,10 @@ func dataGossipHandler(ps *PeerState, logger log.Logger, blockStore sm.BlockStor
 		if shouldPeerBeCaughtUp(rs, prs, blockStoreBase) {
 			if prs.ProposalBlockParts != nil {
 				gossiper.GossipBlockPartsForCatchup(ctx, rs, prs)
-				// block parts already delivered -  send commits?
+				// GossipBlockPartsForCatchup is rate-limited between passes, not
+				// per tick (see catchupResendInterval); GossipCommit runs
+				// regardless, so the peer still gets its missing commit while a
+				// part-set pass is between replays.
 				gossiper.GossipCommit(ctx, rs, prs)
 				return
 			}

--- a/internal/consensus/gossip_peer_worker.go
+++ b/internal/consensus/gossip_peer_worker.go
@@ -42,15 +42,17 @@ func newPeerGossipWorker(
 	state *State,
 	msgSender *p2pMsgSender,
 ) *peerGossipWorker {
+	clock := clockwork.NewRealClock()
 	gossiper := msgGossiper{
 		ps:         ps,
 		blockStore: &blockRepository{BlockStore: state.blockStore, logger: logger},
 		msgSender:  msgSender,
 		logger:     logger,
 		optimistic: true,
+		clock:      clock,
 	}
 	return &peerGossipWorker{
-		clock:          clockwork.NewRealClock(),
+		clock:          clock,
 		logger:         logger,
 		stopCh:         make(chan struct{}),
 		stateDataStore: state.stateDataStore,

--- a/internal/consensus/gossiper.go
+++ b/internal/consensus/gossiper.go
@@ -5,9 +5,12 @@ package consensus
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/hashicorp/go-multierror"
+	"github.com/jonboulle/clockwork"
 
 	cstypes "github.com/dashpay/tenderdash/internal/consensus/types"
 	sm "github.com/dashpay/tenderdash/internal/state"
@@ -21,11 +24,32 @@ import (
 type Gossiper interface {
 	GossipProposal(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 	GossipProposalBlockParts(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
+	// GossipBlockPartsForCatchup sends at most one part per call and enforces a
+	// quiet gap of catchupResendInterval between full-part-set replays — it does
+	// NOT bound the send rate to one per interval for a multi-part block, which
+	// spends several ticks before that gap applies (see catchupResendInterval).
+	// The limit is per gossip worker, not per peer: a peer that reconnects gets a
+	// fresh worker and a fresh pass. Must be called from a single goroutine per
+	// Gossiper instance — its internal locking guards field visibility only, not
+	// the check-then-send sequence a second caller would race.
 	GossipBlockPartsForCatchup(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 	GossipVote(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 	GossipVoteSetMaj23(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 	GossipCommit(ctx context.Context, rs cstypes.RoundState, prs *cstypes.PeerRoundState)
 }
+
+// catchupResendInterval is the quiet gap enforced once a catch-up pass ends —
+// by exhausting its budget, failing a send, or being interrupted by a height
+// change — before a fresh pass may open. Catch-up deliberately never marks
+// parts as delivered, so without this gap a peer we believe is behind would be
+// served on every gossip tick. The gap is between passes, not between sends
+// within one: a pass spends one send per gossip tick for as many ticks as the
+// peer reports parts missing, so it bounds full-part-set replays to roughly
+// one per (missing_parts * PeerGossipSleepDuration + catchupResendInterval),
+// not to a flat one per catchupResendInterval — see peer-gossip-sleep-duration
+// in config/config.go for the cadence this scales with. It also does nothing
+// at all if that cadence is configured slower than this interval.
+const catchupResendInterval = 500 * time.Millisecond
 
 type msgGossiper struct {
 	logger     log.Logger
@@ -33,6 +57,34 @@ type msgGossiper struct {
 	msgSender  *p2pMsgSender
 	blockStore *blockRepository
 	optimistic bool
+	clock      clockwork.Clock
+
+	// Catch-up pass accounting for the one peer this gossiper serves, touched
+	// only from GossipBlockPartsForCatchup (see its single-goroutine-caller
+	// requirement on the Gossiper interface). catchupMu guards the fields
+	// themselves against a hypothetical second caller, but not the
+	// draw-then-send-then-settle sequence across them — that still requires the
+	// single-caller invariant to hold.
+	//
+	// Governing invariant: catchupRemaining > 0 means a pass is currently open,
+	// which means catchupRetryAt is already in the past; catchupRetryAt is only
+	// ever in the future while catchupRemaining <= 0. Every write to either
+	// field must preserve this together.
+	//
+	// catchupRetrySticky distinguishes why catchupRetryAt is currently armed,
+	// for the height-change branch: true means the pass that armed it did NOT
+	// finish rendering service (interrupted before exhausting its own budget,
+	// or ended by endCatchupPass) and the deadline must survive a height
+	// change - including a chain of several in a row, none of which get a
+	// chance to open a pass while it's still pending. false means the pass
+	// closed because it had genuinely nothing left to do (spent its own
+	// budget in full, or the peer reported complete) and a peer that then
+	// reports a new height owes nothing carried over from it.
+	catchupMu          sync.Mutex
+	catchupHeight      int64
+	catchupRemaining   int
+	catchupRetryAt     time.Time
+	catchupRetrySticky bool
 }
 
 func newVoteSetMaj23(height int64, round int32, msgType tmproto.SignedMsgType, maj23 types.BlockID) *tmcons.VoteSetMaj23 {
@@ -166,34 +218,73 @@ func (g *msgGossiper) GossipProposal(ctx context.Context, rs cstypes.RoundState,
 	}
 }
 
-// GossipBlockPartsForCatchup sends a block part for catch up
+// GossipBlockPartsForCatchup sends a block part for catch up; see the doc on
+// the Gossiper interface for its rate limit and goroutine-affinity contract.
 func (g *msgGossiper) GossipBlockPartsForCatchup(
 	ctx context.Context,
 	_ cstypes.RoundState,
 	prs *cstypes.PeerRoundState,
 ) {
-	index, ok := prs.ProposalBlockParts.Not().PickRandom()
-	if !ok {
+	draw, lastSlot := g.beginCatchupAttempt(prs)
+	if !draw {
 		return
 	}
+	sent := false
+	defer func() {
+		switch {
+		case sent && lastSlot:
+			// A spent pass settles here, not in beginCatchupAttempt, so its
+			// quiet gap runs from the moment the send returned: the p2p channel
+			// applies backpressure on this very goroutine, and time spent
+			// blocked inside a send is not quiet time.
+			g.completeCatchupPass()
+		case !sent:
+			// The peer controls both the budget a pass opens with and the
+			// inputs that fail here, so a pass that cannot produce a send is
+			// abandoned rather than charged one slot per tick. A defer, not a
+			// plain if-check on sendCatchupBlockPart's return: its block-store
+			// reads deliberately panic on a decode or read failure (see
+			// blockRepository.loadMeta/loadPart), and runGossipHandler recovers
+			// that panic per tick and keeps ticking - a defer is the only way
+			// this still runs on that path, so a peer that can trigger such a
+			// panic doesn't get a full-stack log and a wasted budget slot on
+			// every tick for the rest of the pass, but exactly one before the
+			// pass ends like any other failed attempt.
+			g.endCatchupPass()
+		}
+	}()
+	sent = g.sendCatchupBlockPart(ctx, prs)
+}
+
+// sendCatchupBlockPart sends the peer one part of its incomplete block, drawn
+// at random from the parts it reports missing, and reports whether the part
+// was handed to the p2p channel. A false result means either the send could
+// not be enqueued (in practice, only on reactor shutdown — see
+// internal/p2p/channel.go) or the block-store inputs were unusable; it is not
+// a delivery acknowledgement from the peer.
+func (g *msgGossiper) sendCatchupBlockPart(ctx context.Context, prs *cstypes.PeerRoundState) bool {
 	logger := g.logger.With([]any{
 		"height", prs.Height,
 		"round", prs.Round,
 	})
+	index, ok := prs.ProposalBlockParts.Not().PickRandom()
+	if !ok {
+		// Defensive: prs is a per-tick deep copy, so the draw cannot come up empty.
+		return false
+	}
+	logger = logger.With("part_index", index)
 	meta, err := g.blockStore.loadMeta(prs.Height)
 	if err != nil {
-		logger.Error("couldn't find a block meta", "error", err)
-		return
+		return false
 	}
 	err = g.ensurePeerPartSetHeader(meta.BlockID.PartSetHeader, prs.ProposalBlockPartSetHeader)
 	if err != nil {
 		logger.Error("block and peer part-set headers do not match", "error", err)
-		return
+		return false
 	}
 	part, err := g.blockStore.loadPart(prs.Height, index)
 	if err != nil {
-		logger.Error("couldn't find a block part", "part_index", index, "error", err)
-		return
+		return false
 	}
 	// Catch-up gossip: do NOT optimistically record the part as delivered.
 	//
@@ -202,13 +293,194 @@ func (g *msgGossiper) GossipBlockPartsForCatchup(
 	// silently drop the part. If we optimistically marked it delivered, our view
 	// of the peer would show the full part set and we would never resend it,
 	// leaving the peer wedged with a stored commit but an incomplete block (it
-	// learns the part-set header only once the catch-up commit arrives). By not
-	// marking it, we keep resending the missing part each gossip tick until the
-	// peer actually applies the block and advances its height.
-	err = g.syncProposalBlockPart(ctx, part, prs.Height, meta.Round, false)
-	if err != nil {
-		logger.Error("failed to sync proposal block part to the peer", "error", err)
+	// learns the part-set header only once the catch-up commit arrives). The
+	// part is instead replayed every pass until the peer applies the block and
+	// advances its height.
+	if err := g.syncProposalBlockPart(ctx, part, prs.Height, meta.Round, false); err != nil {
+		logger.Error("failed to send catch-up block part to the peer", "error", err)
+		return false
 	}
+	return true
+}
+
+// beginCatchupAttempt draws a send from the current catch-up pass, reporting
+// draw=false once the pass is spent and until its retry interval elapses. A
+// pass is worth at most one send per part the peer reported missing when it
+// opened, so a peer that dropped those parts is served again every interval
+// while it stays behind. Any attempt that fails ends the pass early, via
+// endCatchupPass.
+//
+// lastSlot reports that this draw was the pass's final one, which obliges the
+// caller to settle the pass - via completeCatchupPass on a successful send,
+// endCatchupPass otherwise - once the send has returned.
+func (g *msgGossiper) beginCatchupAttempt(prs *cstypes.PeerRoundState) (draw, lastSlot bool) {
+	if prs.ProposalBlockParts == nil {
+		return false, false
+	}
+	g.catchupMu.Lock()
+	defer g.catchupMu.Unlock()
+	now := g.clock.Now()
+	if prs.Height != g.catchupHeight {
+		// A peer only ever reports a higher height, so this cannot be replayed
+		// to reopen a pass.
+		switch {
+		case g.catchupRemaining > 0:
+			// It can, though, interrupt a pass before that pass exhausts its own
+			// budget, which (per the invariant above) means catchupRetryAt was
+			// never armed for it. Arm it here too, or a peer advancing its height
+			// every tick gets a fresh full-budget pass every tick forever. Marked
+			// sticky: unrendered service, must survive further height changes too.
+			g.catchupRetryAt = now.Add(catchupResendInterval)
+			g.catchupRetrySticky = true
+		case g.catchupRetrySticky && now.Before(g.catchupRetryAt):
+			// No pass is open, but the currently-armed deadline is sticky and
+			// hasn't elapsed - it may belong to THIS height change (a pass just
+			// interrupted above), or it may be inherited from an earlier one in
+			// a rapid chain that got no chance to open a pass at all before
+			// advancing again. Leave it untouched either way: a peer hopping
+			// through several heights before the deadline elapses must not be
+			// able to shorten or clear it by hopping through one more.
+		default:
+			// No pass is open, and any armed deadline is either non-sticky
+			// (the previous height's pass closed because it genuinely had
+			// nothing left to do: spent its own budget in full, or the peer
+			// reported complete) or has already elapsed. Clear it: a peer that
+			// isn't replaying anything and owes nothing from before is served
+			// immediately at the new height, matching how catch-up behaves
+			// everywhere upstream of this PR (no per-height throttle at all).
+			//
+			// This does reopen a bounded gap for the non-sticky case: a peer
+			// can open a pass, let it close cleanly (one real send, e.g. by
+			// reporting a single missing part), then immediately claim a new
+			// height and repeat, getting one send per gossip tick indefinitely
+			// instead of one pass per interval. Bounded to that - at most 1
+			// send/PeerGossipSleepDuration tick (10/s, ~640KB/s of block parts
+			// at production defaults) - because CompareHRS enforces monotonic
+			// height only (no replay or ping-ponging) and
+			// ensurePeerPartSetHeader requires the real, currently-stored
+			// PartSetHeader for each claimed height (a mismatch ends the pass
+			// via endCatchupPass, which is sticky, costing the peer a full
+			// interval rather than a send). So sustaining this requires
+			// marching forward through genuine, still-retained history, capped
+			// by blockStoreBase - no worse than the pre-#1365 catch-up rate
+			// this codebase already tolerated in production. Accepted as
+			// strictly cheaper than taxing every honestly-advancing lagging
+			// peer by up to 500ms per height; closing it for real needs a
+			// verified-progress-gated redesign, tracked as follow-up rather
+			// than done here.
+			g.catchupRetryAt = time.Time{}
+			g.catchupRetrySticky = false
+		}
+		g.catchupHeight = prs.Height
+		g.catchupRemaining = 0
+	}
+	noOpenPass := g.catchupRemaining <= 0
+	if noOpenPass && now.Before(g.catchupRetryAt) {
+		// Still backed off: this tick cannot send regardless of what the peer
+		// currently reports missing, so skip the bit-array scan below entirely.
+		// Most ticks land here at the production defaults (one pass's worth of
+		// backoff spans roughly catchupResendInterval / PeerGossipSleepDuration
+		// ticks), and the peer-controlled bit-array can be up to
+		// MaxBlockPartsCount bits.
+		return false, false
+	}
+	// PickRandom draws from the parts the peer reports missing, so the pass is
+	// worth that many sends rather than one per entry in the bit-array. Derived
+	// as size minus set bits rather than via Not().CountTrueBits(), which would
+	// allocate and copy the whole bit-array just to count it.
+	missing := prs.ProposalBlockParts.Size() - prs.ProposalBlockParts.CountTrueBits()
+	if missing == 0 {
+		if !noOpenPass {
+			// The peer now reports a complete part set while a pass was still
+			// open (budget not yet exhausted). This does NOT let the peer send
+			// more than the budget fixed at pass open — catchupRemaining only
+			// ever counts down, never up, so total sends per pass are unaffected
+			// either way. Left open regardless, though, noOpenPass stays false on
+			// every later tick no matter how much time passes, which costs two
+			// things: the backoff-skip check above never re-engages, so the
+			// bit-array scan above runs on every tick for as long as the peer
+			// holds the pass open this way (the CPU cost the backoff-skip check
+			// exists to bound); and the next report of missing parts resumes
+			// sending on that same tick rather than after a fresh
+			// catchupResendInterval. Close the pass here to bound both. This
+			// does mean a peer that legitimately completes its part set and
+			// later falls behind again waits out one interval before catch-up
+			// resumes - accepted deliberately: a peer that just reported a
+			// complete set is by definition not starving, and the wait is
+			// negligible against block time.
+			g.catchupRemaining = 0
+			g.catchupRetryAt = now.Add(catchupResendInterval)
+			// Non-sticky: the peer reporting complete is exactly the "nothing
+			// left to do" case the height-change branch grants amnesty for.
+			g.catchupRetrySticky = false
+		}
+		return false, false
+	}
+	if noOpenPass {
+		// The budget is fixed here, for the whole pass. The peer owns the
+		// bit-array behind missing and may replace it between ticks, so
+		// re-deriving it to raise the budget mid-pass would let it widen the
+		// pass.
+		g.catchupRemaining = missing
+	} else {
+		// The peer's reported missing count can only shrink honestly as parts
+		// are actually delivered elsewhere (e.g. via non-catch-up gossip), so
+		// clamp the remaining budget down to match; never let it raise the
+		// budget mid-pass. Without this, a peer that swaps in a bit-array with
+		// fewer unset bits mid-pass keeps the larger budget the pass opened
+		// with, and every remaining attempt draws from the now-small missing
+		// set - funding repeated duplicate sends of the few parts still unset.
+		g.catchupRemaining = min(g.catchupRemaining, missing)
+	}
+	g.catchupRemaining--
+	if g.catchupRemaining <= 0 {
+		// The pass is spent, but its deadline is left to the caller to arm once
+		// the send returns, so the quiet gap excludes the send's own duration.
+		// Until then the pass is closed with a stale deadline, which the
+		// governing invariant allows (it only forbids a future deadline while
+		// catchupRemaining > 0) and no other code can observe: the single
+		// caller is inside that send for the whole window, so no further
+		// attempt - and no height change, which is only ever read from a
+		// per-tick prs here - can run before it settles.
+		return true, true
+	}
+	return true, false
+}
+
+// endCatchupPass abandons the rest of the current pass and starts its retry
+// interval now. Without it a pass that cannot send costs a block-store read
+// and an error log on every gossip tick until its budget runs out. Marked
+// sticky: ending here means an attempt failed to render service (as opposed
+// to a pass that closed because it had nothing left to do), so the deadline
+// must survive a height change - a peer cannot dodge it by claiming a new
+// height right after triggering the failure.
+func (g *msgGossiper) endCatchupPass() {
+	g.settleCatchupPass(true)
+}
+
+// completeCatchupPass closes a pass whose last slot was just spent on a
+// successful send and starts its retry interval now: at the pass's end rather
+// than its start (a multi-part pass outlasts the interval, so a deadline armed
+// at open has elapsed before the budget runs out) and after that send returned
+// rather than before it (a send blocked on channel backpressure must not spend
+// the quiet gap it is supposed to precede). Non-sticky: every part the peer
+// reported missing when the pass opened got a send, so a peer that then
+// reports a new height owes nothing carried over.
+func (g *msgGossiper) completeCatchupPass() {
+	g.settleCatchupPass(false)
+}
+
+// settleCatchupPass closes the current pass and arms its retry deadline an
+// interval from now; sticky marks a pass that ended without rendering the
+// service it opened for. Called only once an attempt has finished, so the
+// deadline it arms is measured from the moment the pass really stopped
+// working.
+func (g *msgGossiper) settleCatchupPass(sticky bool) {
+	g.catchupMu.Lock()
+	defer g.catchupMu.Unlock()
+	g.catchupRemaining = 0
+	g.catchupRetryAt = g.clock.Now().Add(catchupResendInterval)
+	g.catchupRetrySticky = sticky
 }
 
 // GossipCommit sends a commit message to the peer
@@ -289,11 +561,7 @@ func (g *msgGossiper) syncProposalBlockPart(ctx context.Context, part *types.Par
 		syncFunc = updatePeerProposalBlockPart(g.ps, height, round, int(part.Index))
 	}
 	logger.Debug("syncing proposal block part")
-	err = g.sync(ctx, protoBlockPart, syncFunc)
-	if err != nil {
-		logger.Error("failed to sync proposal block part to the peer", "error", err)
-	}
-	return nil
+	return g.sync(ctx, protoBlockPart, syncFunc)
 }
 
 func (g *msgGossiper) sync(ctx context.Context, protoMsg proto.Message, syncFunc func() error) error {

--- a/internal/consensus/gossiper_test.go
+++ b/internal/consensus/gossiper_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cosmos/gogoproto/proto"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
@@ -17,6 +18,7 @@ import (
 	p2pmocks "github.com/dashpay/tenderdash/internal/p2p/mocks"
 	"github.com/dashpay/tenderdash/internal/state/mocks"
 	"github.com/dashpay/tenderdash/internal/test/factory"
+	"github.com/dashpay/tenderdash/libs/bits"
 	"github.com/dashpay/tenderdash/libs/log"
 	tmrand "github.com/dashpay/tenderdash/libs/rand"
 	tmcons "github.com/dashpay/tenderdash/proto/tendermint/consensus"
@@ -29,6 +31,7 @@ type GossiperSuiteTest struct {
 
 	ps         *PeerState
 	gossiper   *msgGossiper
+	clock      *clockwork.FakeClock
 	sender     *p2pMsgSender
 	blockStore *mocks.BlockStore
 	stateCh    *p2pmocks.Channel
@@ -68,6 +71,7 @@ func (suite *GossiperSuiteTest) SetupTest() {
 		},
 	}
 	suite.blockStore = &mocks.BlockStore{}
+	suite.clock = clockwork.NewFakeClock()
 	suite.gossiper = &msgGossiper{
 		logger:    suite.logger,
 		ps:        suite.ps,
@@ -77,6 +81,7 @@ func (suite *GossiperSuiteTest) SetupTest() {
 			logger:     suite.logger,
 		},
 		optimistic: true,
+		clock:      suite.clock,
 	}
 }
 
@@ -364,7 +369,7 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchup() {
 				suite.blockStore.On("Base").Once().Return(int64(1))
 				suite.blockStore.On("Height").Once().Return(int64(1000))
 			},
-			wantLog: `couldn't find a block meta`,
+			wantLog: `failed to load block meta`,
 		},
 		{
 			prs: cstypes.PeerRoundState{Height: 999, ProposalBlockParts: partSet1.BitArray().Not()},
@@ -382,7 +387,7 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchup() {
 				suite.blockStore.On("LoadBlockMeta", int64(999)).Once().Return(&blockMeta)
 				suite.blockStore.On("LoadBlockPart", int64(999), 0).Once().Return(nil)
 			},
-			wantLog: `couldn't find a block part`,
+			wantLog: `failed to load block part`,
 		},
 	}
 	for i, tc := range testCases {
@@ -390,6 +395,9 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchup() {
 			if tc.mockFn != nil {
 				tc.mockFn()
 			}
+			// The cases are independent occasions at the same height; without this
+			// they share one catch-up retry interval and only the first one acts.
+			suite.clock.Advance(catchupResendInterval)
 			suite.ps.PRS = tc.prs
 			if tc.wantMsg != nil {
 				suite.dataCh.
@@ -405,12 +413,11 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchup() {
 	}
 }
 
-// TestGossipBlockPartsForCatchupResends verifies that catch-up block-part
-// gossip does NOT optimistically record the part as delivered. A lagging peer
-// may be at a step where it is not yet expecting block parts and silently drops
-// them; if we marked the part delivered we would never resend it, wedging the
-// peer with an incomplete block. The part must therefore keep being sent on
-// every tick until the peer applies the block and advances its height.
+// TestGossipBlockPartsForCatchupResends verifies the two halves of the catch-up
+// contract for a single-part block: the part is never optimistically recorded as
+// delivered (a lagging peer may silently drop it, and marking would wedge the
+// peer with an incomplete block), and it is replayed once the retry interval has
+// elapsed rather than on every gossip tick.
 func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResends() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -432,28 +439,42 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResends() {
 
 	suite.blockStore.On("LoadBlockMeta", int64(999)).Twice().Return(&blockMeta)
 	suite.blockStore.On("LoadBlockPart", int64(999), 0).Twice().Return(part0)
+	sends := 0
 	suite.dataCh.
 		On("Send", ctx, p2p.Envelope{
 			To:      suite.ps.peerID,
 			Message: &tmcons.BlockPart{Height: 999, Round: 0, Part: *protoPart0},
 		}).
+		Run(func(_ mock.Arguments) { sends++ }).
 		Twice().
 		Return(nil)
 
-	// First tick: send the missing part.
+	// First tick sends the missing part, completing the pass for this height.
 	suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	suite.Require().Equal(1, sends)
 	suite.Require().False(suite.ps.PRS.ProposalBlockParts.GetIndex(0),
 		"catch-up must not optimistically mark the peer as having the part")
 
-	// Second tick: the part is still considered missing, so it is resent.
+	// Further ticks inside the retry interval must not replay the part: that is
+	// what floods a peer we only believe to be lagging.
+	for range 100 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(1, sends, "catch-up must not resend within the retry interval")
+
+	// Once the interval elapses the peer is still behind, so the part is resent.
+	suite.clock.Advance(catchupResendInterval)
 	suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	suite.Require().Equal(2, sends, "catch-up must resend after the retry interval")
+	suite.Require().False(suite.ps.PRS.ProposalBlockParts.GetIndex(0),
+		"catch-up must not optimistically mark the peer as having the part")
 }
 
 // TestGossipBlockPartsForCatchupResendsMultiPart verifies that catch-up
 // block-part gossip iterates across ALL missing indices in a multi-part block,
-// not just a single index. With three parts all initially missing, every part
-// index must be sent to the lagging peer across repeated gossip ticks, and the
-// peer's ProposalBlockParts bit-array must never be optimistically marked.
+// not just a single index, while spending at most one part-set pass per retry
+// interval. The peer's ProposalBlockParts bit-array must never be optimistically
+// marked.
 func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResendsMultiPart() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -472,11 +493,11 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResendsMultiPart()
 		ProposalBlockPartSetHeader: partSet.Header(),
 	}
 
-	// Each gossip tick picks ONE random missing index via PickRandom.
-	// By the coupon-collector model, covering all 3 indices takes ~5.5 ticks on
-	// average; 90 ticks makes the probability of any single index going unseen
-	// below (2/3)^90 ≈ 10^-16 per index — negligible in practice.
-	const ticks = 90
+	// A pass spends one send per part, each picking a random missing index, so a
+	// single pass need not cover every index. By the coupon-collector model 30
+	// passes of 3 sends leave any index unseen with probability (2/3)^90 ≈
+	// 10^-16 — negligible in practice.
+	const passes = 30
 
 	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
 	for i := uint32(0); i < partSet.Total(); i++ {
@@ -485,6 +506,7 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResendsMultiPart()
 
 	// Capture which part indices the gossiper actually sends.
 	sentIndices := make(map[uint32]bool)
+	sends := 0
 	suite.dataCh.On("Send", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			env, ok := args.Get(1).(p2p.Envelope)
@@ -493,18 +515,31 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResendsMultiPart()
 			}
 			if bp, ok := env.Message.(*tmcons.BlockPart); ok {
 				sentIndices[bp.Part.Index] = true
+				sends++
 			}
 		}).
 		Return(nil)
 
-	for range ticks {
+	// One pass covers the part set; extra ticks within the interval are skipped.
+	for range int(partSet.Total()) + 5 {
 		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
 	}
+	suite.Require().Equal(int(partSet.Total()), sends,
+		"a catch-up pass must send exactly one part per part-set entry")
+
+	for range passes - 1 {
+		suite.clock.Advance(catchupResendInterval)
+		for range int(partSet.Total()) {
+			suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+		}
+	}
+	suite.Require().Equal(passes*int(partSet.Total()), sends,
+		"each elapsed retry interval must allow exactly one further pass")
 
 	// Every part index must have been sent to the peer at least once.
 	for i := uint32(0); i < partSet.Total(); i++ {
 		suite.Assert().True(sentIndices[i],
-			"part index %d was never sent across %d gossip ticks", i, ticks)
+			"part index %d was never sent across %d catch-up passes", i, passes)
 	}
 
 	// The peer's bit-array must remain un-marked (no optimistic delivery).
@@ -513,6 +548,815 @@ func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupResendsMultiPart()
 		suite.Assert().False(prs.ProposalBlockParts.GetIndex(int(i)),
 			"catch-up must not optimistically mark part %d as delivered", i)
 	}
+}
+
+// TestGossipBlockPartsForCatchupBudgetIsNeverRaisedMidPass pins a pass's
+// budget as an upper bound fixed at open: it may be clamped down when the
+// peer's reported missing count drops (see
+// TestGossipBlockPartsForCatchupBudgetShrinksWithReportedMissing) but never
+// raised back up once clamped. The peer supplies the bit-array the missing
+// count is derived from and may replace it between ticks, so if raising the
+// count mid-pass were honored, a peer could both recover budget the clamp had
+// taken away and step over the deadline the clamp-triggered exhaustion armed.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetIsNeverRaisedMidPass() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	const numParts = 5
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*numParts), partSize)
+	suite.Require().Equal(uint32(numParts), partSet.Total(), "need headroom above the clamped-down budget")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	// reportMissing has the peer claim its first n parts are outstanding.
+	reportMissing := func(n int) {
+		reported := partSet.BitArray().Copy() // every bit set: peer has them all
+		for i := range n {
+			reported.SetIndex(i, false)
+		}
+		suite.Require().Equal(n, reported.Not().CountTrueBits())
+		suite.ps.PRS.ProposalBlockParts = reported
+	}
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+	reportMissing(numParts)
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	for i := range int(partSet.Total()) {
+		suite.blockStore.On("LoadBlockPart", int64(999), i).Return(partSet.GetPart(i))
+	}
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	tick := func() {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+
+	// Open a 5-send pass and spend two of them, leaving 3 in the budget.
+	tick()
+	tick()
+
+	// Drop hard, to fewer than the 3 remaining: a genuine clamp, not a no-op.
+	// The pass now has only 1 slot left instead of 3, so it exhausts (and arms
+	// the deadline) on the very next tick.
+	reportMissing(1)
+	tick()
+	suite.Require().Equal(3, sends, "the clamp must actually shrink the remaining budget, ending the pass early")
+
+	// Raise it back to the original count, at the same clock instant the
+	// deadline was just armed at.
+	reportMissing(numParts)
+	tick()
+	tick()
+	suite.Require().Equal(3, sends,
+		"raising the reported count after the clamp ended the pass must not reopen it before the deadline")
+
+	// Only once the interval elapses does a fresh pass open, budgeted on
+	// whatever the peer currently reports -- all 5 parts once again.
+	suite.clock.Advance(catchupResendInterval)
+	tick()
+	suite.Require().Equal(4, sends, "the next pass opens fresh, unrelated to the one the clamp cut short")
+}
+
+// TestGossipBlockPartsForCatchupBudgetsMissingParts pins the catch-up pass to
+// the number of parts the peer is actually missing rather than the size of its
+// bit-array. The peer supplies that bit-array over the wire and only its length
+// is validated, so budgeting on the length would let a peer reporting a single
+// missing part draw one resend of it per bit in the array.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetsMissingParts() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*3), partSize)
+	suite.Require().Equal(uint32(3), partSet.Total(), "need a 3-part block for this test")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	// The peer reports every part but the last, so exactly one is missing.
+	peerParts := partSet.BitArray().Copy()
+	peerParts.SetIndex(2, false)
+	suite.Require().Equal(2, peerParts.CountTrueBits())
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         peerParts,
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	suite.blockStore.On("LoadBlockPart", int64(999), 2).Return(partSet.GetPart(2))
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	for range int(partSet.Total()) + 5 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(1, sends,
+		"a pass must spend one send per missing part, not one per bit-array entry")
+
+	suite.clock.Advance(catchupResendInterval)
+	suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	suite.Require().Equal(2, sends, "the missing part is retried once the interval elapses")
+}
+
+// TestGossipBlockPartsForCatchupRetryIntervalArmsWhenPassEnds verifies the
+// pass's retry deadline is measured from its last send, not from when it
+// opened. A pass with enough missing parts to span more gossip ticks than
+// catchupResendInterval allows takes longer than the interval to exhaust; a
+// deadline armed at open time has already elapsed by then, so the next tick
+// would otherwise reopen a fresh pass immediately - leaving no quiet gap
+// between passes, which is exactly the flooding behavior this throttle
+// exists to stop.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupRetryIntervalArmsWhenPassEnds() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	const numParts = 6
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*numParts), partSize)
+	suite.Require().Equal(uint32(numParts), partSet.Total(), "need a 6-part block for this test")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         partSet.BitArray().Not(), // peer has none
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	for i := uint32(0); i < partSet.Total(); i++ {
+		suite.blockStore.On("LoadBlockPart", int64(999), int(i)).Return(partSet.GetPart(int(i)))
+	}
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	tick := func() {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+
+	// A gossip tick every fifth of the interval: 6 missing parts therefore
+	// take longer than catchupResendInterval to exhaust the pass.
+	step := catchupResendInterval / 5
+
+	// The first 5 ticks drain 5 of the pass's 6 sends, ending at
+	// t = catchupResendInterval.
+	for range 5 {
+		tick()
+		suite.clock.Advance(step)
+	}
+	suite.Require().Equal(5, sends)
+
+	// This tick, still at t = catchupResendInterval, spends the pass's last
+	// send.
+	tick()
+	suite.Require().Equal(6, sends, "the pass's budget covers all 6 missing parts")
+
+	// A tick right after the pass's last send must NOT open a new pass: a
+	// full interval must elapse after the LAST send, not after the pass
+	// opened (which was catchupResendInterval ago by now too).
+	tick()
+	suite.Require().Equal(6, sends,
+		"no further send until a full retry interval has elapsed since the pass's last send")
+
+	// Advancing to just short of a full interval past the last send still
+	// must not reopen the pass.
+	suite.clock.Advance(catchupResendInterval - step)
+	tick()
+	suite.Require().Equal(6, sends,
+		"the retry deadline must be measured from the pass's last send, not from when it opened")
+
+	// Only once a full interval has elapsed since the last send does a fresh
+	// pass open.
+	suite.clock.Advance(step)
+	tick()
+	suite.Require().Equal(7, sends, "a fresh pass opens once the full interval has elapsed")
+}
+
+// TestGossipBlockPartsForCatchupRetryIntervalArmsAfterSendReturns is a
+// regression test for a defect where the pass's retry deadline was armed from
+// a timestamp taken before the send, so a send that blocked for part of the
+// interval - the p2p channel applies backpressure on this very goroutine -
+// had its own duration counted against the quiet gap that is supposed to
+// start once it returns. A send lasting a full catchupResendInterval left the
+// deadline already elapsed on return, so the next gossip tick opened a fresh
+// pass with no gap at all: the slower the peer's channel, the weaker the
+// throttle, which is exactly backwards.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupRetryIntervalArmsAfterSendReturns() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*3), partSize)
+	suite.Require().Equal(uint32(3), partSet.Total(), "need a 3-part block for this test")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	// The peer reports exactly one part missing, so a pass is one send wide
+	// and the very first tick spends its last slot.
+	peerParts := partSet.BitArray().Copy()
+	peerParts.SetIndex(2, false)
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         peerParts,
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	suite.blockStore.On("LoadBlockPart", int64(999), 2).Return(partSet.GetPart(2))
+
+	// Each send occupies the whole interval before it returns.
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+				suite.clock.Advance(catchupResendInterval)
+			}
+		}).
+		Return(nil)
+
+	tick := func() {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+
+	tick()
+	suite.Require().Equal(1, sends, "the pass's single slot is spent on the first tick")
+
+	tick()
+	suite.Require().Equal(1, sends,
+		"the time spent inside the send must not count towards the quiet gap that follows it")
+
+	suite.clock.Advance(catchupResendInterval - time.Nanosecond)
+	tick()
+	suite.Require().Equal(1, sends, "a full interval after the send returned is still not up")
+
+	suite.clock.Advance(time.Nanosecond)
+	tick()
+	suite.Require().Equal(2, sends, "a fresh pass opens an interval after the send returned")
+}
+
+// TestGossipBlockPartsForCatchupHeightAdvanceInterruptingPassIsThrottled is a
+// regression test for a defect where a height change interrupting a pass
+// BEFORE it exhausted its own budget left catchupRetryAt unarmed (only
+// exhaustion or a failed send armed it). A peer that advances its reported
+// height every tick -- legitimate and monotonic, no protocol violation -- then
+// forced a fresh full-budget pass on every single tick, forever, whenever the
+// block at each claimed height took more than one tick to exhaust (i.e. any
+// block with more than one missing part, the common case). The clock is never
+// advanced across the first block of ticks below: a working throttle must
+// still bound the send rate even though the peer supplies a "new" pass at
+// every step.
+//
+// Also pins a narrower defect the fix for the above introduced and this test
+// caught directly: naively granting a new height amnesty from the previous
+// height's deadline whenever catchupRemaining == 0 is wrong when that 0 came
+// from an INTERMEDIATE height that never got a chance to open a pass at all
+// (still serving an earlier interruption's penalty) rather than from a pass
+// that genuinely finished. Every height below except the first is exactly
+// that intermediate case, so a version of the fix that doesn't track WHY
+// catchupRetryAt is armed (see catchupRetrySticky) turns this test's 1 send
+// into a fresh send roughly every other height.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupHeightAdvanceInterruptingPassIsThrottled() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	const numParts = 3
+	const numHeights = 20
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	tick := func(height int64) {
+		partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*numParts), partSize)
+		suite.Require().Equal(uint32(numParts), partSet.Total())
+		blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+		suite.blockStore.On("LoadBlockMeta", height).Return(&blockMeta)
+		for i := uint32(0); i < partSet.Total(); i++ {
+			suite.blockStore.On("LoadBlockPart", height, int(i)).Return(partSet.GetPart(int(i)))
+		}
+		suite.ps.PRS = cstypes.PeerRoundState{
+			Height:                     height,
+			Round:                      0,
+			ProposalBlockParts:         partSet.BitArray().Not(), // peer has none
+			ProposalBlockPartSetHeader: partSet.Header(),
+		}
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+
+	// The peer advances its reported height on every tick, at the same clock
+	// instant, before any pass at a prior height could exhaust its 3-send
+	// budget. A throttle that only arms its deadline on exhaustion or failure
+	// never gets a chance to arm it here.
+	for h := int64(1); h <= numHeights; h++ {
+		tick(h)
+	}
+	suite.Require().Equal(1, sends,
+		"an unexhausted pass interrupted by a height change must still throttle to one pass per interval")
+
+	suite.clock.Advance(catchupResendInterval)
+	tick(numHeights + 1)
+	suite.Require().Equal(2, sends, "a fresh pass opens once the interval has elapsed since the interrupted pass")
+}
+
+// TestGossipBlockPartsForCatchupCleanHeightAdvanceIsNotThrottled is a
+// regression test for a defect where a pass that closed CLEANLY (its own
+// budget exhausted, catchupRemaining == 0) at the old height left
+// catchupRetryAt armed against that old height, and a peer that then
+// genuinely advanced past it inherited that leftover deadline: the new
+// height's first pass would wait out up to catchupResendInterval for no
+// reason, even though the peer isn't replaying anything and holds no
+// interrupted budget. Catch-up is the only path offered to a peer at a
+// different height than ours, so this taxes every honestly-advancing lagging
+// peer, once per height. Contrast with
+// TestGossipBlockPartsForCatchupHeightAdvanceInterruptingPassIsThrottled,
+// which pins that an height change interrupting an UNEXHAUSTED pass must
+// still throttle - that case is intentionally unchanged here.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupCleanHeightAdvanceIsNotThrottled() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	// Height 999: a single-part block, so one tick both opens AND fully
+	// exhausts the pass's budget - it closes cleanly, not by interruption.
+	onePart := types.NewPartSetFromData(tmrand.Bytes(100), 100)
+	suite.Require().Equal(uint32(1), onePart.Total())
+	onePartMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: onePart.Header()}}
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&onePartMeta)
+	suite.blockStore.On("LoadBlockPart", int64(999), 0).Return(onePart.GetPart(0))
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         onePart.BitArray().Not(),
+		ProposalBlockPartSetHeader: onePart.Header(),
+	}
+	suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	suite.Require().Equal(1, sends, "the single-part pass must close on its own budget, not by interruption")
+
+	// The peer genuinely advances to height 1000, on the very same simulated
+	// instant - no time has passed since the height-999 pass closed.
+	threeParts := types.NewPartSetFromData(tmrand.Bytes(300), 100)
+	suite.Require().Equal(uint32(3), threeParts.Total())
+	threePartsMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: threeParts.Header()}}
+	suite.blockStore.On("LoadBlockMeta", int64(1000)).Return(&threePartsMeta)
+	for i := uint32(0); i < threeParts.Total(); i++ {
+		suite.blockStore.On("LoadBlockPart", int64(1000), int(i)).Return(threeParts.GetPart(int(i)))
+	}
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     1000,
+		Round:                      0,
+		ProposalBlockParts:         threeParts.BitArray().Not(),
+		ProposalBlockPartSetHeader: threeParts.Header(),
+	}
+	suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	suite.Require().Equal(2, sends,
+		"a cleanly-closed pass at the old height must not throttle the new height's first pass")
+}
+
+// TestGossipBlockPartsForCatchupBudgetShrinksWithReportedMissing verifies the
+// pass's remaining budget is clamped down when the peer's bit-array later
+// reports fewer parts missing than when the pass opened. Successful catch-up
+// sends never mark parts delivered locally (see
+// TestGossipBlockPartsForCatchupResends), so the peer fully controls what
+// ProposalBlockParts.Not().CountTrueBits() reports on every tick -
+// NewValidBlockMessage.ValidateBasic checks only the array's length and
+// ApplyNewValidBlockMessage installs it wholesale. A peer that opens a pass
+// reporting many parts missing and then swaps in a bit-array with only one
+// unset bit must not keep the larger original budget: every remaining
+// attempt would draw that same single index, funding repeated duplicate
+// sends of it.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupBudgetShrinksWithReportedMissing() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	const numParts = 5
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*numParts), partSize)
+	suite.Require().Equal(uint32(numParts), partSet.Total(), "need a 5-part block for this test")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         partSet.BitArray().Not(), // peer has none: 5 missing
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	for i := uint32(0); i < partSet.Total(); i++ {
+		suite.blockStore.On("LoadBlockPart", int64(999), int(i)).Return(partSet.GetPart(int(i)))
+	}
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	tick := func() {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+
+	// The first two ticks open a 5-send pass and spend two of them.
+	tick()
+	tick()
+	suite.Require().Equal(2, sends)
+
+	// The peer now reports only one part missing, without the height
+	// changing - a bit-array the peer fully controls over the wire (see the
+	// doc comment above).
+	shrunk := partSet.BitArray().Copy() // every bit set: peer has them all
+	shrunk.SetIndex(4, false)           // except part 4
+	suite.ps.PRS.ProposalBlockParts = shrunk
+	suite.Require().Equal(1, shrunk.Not().CountTrueBits())
+
+	for range 5 {
+		tick()
+	}
+	suite.Require().Equal(3, sends,
+		"a pass must not fund more sends than the peer's currently-reported missing count once it shrinks")
+
+	// The next interval opens a fresh pass, budgeted on what the peer reports
+	// at that point (still 1 missing).
+	suite.clock.Advance(catchupResendInterval)
+	tick()
+	suite.Require().Equal(4, sends)
+}
+
+// TestGossipBlockPartsForCatchupCompleteReportMidPassClosesIt verifies that a
+// peer reporting a complete part set while a pass is still open (budget not
+// yet exhausted) closes the pass and arms the retry deadline, rather than
+// leaving it open indefinitely. This is not about exceeding the pass's
+// budget - catchupRemaining only ever counts down, so total sends per pass
+// are the same either way. It's about what an indefinitely-open pass costs:
+// the bit-array scan above runs on every tick instead of being skipped by
+// backoff (see TestGossipBlockPartsForCatchupRetryIntervalArmsWhenPassEnds'
+// sibling optimization), and the next report of missing parts resumes
+// sending on the very same tick instead of after a fresh
+// catchupResendInterval, which this test pins.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupCompleteReportMidPassClosesIt() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	const numParts = 3
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*numParts), partSize)
+	suite.Require().Equal(uint32(numParts), partSet.Total(), "need a 3-part block for this test")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         partSet.BitArray().Not(), // peer has none: 3 missing
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	for i := uint32(0); i < partSet.Total(); i++ {
+		suite.blockStore.On("LoadBlockPart", int64(999), int(i)).Return(partSet.GetPart(int(i)))
+	}
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	tick := func() {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+
+	// Open a 3-send pass and spend one of them.
+	tick()
+	suite.Require().Equal(1, sends)
+
+	// The peer now reports a complete part set, without the height changing -
+	// a bit-array the peer fully controls over the wire.
+	suite.ps.PRS.ProposalBlockParts = partSet.BitArray() // every bit set: peer has them all
+	tick()
+	suite.Require().Equal(1, sends, "a complete report must not itself send")
+
+	// The peer reports one part missing again, immediately (same simulated
+	// instant - the clock has not advanced at all since the pass opened).
+	suite.ps.PRS.ProposalBlockParts = partSet.BitArray().Not()
+	tick()
+	suite.Require().Equal(1, sends,
+		"a pass closed by a complete report must honor the retry interval before sending again")
+
+	// Only once the interval has elapsed does a fresh pass open.
+	suite.clock.Advance(catchupResendInterval)
+	tick()
+	suite.Require().Equal(2, sends, "a fresh pass opens once the retry interval has elapsed")
+}
+
+// TestGossipBlockPartsForCatchupMismatchedHeaderEndsPass covers a pass that can
+// never produce a send. The peer supplies both the part-set header and the size
+// of the missing bit-array, and only their encoding is validated, so a pass
+// opened on a maximum-size array with a header matching no stored block would
+// otherwise charge a block-store read and an error log to every gossip tick for
+// the whole budget - and, its deadline having been armed when the pass opened,
+// reopen immediately afterwards.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupMismatchedHeaderEndsPass() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stored := types.NewPartSetFromData(tmrand.Bytes(100), 100)
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: stored.Header()}}
+
+	// Largest pass the peer can ask for: every bit of a maximum-length array
+	// reported missing, under a header no stored block can match.
+	bogus := types.NewPartSetFromData(tmrand.Bytes(100), 100)
+	suite.Require().False(bogus.Header().Equals(stored.Header()))
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         bits.NewBitArray(int(types.MaxBlockPartsCount)),
+		ProposalBlockPartSetHeader: bogus.Header(),
+	}
+
+	// The data channel has no expectations: a mismatched header must send nothing.
+	metaReads := 0
+	suite.blockStore.On("LoadBlockMeta", int64(999)).
+		Run(func(_ mock.Arguments) { metaReads++ }).
+		Return(&blockMeta)
+
+	for range 50 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(1, metaReads,
+		"a pass that cannot send must cost one attempt per interval, not one per tick")
+
+	suite.clock.Advance(catchupResendInterval)
+	for range 50 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(2, metaReads, "each elapsed interval allows exactly one further attempt")
+}
+
+// TestGossipBlockPartsForCatchupSendFailureEndsPass is a regression test for a
+// defect where syncProposalBlockPart unconditionally returned nil regardless of
+// the underlying send's real result, so sendCatchupBlockPart always reported
+// success: a send that never reached the peer was indistinguishable from one
+// that did, and the pass kept spending its budget one failed attempt per tick
+// instead of ending on the first one -- exactly the spin endCatchupPass exists
+// to prevent. Uses a multi-part block so the budget itself (rather than
+// endCatchupPass) is never the thing limiting attempts.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupSendFailureEndsPass() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*5), partSize)
+	suite.Require().Equal(uint32(5), partSet.Total(), "need multiple missing parts so the budget isn't the limiting factor")
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         partSet.BitArray().Not(), // peer has none
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	partReads := 0
+	suite.blockStore.On("LoadBlockPart", int64(999), mock.Anything).
+		Run(func(_ mock.Arguments) { partReads++ }).
+		Return(partSet.GetPart(0))
+
+	// Every send fails to reach the peer.
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).Return(fmt.Errorf("simulated send failure"))
+
+	for range 50 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(1, partReads,
+		"a send that never reaches the peer must end the pass on the first attempt, not spend the whole budget")
+
+	suite.clock.Advance(catchupResendInterval)
+	for range 50 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(2, partReads, "each elapsed interval allows exactly one further attempt")
+}
+
+// TestGossipBlockPartsForCatchupPanicEndsPass is a regression test for a
+// defect where a panic out of sendCatchupBlockPart's block-store reads left
+// the pass open. LoadBlockMeta and LoadBlockPart panic deliberately on a
+// decode or read failure (see internal/store/store.go), and
+// peerGossipWorker.runGossipHandler recovers that per gossip tick and keeps
+// ticking - GossipBlockPartsForCatchup's own endCatchupPass call used to run
+// only on a normal false return, which a panic's unwind skips entirely,
+// leaving the remaining budget spendable. A peer that can trigger the panic
+// (any store corruption or read failure at a height it names) would then get
+// a fresh attempt - and a fresh panic, and a fresh full-stack log - on every
+// tick for the rest of the pass instead of ending on the first one, same as
+// TestGossipBlockPartsForCatchupSendFailureEndsPass covers for a normal
+// failure. The test recovers the panic itself, standing in for
+// runGossipHandler; that recovery is not itself under test here.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupPanicEndsPass() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const partSize = uint32(100)
+	partSet := types.NewPartSetFromData(tmrand.Bytes(int(partSize)*5), partSize)
+	suite.Require().Equal(uint32(5), partSet.Total(), "need multiple missing parts so the budget isn't the limiting factor")
+
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         partSet.BitArray().Not(), // peer has none
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	metaReads := 0
+	suite.blockStore.On("LoadBlockMeta", int64(999)).
+		Run(func(_ mock.Arguments) {
+			metaReads++
+			panic("simulated block-store decode failure")
+		}).
+		Return((*types.BlockMeta)(nil))
+
+	tick := func() {
+		func() {
+			defer func() { _ = recover() }() // stands in for runGossipHandler's recover
+			suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+		}()
+	}
+
+	for range 50 {
+		tick()
+	}
+	suite.Require().Equal(1, metaReads,
+		"a panicking attempt must end the pass just like a normal failed one, not retry every tick for the rest of the budget")
+
+	suite.clock.Advance(catchupResendInterval)
+	for range 50 {
+		tick()
+	}
+	suite.Require().Equal(2, metaReads, "each elapsed interval allows exactly one further attempt")
+}
+
+// TestGossipBlockPartsForCatchupMalformedHeaderDoesNotFundSends pins the budget
+// to a pass that got as far as sending. A pass is deliberately not re-derived
+// from the peer's bit-array once open, so a budget opened against an unusable
+// header would otherwise stay spendable when the peer replaces its state, at the
+// same height, with the stored block's real header and a single missing part:
+// the whole inflated budget then lands as duplicate sends of that one part.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupMalformedHeaderDoesNotFundSends() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	partSet := types.NewPartSetFromData(tmrand.Bytes(100), 100)
+	suite.Require().Equal(uint32(1), partSet.Total())
+	blockMeta := types.BlockMeta{BlockID: types.BlockID{PartSetHeader: partSet.Header()}}
+
+	bogus := types.NewPartSetFromData(tmrand.Bytes(100), 100)
+	suite.Require().False(bogus.Header().Equals(partSet.Header()))
+
+	// Open the largest pass available, under a header that cannot match.
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         bits.NewBitArray(int(types.MaxBlockPartsCount)),
+		ProposalBlockPartSetHeader: bogus.Header(),
+	}
+
+	suite.blockStore.On("LoadBlockMeta", int64(999)).Return(&blockMeta)
+	suite.blockStore.On("LoadBlockPart", int64(999), 0).Return(partSet.GetPart(0))
+
+	sends := 0
+	suite.dataCh.On("Send", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env, ok := args.Get(1).(p2p.Envelope)
+			if !ok {
+				return
+			}
+			if _, ok := env.Message.(*tmcons.BlockPart); ok {
+				sends++
+			}
+		}).
+		Return(nil)
+
+	suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+
+	// Same height, now with the real header and one part outstanding.
+	suite.ps.PRS.ProposalBlockPartSetHeader = partSet.Header()
+	suite.ps.PRS.ProposalBlockParts = partSet.BitArray().Not()
+
+	for range 50 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(0, sends,
+		"a budget opened against an unusable header must not fund sends after the peer swaps it out")
+
+	// The next interval opens a fresh pass, budgeted on what the peer now reports.
+	suite.clock.Advance(catchupResendInterval)
+	for range 50 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.Require().Equal(1, sends, "the fresh pass is worth the single part the peer now reports missing")
+}
+
+// TestGossipBlockPartsForCatchupPeerHasEveryPart covers the peer reporting a
+// complete part set: there is nothing to send, and no pass may be opened.
+func (suite *GossiperSuiteTest) TestGossipBlockPartsForCatchupPeerHasEveryPart() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	partSet := types.NewPartSetFromData(tmrand.Bytes(100), 100)
+	suite.ps.PRS = cstypes.PeerRoundState{
+		Height:                     999,
+		Round:                      0,
+		ProposalBlockParts:         partSet.BitArray(), // peer has them all
+		ProposalBlockPartSetHeader: partSet.Header(),
+	}
+
+	// Neither the block store nor the data channel may be touched; the mocks are
+	// constructed with no expectations, so any call fails the test too.
+	for range 10 {
+		suite.gossiper.GossipBlockPartsForCatchup(ctx, cstypes.RoundState{}, suite.ps.GetRoundState())
+	}
+	suite.dataCh.AssertNotCalled(suite.T(), "Send", mock.Anything, mock.Anything)
 }
 
 func (suite *GossiperSuiteTest) TestGossipCommit() {

--- a/internal/consensus/msg_handlers.go
+++ b/internal/consensus/msg_handlers.go
@@ -37,6 +37,7 @@ func isPeerFloodableError(err error) bool {
 		errors.Is(err, ErrInvalidProposalSignature) ||
 		errors.Is(err, ErrInvalidProposalPOLRound) ||
 		errors.Is(err, ErrInvalidProposalCoreHeight) ||
+		errors.Is(err, ErrInvalidProposalBlockID) ||
 		errors.Is(err, ErrInvalidProposalForCommit) ||
 		errors.Is(err, ErrUnableToVerifyProposal) ||
 		errors.Is(err, ErrPeerStateInvalidVoteIndex) ||

--- a/internal/consensus/proposal_block_id_test.go
+++ b/internal/consensus/proposal_block_id_test.go
@@ -1,0 +1,143 @@
+package consensus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cstypes "github.com/dashpay/tenderdash/internal/consensus/types"
+	"github.com/dashpay/tenderdash/internal/test/factory"
+	tmbytes "github.com/dashpay/tenderdash/libs/bytes"
+	tmtime "github.com/dashpay/tenderdash/libs/time"
+	"github.com/dashpay/tenderdash/types"
+)
+
+// forgeField returns blockID with one byte of the named field flipped, leaving
+// every other field honest. That is the shape that matters: a BlockID whose Hash
+// and PartSetHeader are genuine passes every hash comparison on the way to a
+// signature, so only a comparison against the block itself can catch it.
+func forgeField(t *testing.T, blockID types.BlockID, field string) types.BlockID {
+	t.Helper()
+
+	forged := blockID
+	switch field {
+	case "state_id":
+		sid := make(tmbytes.HexBytes, len(blockID.StateID))
+		copy(sid, blockID.StateID)
+		require.NotEmpty(t, sid, "the block must have a StateID to forge")
+		sid[0] ^= 0xFF
+		forged.StateID = sid
+	case "hash":
+		h := make(tmbytes.HexBytes, len(blockID.Hash))
+		copy(h, blockID.Hash)
+		require.NotEmpty(t, h, "the block must have a Hash to forge")
+		h[0] ^= 0xFF
+		forged.Hash = h
+	default:
+		t.Fatalf("unknown field %q", field)
+	}
+	require.False(t, forged.Equals(blockID), "the forgery must actually differ")
+	return forged
+}
+
+// TestRoundStateBlockIDPrefersTheBlockItHolds pins which of the two answers
+// reaches a vote signature. A Proposal's BlockID is proposer-signed but describes
+// a block nobody had seen when it was signed; the block and its parts are the
+// block itself. Returning the claim lets a proposer put a value of its choosing
+// into every honest node's prevote, and a commit built from those votes names a
+// block that the next height's LastCommit can never match.
+func TestRoundStateBlockIDPrefersTheBlockItHolds(t *testing.T) {
+	block := &types.Block{
+		Header:     *factory.MakeHeader(t, &types.Header{Height: 10}),
+		LastCommit: &types.Commit{},
+	}
+	parts, err := block.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	honest := block.BlockID(parts)
+	require.NotEmpty(t, honest.StateID)
+
+	for _, field := range []string{"state_id", "hash"} {
+		t.Run("forged "+field, func(t *testing.T) {
+			forged := forgeField(t, honest, field)
+			rs := cstypes.RoundState{
+				Height:             10,
+				Round:              0,
+				Proposal:           types.NewProposal(10, 1, 0, -1, forged, tmtime.Now()),
+				ProposalBlock:      block,
+				ProposalBlockParts: parts,
+			}
+			assert.True(t, rs.BlockID().Equals(honest),
+				"the block ID that reaches a signature must describe the block we hold")
+			assert.False(t, rs.BlockID().Equals(forged),
+				"a proposer's claim must not reach a signature unchecked")
+		})
+	}
+
+	t.Run("honest proposal is unaffected", func(t *testing.T) {
+		rs := cstypes.RoundState{
+			Height:             10,
+			Round:              0,
+			Proposal:           types.NewProposal(10, 1, 0, -1, honest, tmtime.Now()),
+			ProposalBlock:      block,
+			ProposalBlockParts: parts,
+		}
+		assert.True(t, rs.BlockID().Equals(honest))
+	})
+
+	t.Run("no block held falls back to the proposal", func(t *testing.T) {
+		rs := cstypes.RoundState{
+			Height:   10,
+			Round:    0,
+			Proposal: types.NewProposal(10, 1, 0, -1, honest, tmtime.Now()),
+		}
+		assert.True(t, rs.BlockID().Equals(honest),
+			"with no block to derive from, the proposal is all there is")
+	})
+}
+
+// TestCompletedBlockDropsAProposalThatMisdescribesIt covers the other half: the
+// round state must not go on holding a Proposal whose BlockID the assembled block
+// contradicts. Dropping it leaves isProposalComplete false, so the round prevotes
+// nil on timeoutPropose rather than voting for a block ID nothing verified.
+func TestCompletedBlockDropsAProposalThatMisdescribesIt(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	config := configSetup(t)
+
+	cs, vss := makeState(ctx, t, makeStateArgs{config: config, validators: 4})
+	stateData := cs.GetStateData()
+	height, round := stateData.Height, stateData.Round
+
+	proposal, block := decideProposal(ctx, t, cs, vss[0], height, round)
+	parts, err := block.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	honest := block.BlockID(parts)
+	require.True(t, proposal.BlockID.Equals(honest),
+		"an honest proposer derives the block ID from the block and its parts")
+
+	proposal.BlockID = forgeField(t, honest, "state_id")
+
+	stateData = cs.GetStateData()
+	stateData.Proposal = proposal
+	stateData.ProposalReceiveTime = tmtime.Now()
+	stateData.ProposalBlockParts = types.NewPartSetFromHeader(honest.PartSetHeader)
+	require.NoError(t, stateData.Save())
+
+	for i := 0; i < int(parts.Total()); i++ {
+		msg := &BlockPartMessage{Height: height, Round: round, Part: parts.GetPart(i)}
+		partCtx := msgInfoWithCtx(ctx, msgInfo{Msg: msg, PeerID: "peerX"})
+		require.NoError(t,
+			cs.ctrl.Dispatch(partCtx, &AddProposalBlockPartEvent{Msg: msg, PeerID: "peerX"}, &stateData),
+			"the block itself is valid and must still be collected: part %d", i)
+	}
+
+	require.NotNil(t, stateData.ProposalBlock, "the block is the bytes; it is kept")
+	assert.Nil(t, stateData.Proposal,
+		"a proposal whose block ID the assembled block contradicts must not survive")
+	assert.True(t, stateData.ProposalReceiveTime.IsZero(),
+		"the receive time goes with the proposal it measures")
+	assert.False(t, stateData.isProposalComplete(),
+		"without a proposal the round prevotes nil rather than a block ID nothing verified")
+}

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -559,16 +559,24 @@ func TestReactorValidatorSetChanges(t *testing.T) {
 		{height: 10, count: 2, operation: addValsOp},
 		{height: 17, count: 2, operation: removeValsOp},
 	}
+	// The network needs a real timeout ticker: it recovers from a missing or late
+	// proposal only through the timeoutPropose / timeoutPrecommitWait round change,
+	// and mockTicker discards every timeout but the first.
 	gen := consensusNetGen{
 		cfg:              cfg,
 		nPeers:           nPeers,
 		nVals:            nVals,
 		appFunc:          newKVStoreFunc(t),
-		tickerFun:        newMockTickerFunc(true),
+		tickerFun:        newTickerFunc(),
 		validatorUpdates: updates,
 		consensusParams: factory.ConsensusParams(func(cp *types.ConsensusParams) {
-			cp.Timeout.Propose = 2 * time.Second
-			cp.Timeout.Vote = 1 * time.Second
+			// Seven nodes gossiping in one process under the race detector need far
+			// more wall clock per round than production does. These timeouts only
+			// fire when the network stalls; tighter ones make a loaded runner
+			// abandon rounds it would have completed, so it churns instead of
+			// converging.
+			cp.Timeout.Propose = 5 * time.Second
+			cp.Timeout.Vote = 2 * time.Second
 		}),
 	}
 	states, genDoc, _, validatorSetUpdates := gen.generate(ctx, t)

--- a/internal/consensus/stale_proposal_gate_test.go
+++ b/internal/consensus/stale_proposal_gate_test.go
@@ -1,0 +1,147 @@
+package consensus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tmtime "github.com/dashpay/tenderdash/libs/time"
+	"github.com/dashpay/tenderdash/types"
+)
+
+// rebuildWithCoreChainLockedHeight returns a block that differs from src only in
+// its core chain locked height. It round-trips through proto rather than copying
+// the struct, because types.Block carries a mutex.
+func rebuildWithCoreChainLockedHeight(t *testing.T, src *types.Block, height uint32) *types.Block {
+	t.Helper()
+
+	pb, err := src.ToProto()
+	require.NoError(t, err)
+	pb.Header.CoreChainLockedHeight = height
+
+	block, err := types.BlockFromProto(pb)
+	require.NoError(t, err)
+	require.NoError(t, block.ValidateBasic())
+	return block
+}
+
+// TestCompletingPartSetIsNotJudgedAgainstAnotherBlocksProposal covers the case a
+// proposal left over from an earlier round creates: the round collects parts for
+// one block while still holding a proposal that describes a different one.
+//
+// The core chain locked height comparison used to run whenever any proposal was
+// present, so the completing part was judged against a proposal that says nothing
+// about the block being assembled. The part is consumed by AddPart before that
+// judgement is reached, and PartSet.AddPart returns (false, nil) for a part it
+// already holds (types/part_set.go), so the completion branch is never re-entered
+// and the block cannot be assembled again by any route.
+func TestCompletingPartSetIsNotJudgedAgainstAnotherBlocksProposal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	config := configSetup(t)
+
+	cs, vss := makeState(ctx, t, makeStateArgs{config: config, validators: 4})
+	stateData := cs.GetStateData()
+	height, round := stateData.Height, stateData.Round
+
+	staleProposal, staleBlock := decideProposal(ctx, t, cs, vss[0], height, round)
+
+	// The block the round is actually collecting: same in every respect except
+	// the field the stale proposal is about to be compared against.
+	collected := rebuildWithCoreChainLockedHeight(t, staleBlock, staleBlock.CoreChainLockedHeight+1)
+	parts, err := collected.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+
+	require.NotEqual(t, staleProposal.CoreChainLockedHeight, collected.CoreChainLockedHeight,
+		"fixture: the stale proposal must disagree, or the old code would accept the block anyway")
+	require.False(t, parts.HasHeader(staleProposal.BlockID.PartSetHeader),
+		"fixture: the proposal must describe other bytes, or this cannot tell the gate from its absence")
+
+	// These two blocks differ only in their core chain locked height, and that
+	// field reaches Header.Hash() through cdcEncode, which has no uint32 case and
+	// returns an empty leaf for every value. So they share a block hash: a hash
+	// comparison cannot separate them, and the part set header -- a root over the
+	// serialized block -- is what the gate has to ask.
+
+	stateData = cs.GetStateData()
+	stateData.Proposal = staleProposal
+	stateData.ProposalReceiveTime = tmtime.Now()
+	stateData.ProposalBlockParts = types.NewPartSetFromHeader(parts.Header())
+	require.NoError(t, stateData.Save())
+
+	for i := 0; i < int(parts.Total()); i++ {
+		msg := &BlockPartMessage{Height: height, Round: round, Part: parts.GetPart(i)}
+		partCtx := msgInfoWithCtx(ctx, msgInfo{Msg: msg, PeerID: "peerX"})
+		require.NoError(t,
+			cs.ctrl.Dispatch(partCtx, &AddProposalBlockPartEvent{Msg: msg, PeerID: "peerX"}, &stateData),
+			"a part of the block being collected must be accepted: part %d", i)
+	}
+
+	require.NotNil(t, stateData.ProposalBlock,
+		"the assembled block must be kept: the completing part is spent and cannot be replayed")
+	assert.True(t, stateData.ProposalBlock.HashesTo(collected.Hash()),
+		"the block kept must be the one the parts carried")
+	assert.Nil(t, stateData.Proposal,
+		"a proposal describing a different block must not survive the block that contradicts it")
+}
+
+// TestProposalDisagreeingAboutChainLockDoesNotCostTheBlock covers a proposal
+// that names the block being assembled but disagrees with it about the core
+// chain locked height.
+//
+// Two very different things produce that: a proposer that built the proposal
+// wrongly, and any peer that raised the field while relaying, since
+// CanonicalizeProposal omits the dash fields from what the proposer signs and
+// state_proposaler.go enforces only a lower bound. This code cannot tell them
+// apart and deliberately does not try -- one arrangement covers both because
+// the handling does not depend on the cause. That is the property being bought:
+// the outcome is safe without the diagnosis being complete.
+//
+// The block survives either way. It is authenticated by the part set header,
+// the completing part is spent by the time the comparison runs, and dropping
+// the proposal is what lets an honest copy be accepted afterwards.
+func TestProposalDisagreeingAboutChainLockDoesNotCostTheBlock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	config := configSetup(t)
+
+	cs, vss := makeState(ctx, t, makeStateArgs{config: config, validators: 4})
+	stateData := cs.GetStateData()
+	height, round := stateData.Height, stateData.Round
+
+	proposal, block := decideProposal(ctx, t, cs, vss[0], height, round)
+	parts, err := block.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+
+	require.True(t, parts.HasHeader(proposal.BlockID.PartSetHeader),
+		"fixture: the proposal must describe these bytes, or this repeats the staleness case")
+
+	proposal.CoreChainLockedHeight = block.CoreChainLockedHeight + 1
+
+	stateData = cs.GetStateData()
+	stateData.Proposal = proposal
+	stateData.ProposalReceiveTime = tmtime.Now()
+	stateData.ProposalBlockParts = types.NewPartSetFromHeader(parts.Header())
+	require.NoError(t, stateData.Save())
+
+	for i := 0; i < int(parts.Total()); i++ {
+		msg := &BlockPartMessage{Height: height, Round: round, Part: parts.GetPart(i)}
+		partCtx := msgInfoWithCtx(ctx, msgInfo{Msg: msg, PeerID: "peerX"})
+		require.NoError(t,
+			cs.ctrl.Dispatch(partCtx, &AddProposalBlockPartEvent{Msg: msg, PeerID: "peerX"}, &stateData),
+			"a disagreeing proposal must not cost the round the block: part %d", i)
+	}
+
+	require.NotNil(t, stateData.ProposalBlock,
+		"the block is authenticated by the part set header and must be kept")
+	assert.True(t, stateData.ProposalBlock.HashesTo(block.Hash()),
+		"the block kept must be the one the parts carried")
+	assert.Nil(t, stateData.Proposal,
+		"the proposal must be cleared, which is what lets an honest copy be accepted")
+	assert.True(t, stateData.ProposalReceiveTime.IsZero(),
+		"the receive time goes with the proposal it measures")
+	assert.False(t, stateData.isProposalComplete(),
+		"the round prevotes nil and advances rather than stalling on a spent part set")
+}

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -37,6 +37,7 @@ const (
 var (
 	ErrInvalidProposalNotSet     = errors.New("error invalid proposal not set")
 	ErrInvalidProposalForCommit  = errors.New("error invalid proposal for commit")
+	ErrInvalidProposalBlockID    = errors.New("proposal block ID does not describe the assembled block")
 	ErrUnableToVerifyProposal    = errors.New("error unable to verify proposal")
 	ErrInvalidProposalSignature  = errors.New("error invalid proposal signature")
 	ErrInvalidProposalCoreHeight = errors.New("error invalid proposal core height")

--- a/internal/consensus/state_add_commit.go
+++ b/internal/consensus/state_add_commit.go
@@ -40,7 +40,9 @@ func (c *AddCommitAction) Execute(ctx context.Context, stateEvent StateEvent) er
 	c.eventPublisher.PublishNewRoundStepEvent(stateData.RoundState)
 
 	// The commit is all good, let's apply it to the state
-	_ = stateEvent.Ctrl.Dispatch(ctx, &ApplyCommitEvent{Commit: commit}, stateData)
+	if err := stateEvent.Ctrl.Dispatch(ctx, &ApplyCommitEvent{Commit: commit}, stateData); err != nil {
+		return err
+	}
 
 	// This will relay the commit to peers
 	err = c.eventPublisher.PublishCommitEvent(commit)

--- a/internal/consensus/state_add_prop_block.go
+++ b/internal/consensus/state_add_prop_block.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/cosmos/gogoproto/proto"
 
@@ -176,6 +177,27 @@ func (c *AddProposalBlockPartAction) addProposalBlockPart(
 			block.Header.CoreChainLockedHeight != stateData.RoundState.Proposal.CoreChainLockedHeight {
 			return added, fmt.Errorf("core chain lock height of block %d does not match proposal %d",
 				block.Header.CoreChainLockedHeight, stateData.RoundState.Proposal.CoreChainLockedHeight)
+		}
+
+		// A Proposal carries a BlockID the proposer signed before anyone had seen
+		// the block. Now that the block is assembled the claim is checkable, and a
+		// proposer that builds one honestly derives it from exactly these bytes and
+		// these parts, so any difference is a signed statement about a block this
+		// is not. The block is kept -- it is the bytes, and they are what they are;
+		// the Proposal is discarded, so nothing downstream signs its BlockID.
+		if proposal := stateData.Proposal; proposal != nil {
+			if derived := block.BlockID(stateData.ProposalBlockParts); !derived.Equals(proposal.BlockID) {
+				c.logger.Error("proposal block ID does not describe the proposed block; dropping the proposal",
+					"height", stateData.Height,
+					"round", stateData.Round,
+					"proposer_pro_tx_hash", stateData.Validators.Proposer().ProTxHash.ShortString(),
+					"proposal_block_id", proposal.BlockID,
+					"block_id", derived,
+					"peer", peerID,
+				)
+				stateData.Proposal = nil
+				stateData.ProposalReceiveTime = time.Time{}
+			}
 		}
 
 		stateData.ProposalBlock = block

--- a/internal/consensus/state_add_prop_block.go
+++ b/internal/consensus/state_add_prop_block.go
@@ -173,10 +173,25 @@ func (c *AddProposalBlockPartAction) addProposalBlockPart(
 			return added, err
 		}
 
-		if stateData.RoundState.Proposal != nil &&
-			block.Header.CoreChainLockedHeight != stateData.RoundState.Proposal.CoreChainLockedHeight {
-			return added, fmt.Errorf("core chain lock height of block %d does not match proposal %d",
-				block.Header.CoreChainLockedHeight, stateData.RoundState.Proposal.CoreChainLockedHeight)
+		// Dropping the proposal, rather than rejecting the block, is what keeps this
+		// recoverable: the completing part is already spent -- AddPart returns
+		// (false, nil) for one it holds -- and Proposaler.Set refuses a second
+		// proposal while one is held, so only clearing it lets the honest copy land.
+		// HasHeader selects the diagnosis, not the outcome: a proposal about other
+		// bytes is reported by the block ID check below, so reaching this message
+		// means a genuine chain lock disagreement.
+		if proposal := stateData.Proposal; proposal != nil &&
+			stateData.ProposalBlockParts.HasHeader(proposal.BlockID.PartSetHeader) &&
+			block.CoreChainLockedHeight != proposal.CoreChainLockedHeight {
+			c.logger.Error("proposal disagrees with the block it names about the core chain locked height; dropping the proposal",
+				"height", stateData.Height,
+				"round", stateData.Round,
+				"block_core_chain_locked_height", block.CoreChainLockedHeight,
+				"proposal_core_chain_locked_height", proposal.CoreChainLockedHeight,
+				"peer", peerID,
+			)
+			stateData.Proposal = nil
+			stateData.ProposalReceiveTime = time.Time{}
 		}
 
 		// A Proposal carries a BlockID the proposer signed before anyone had seen

--- a/internal/consensus/state_apply_commit.go
+++ b/internal/consensus/state_apply_commit.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	sm "github.com/dashpay/tenderdash/internal/state"
@@ -45,6 +46,17 @@ func (c *ApplyCommitAction) Execute(ctx context.Context, stateEvent StateEvent) 
 	c.logger.Info("applying commit", "commit", commit, "height", height, "round", round)
 
 	block, blockParts := stateData.ProposalBlock, stateData.ProposalBlockParts
+
+	// Parked commits and locally assembled commits bypass TryAddCommit's block check.
+	if commit != nil {
+		ready, err := verifyCommitBlock(ctx, c.logger, stateData, commit)
+		if err != nil {
+			return err
+		}
+		if !ready {
+			return errors.New("cannot apply commit without its proposal block")
+		}
+	}
 
 	c.blockExec.mustEnsureProcess(ctx, &stateData.RoundState, round)
 	c.blockExec.mustValidate(ctx, stateData)

--- a/internal/consensus/state_proposaler.go
+++ b/internal/consensus/state_proposaler.go
@@ -73,6 +73,16 @@ func (p *Proposaler) Set(
 		return ErrInvalidProposalCoreHeight
 	}
 
+	// Parts may finish before a replacement proposal arrives.
+	if rs.ProposalBlock != nil && rs.ProposalBlockParts != nil {
+		if !rs.ProposalBlock.BlockID(rs.ProposalBlockParts).Equals(proposal.BlockID) {
+			return ErrInvalidProposalBlockID
+		}
+		if rs.ProposalBlock.CoreChainLockedHeight != proposal.CoreChainLockedHeight {
+			return ErrInvalidProposalCoreHeight
+		}
+	}
+
 	err := p.verifyProposal(ctx, proposal, rs)
 	if err != nil {
 		return err

--- a/internal/consensus/state_proposaler_test.go
+++ b/internal/consensus/state_proposaler_test.go
@@ -111,6 +111,43 @@ func (suite *ProposalerTestSuite) TearDownTest() {
 	suite.msgInfoQueue.stop()
 }
 
+func (suite *ProposalerTestSuite) TestSetChecksAlreadyAssembledBlock() {
+	ctx := context.Background()
+	block := suite.blockH100R0
+	parts, err := block.MakePartSet(types.BlockPartSizeBytes)
+	suite.Require().NoError(err)
+	for _, field := range []string{"state_id", "hash", "part_set", "core_height"} {
+		suite.Run(field, func() {
+			proposal := makeProposal(block.Height, 0, -1, block, parts)
+			switch field {
+			case "state_id", "hash":
+				proposal.BlockID = forgeField(suite.T(), proposal.BlockID, field)
+			case "part_set":
+				proposal.BlockID.PartSetHeader.Total++
+			case "core_height":
+				proposal.CoreChainLockedHeight++
+			}
+			suite.signProposal(ctx, proposal)
+			rs := cstypes.RoundState{
+				Height:             block.Height,
+				Round:              0,
+				Validators:         suite.mockValSet,
+				ProposerSelector:   suite.proposerSelector,
+				ProposalBlock:      block,
+				ProposalBlockParts: parts,
+			}
+			suite.Require().Error(suite.proposer.Set(ctx, proposal, block.Time, &rs))
+			suite.Require().Nil(rs.Proposal, "a late proposal must pass the same checks as an early one")
+			suite.Require().True(rs.ProposalReceiveTime.IsZero())
+			suite.Require().Same(block, rs.ProposalBlock)
+			honest := makeProposal(block.Height, 0, -1, block, parts)
+			suite.signProposal(ctx, honest)
+			suite.Require().NoError(suite.proposer.Set(ctx, honest, block.Time, &rs))
+			suite.Require().Same(honest, rs.Proposal, "rejection must leave room for the matching proposal")
+		})
+	}
+}
+
 func (suite *ProposalerTestSuite) TestSet() {
 	ctx := context.Background()
 	blockID := suite.blockH100R0.BlockID(nil)

--- a/internal/consensus/state_try_add_commit.go
+++ b/internal/consensus/state_try_add_commit.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -125,19 +126,18 @@ func (cs *TryAddCommitAction) handleCommitVerifyError(err error, peerID types.No
 	}
 }
 
-func (cs *TryAddCommitAction) verifyCommit(ctx context.Context, stateData *StateData, commit *types.Commit, peerID types.NodeID, ignoreProposalBlock bool) (verified bool, err error) {
-	verified, err = stateData.verifyCommit(
-		commit,
-		peerID,
-		ignoreProposalBlock,
-		verificationBudgetFromCtx(ctx),
-	)
-	if !verified || err != nil {
-		return verified, err
-	}
-	if ignoreProposalBlock {
-		return true, nil
-	}
+// verifyCommitBlock checks that commit.BlockID describes the block this round
+// holds. A BlockID has three fields and each is asked separately, so an operator
+// is told which one disagreed; a single combined comparison would report only
+// that something did.
+//
+// A false return with a nil error means the block has not arrived yet, which is
+// the ordinary case for a commit that overtook it.
+func (cs *TryAddCommitAction) verifyCommitBlock(
+	ctx context.Context,
+	stateData *StateData,
+	commit *types.Commit,
+) (bool, error) {
 	block, blockParts := stateData.ProposalBlock, stateData.ProposalBlockParts
 	if block == nil {
 		return false, nil
@@ -155,6 +155,39 @@ func (cs *TryAddCommitAction) verifyCommit(ctx context.Context, stateData *State
 			"complete_proposal", stateData.isProposalComplete(),
 		)
 		return false, fmt.Errorf("cannot finalize commit; proposal block does not hash to commit hash")
+	}
+	// The third field, and the only one nothing else here would notice. A commit
+	// agreeing on hash and part set header while naming a different state ID is
+	// applied against this block and then recorded carrying its own BlockID. The
+	// next height compares that record against the state this block produced;
+	// they disagree, and no proposer at any round can satisfy both.
+	if !bytes.Equal(block.StateID().Hash(), commit.BlockID.StateID) {
+		cs.logger.Error("commit state ID does not match the block it commits",
+			"height", commit.Height,
+			"node_proTxHash", proTxHash.ShortString(),
+			"block_state_id", block.StateID().Hash(),
+			"commit_state_id", commit.BlockID.StateID,
+		)
+		return false, fmt.Errorf("cannot finalize commit; proposal block state ID does not match commit state ID")
+	}
+	return true, nil
+}
+
+func (cs *TryAddCommitAction) verifyCommit(ctx context.Context, stateData *StateData, commit *types.Commit, peerID types.NodeID, ignoreProposalBlock bool) (verified bool, err error) {
+	verified, err = stateData.verifyCommit(
+		commit,
+		peerID,
+		ignoreProposalBlock,
+		verificationBudgetFromCtx(ctx),
+	)
+	if !verified || err != nil {
+		return verified, err
+	}
+	if ignoreProposalBlock {
+		return true, nil
+	}
+	if verified, err := cs.verifyCommitBlock(ctx, stateData, commit); !verified || err != nil {
+		return verified, err
 	}
 	// We have a correct block, let's process it before applying the commit
 	err = cs.blockExec.ensureProcess(ctx, &stateData.RoundState, commit.Round)

--- a/internal/consensus/state_try_add_commit.go
+++ b/internal/consensus/state_try_add_commit.go
@@ -133,8 +133,9 @@ func (cs *TryAddCommitAction) handleCommitVerifyError(err error, peerID types.No
 //
 // A false return with a nil error means the block has not arrived yet, which is
 // the ordinary case for a commit that overtook it.
-func (cs *TryAddCommitAction) verifyCommitBlock(
+func verifyCommitBlock(
 	ctx context.Context,
+	logger log.Logger,
 	stateData *StateData,
 	commit *types.Commit,
 ) (bool, error) {
@@ -147,7 +148,7 @@ func (cs *TryAddCommitAction) verifyCommitBlock(
 	}
 	proTxHash := dash.MustProTxHashFromContext(ctx)
 	if !block.HashesTo(commit.BlockID.Hash) {
-		cs.logger.Error("proposal block does not hash to commit hash",
+		logger.Error("proposal block does not hash to commit hash",
 			"height", commit.Height,
 			"node_proTxHash", proTxHash.ShortString(),
 			"block", block,
@@ -162,7 +163,7 @@ func (cs *TryAddCommitAction) verifyCommitBlock(
 	// next height compares that record against the state this block produced;
 	// they disagree, and no proposer at any round can satisfy both.
 	if !bytes.Equal(block.StateID().Hash(), commit.BlockID.StateID) {
-		cs.logger.Error("commit state ID does not match the block it commits",
+		logger.Error("commit state ID does not match the block it commits",
 			"height", commit.Height,
 			"node_proTxHash", proTxHash.ShortString(),
 			"block_state_id", block.StateID().Hash(),
@@ -186,7 +187,7 @@ func (cs *TryAddCommitAction) verifyCommit(ctx context.Context, stateData *State
 	if ignoreProposalBlock {
 		return true, nil
 	}
-	if verified, err := cs.verifyCommitBlock(ctx, stateData, commit); !verified || err != nil {
+	if verified, err := verifyCommitBlock(ctx, cs.logger, stateData, commit); !verified || err != nil {
 		return verified, err
 	}
 	// We have a correct block, let's process it before applying the commit

--- a/internal/consensus/types/round_state.go
+++ b/internal/consensus/types/round_state.go
@@ -172,9 +172,18 @@ func (rs *RoundState) NewRoundEvent() types.EventDataNewRound {
 	}
 }
 
-// BlockID returns block ID from proposal or constructs new block ID from ProposalBlock and ProposalBlockParts.
-// cs.Proposal is not guaranteed to be set when this function is called
+// BlockID returns the block ID this round state stands behind.
+//
+// A Proposal's BlockID is the proposer's claim about a block; the block and the
+// parts it was assembled from are the block itself. When both are available the
+// derived value is returned, because this BlockID reaches a vote signature and a
+// claim must not. The Proposal is used only when there is no block to derive
+// from, and cs.Proposal is not guaranteed to be set at all.
 func (rs *RoundState) BlockID() types.BlockID {
+	if rs.ProposalBlock != nil && rs.ProposalBlockParts != nil {
+		return rs.ProposalBlock.BlockID(rs.ProposalBlockParts)
+	}
+
 	if rs.Proposal != nil && rs.Height == rs.Proposal.Height && rs.Round == rs.Proposal.Round {
 		return rs.Proposal.BlockID
 	}

--- a/internal/p2p/conn_tracker_test.go
+++ b/internal/p2p/conn_tracker_test.go
@@ -14,6 +14,12 @@ func randByte() byte {
 	return byte(rand.Intn(math.MaxUint8))
 }
 
+// randLocalIPv4 returns a random 127.0.0.0/8 address. Its three random octets
+// span only 255^3 addresses, so a loop drawing many of them collides at a rate
+// that matters: 100 draws collide once in ~3400 runs. connTrackerImpl keys its
+// cache by address, so a collision silently costs an entry and fails a Len()
+// assertion. Use it only where a single address is needed; loops that need
+// distinct addresses must use seqIPv4.
 func randLocalIPv4() net.IP {
 	return net.IPv4(127, randByte(), randByte(), randByte())
 }
@@ -50,14 +56,14 @@ func TestConnTracker(t *testing.T) {
 			t.Run("AddingMany", func(t *testing.T) {
 				ct := factory()
 				for i := 0; i < 100; i++ {
-					_ = ct.AddConn(randLocalIPv4())
+					_ = ct.AddConn(seqIPv4(i))
 				}
 				require.Equal(t, 100, ct.Len())
 			})
 			t.Run("Cycle", func(t *testing.T) {
 				ct := factory()
 				for i := 0; i < 100; i++ {
-					ip := randLocalIPv4()
+					ip := seqIPv4(i)
 					require.NoError(t, ct.AddConn(ip))
 					ct.RemoveConn(ip)
 				}
@@ -68,7 +74,7 @@ func TestConnTracker(t *testing.T) {
 	t.Run("VeryShort", func(t *testing.T) {
 		ct := newConnTracker(10, time.Microsecond)
 		for i := 0; i < 10; i++ {
-			ip := randLocalIPv4()
+			ip := seqIPv4(i)
 			require.NoError(t, ct.AddConn(ip))
 			time.Sleep(2 * time.Microsecond)
 			require.NoError(t, ct.AddConn(ip))


### PR DESCRIPTION
## Issue being fixed or feature implemented

Catch-up peers need bounded block-part retries, and consensus must check that proposals and commits describe the block being processed. A disagreeing proposal must leave the downloaded block available for recovery.

## What was done?

- Bound catch-up block-part resends with a 500 ms gap between passes. Failed attempts end the pass; advancing peers can start promptly after a completed pass. Commit gossip continues during the gap.
- Restore real round timeouts in the validator-set-change reactor test.
- Derive voting block IDs from the assembled block and check proposal block IDs and core-chain-locked heights, including proposals arriving after assembly. Drop disagreeing proposals while retaining the block, allowing a matching replacement.
- Check all three block ID fields before applying a commit, including commits received before their blocks and commits assembled from local votes. Propagate rejection before broadcasting a commit or advancing the round.
- Use distinct deterministic addresses in connection-tracker test loops.

The catch-up and initial block ID changes are ported from #1418 and #1435. This PR targets `v1.7-dev`; it does not update `v1.8-dev`.

## How Has This Been Tested?

- Consensus packages and configuration tests with CGO/BLS and the `deadlock` build tag.
- Focused race tests for gossip, proposal admission, commit validation, and connection tracking.
- Regression tests confirmed failing before fixes for commit-first StateID validation and late proposal consistency, with matching-input recovery controls.
- `gofmt`, whitespace checks, and golangci-lint 2.13.2 built with Go 1.27.1 against the PR base.

CI status is excluded from this review loop. Live deployment and WAL restart replay were not independently exercised.

## Breaking Changes

No wire-format, hashing, dependency, or configuration-key changes. Inconsistent proposal metadata and commit block IDs are rejected.

Existing partial block-hash comparisons elsewhere and changes to which header fields are hashed are outside this patch. A discarded proposal loses its receive timestamp, so delayed replacement can still cost a round.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
