### PR TITLE
fix(consensus): apply late commits for completed blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+- Apply valid late commits when the complete block is retained after rejecting conflicting proposal metadata.
 - Check complete block IDs before applying commits and validate proposals arriving after their blocks (#1439).
 
 ## [1.7.0] - 2026-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-- Apply valid late commits when the complete block is retained after rejecting conflicting proposal metadata.
+- Apply valid late commits when the complete block is retained after rejecting conflicting proposal metadata, and fetch the committed block if it differs from the retained one.
 - Check complete block IDs before applying commits and validate proposals arriving after their blocks (#1439).
 
 ## [1.7.0] - 2026-08-17

--- a/internal/consensus/late_commit_test.go
+++ b/internal/consensus/late_commit_test.go
@@ -24,12 +24,17 @@ func TestCommitAfterDroppedProposalAppliesCompleteBlock(t *testing.T) {
 		localRound      int32
 		step            cstypes.RoundStepType
 		stateIDMismatch bool
+		differentBlock  bool
 		invalidCommit   string
 	}{
 		{name: "commit before block control", commitFirst: true, step: cstypes.RoundStepPrevote},
 		{name: "block before current round commit", step: cstypes.RoundStepPrevote},
 		{name: "block before commit during propose", step: cstypes.RoundStepPropose},
 		{name: "block before earlier round commit", localRound: 1, step: cstypes.RoundStepPrevote},
+		{name: "different block before current round commit", differentBlock: true, step: cstypes.RoundStepPrevote},
+		{name: "different block before earlier round commit", differentBlock: true, localRound: 1, step: cstypes.RoundStepPrevote},
+		{name: "different block before commit during propose", differentBlock: true, step: cstypes.RoundStepPropose},
+		{name: "different block with invalid commit signature", differentBlock: true, invalidCommit: "signature", step: cstypes.RoundStepPrevote},
 		{name: "state ID mismatch before current round commit", stateIDMismatch: true, step: cstypes.RoundStepPrevote},
 		{name: "state ID mismatch before earlier round commit", localRound: 1, stateIDMismatch: true, step: cstypes.RoundStepPrevote},
 		{name: "invalid commit signature", invalidCommit: "signature", step: cstypes.RoundStepPrevote},
@@ -48,9 +53,22 @@ func TestCommitAfterDroppedProposalAppliesCompleteBlock(t *testing.T) {
 			block, err := sf.MakeBlock(source.state, 1, &types.Commit{}, kvstore.ProtocolVersion)
 			require.NoError(t, err)
 			block.CoreChainLockedHeight = 1
+			if tc.differentBlock {
+				block.CoreChainLockedHeight = 2
+			}
 			parts, err := block.MakePartSet(types.BlockPartSizeBytes)
 			require.NoError(t, err)
-			commitBlockID := block.BlockID(parts)
+			committedParts := parts
+			committedBlock := block
+			if tc.differentBlock {
+				committedBlock, err = sf.MakeBlock(source.state, 1, &types.Commit{}, kvstore.ProtocolVersion)
+				require.NoError(t, err)
+				committedBlock.CoreChainLockedHeight = 1
+				committedParts, err = committedBlock.MakePartSet(types.BlockPartSizeBytes)
+				require.NoError(t, err)
+				require.False(t, parts.HasHeader(committedParts.Header()))
+			}
+			commitBlockID := committedBlock.BlockID(committedParts)
 			switch tc.invalidCommit {
 			case "hash", "state_id":
 				commitBlockID = forgeField(t, commitBlockID, tc.invalidCommit)
@@ -110,12 +128,28 @@ func TestCommitAfterDroppedProposalAppliesCompleteBlock(t *testing.T) {
 				if tc.invalidCommit != "" {
 					deliver(&CommitMessage{Commit: commit})
 					assert.Equal(t, block.Height, stateData.Height)
+					if tc.invalidCommit == "parts" {
+						// An authenticated unknown part set selects a download, not the retained block.
+						assert.Equal(t, commit, stateData.Commit)
+						assert.False(t, stateData.ProposalBlockParts.IsComplete())
+						assert.True(t, stateData.ProposalBlockParts.HasHeader(commit.BlockID.PartSetHeader))
+						return
+					}
 					assert.Nil(t, stateData.Commit)
 					assert.True(t, stateData.ProposalBlockParts.IsComplete())
 					assert.True(t, stateData.ProposalBlockParts.HasHeader(parts.Header()))
 					return
 				}
 				deliver(&CommitMessage{Commit: commit})
+				if tc.differentBlock {
+					require.Equal(t, block.Height, stateData.Height, "the retained block must not be applied")
+					require.Equal(t, commit, stateData.Commit)
+					require.False(t, stateData.ProposalBlockParts.IsComplete())
+					require.True(t, stateData.ProposalBlockParts.HasHeader(committedParts.Header()))
+					for i := 0; i < int(committedParts.Total()); i++ {
+						deliver(&BlockPartMessage{Height: block.Height, Round: tc.localRound, Part: committedParts.GetPart(i)})
+					}
+				}
 			}
 			assert.Equal(t, block.Height+1, stateData.Height,
 				"the valid committed block must be applied regardless of arrival order")

--- a/internal/consensus/late_commit_test.go
+++ b/internal/consensus/late_commit_test.go
@@ -1,0 +1,125 @@
+package consensus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dashpay/tenderdash/abci/example/kvstore"
+	"github.com/dashpay/tenderdash/dash"
+	cstypes "github.com/dashpay/tenderdash/internal/consensus/types"
+	sf "github.com/dashpay/tenderdash/internal/state/test/factory"
+	"github.com/dashpay/tenderdash/internal/test/factory"
+	tmtime "github.com/dashpay/tenderdash/libs/time"
+	"github.com/dashpay/tenderdash/types"
+)
+
+func TestCommitAfterDroppedProposalAppliesCompleteBlock(t *testing.T) {
+	chainID := t.Name()
+	for _, tc := range []struct {
+		name            string
+		commitFirst     bool
+		localRound      int32
+		step            cstypes.RoundStepType
+		stateIDMismatch bool
+		invalidCommit   string
+	}{
+		{name: "commit before block control", commitFirst: true, step: cstypes.RoundStepPrevote},
+		{name: "block before current round commit", step: cstypes.RoundStepPrevote},
+		{name: "block before commit during propose", step: cstypes.RoundStepPropose},
+		{name: "block before earlier round commit", localRound: 1, step: cstypes.RoundStepPrevote},
+		{name: "state ID mismatch before current round commit", stateIDMismatch: true, step: cstypes.RoundStepPrevote},
+		{name: "state ID mismatch before earlier round commit", localRound: 1, stateIDMismatch: true, step: cstypes.RoundStepPrevote},
+		{name: "invalid commit signature", invalidCommit: "signature", step: cstypes.RoundStepPrevote},
+		{name: "commit with different state ID", invalidCommit: "state_id", step: cstypes.RoundStepPrevote},
+		{name: "commit with different block hash", invalidCommit: "hash", step: cstypes.RoundStepPrevote},
+		{name: "commit with different part set", invalidCommit: "parts", step: cstypes.RoundStepPrevote},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			css := makeConsensusState(ctx, t, configSetup(t), 2, chainID, newTickerFunc())
+			node := css[1]
+			ctx = dash.ContextWithProTxHash(ctx, node.privValidator.ProTxHash)
+			source, stateData := css[0].GetStateData(), node.GetStateData()
+			privVals := []types.PrivValidator{css[0].privValidator.PrivValidator, css[1].privValidator.PrivValidator}
+			block, err := sf.MakeBlock(source.state, 1, &types.Commit{}, kvstore.ProtocolVersion)
+			require.NoError(t, err)
+			block.CoreChainLockedHeight = 1
+			parts, err := block.MakePartSet(types.BlockPartSizeBytes)
+			require.NoError(t, err)
+			commitBlockID := block.BlockID(parts)
+			switch tc.invalidCommit {
+			case "hash", "state_id":
+				commitBlockID = forgeField(t, commitBlockID, tc.invalidCommit)
+			case "parts":
+				commitBlockID.PartSetHeader.Total++
+			}
+			commit, err := factory.MakeCommit(ctx, commitBlockID, block.Height, 0,
+				source.Votes.Precommits(0), source.Validators, privVals)
+			require.NoError(t, err)
+			require.NoError(t, stateData.Validators.VerifyCommit(stateData.state.ChainID,
+				commitBlockID, block.Height, commit))
+			if tc.invalidCommit == "signature" {
+				commit.ThresholdBlockSignature[0] ^= 0xFF
+			}
+			stateData.updateRoundStep(tc.localRound, tc.step)
+			proposer, err := stateData.ProposerSelector.GetProposer(block.Height, tc.localRound)
+			require.NoError(t, err)
+			var proposerKey types.PrivValidator
+			for _, pv := range privVals {
+				id, err := pv.GetProTxHash(ctx)
+				require.NoError(t, err)
+				if id.Equal(proposer.ProTxHash) {
+					proposerKey = pv
+				}
+			}
+			require.NotNil(t, proposerKey)
+			proposal := types.NewProposal(block.Height, block.CoreChainLockedHeight+1,
+				tc.localRound, -1, block.BlockID(parts), block.Time)
+			if tc.stateIDMismatch {
+				proposal.CoreChainLockedHeight = block.CoreChainLockedHeight
+				proposal.BlockID = forgeField(t, block.BlockID(parts), "state_id")
+			}
+			protoProposal := proposal.ToProto()
+			_, err = proposerKey.SignProposal(ctx, stateData.state.ChainID,
+				stateData.Validators.QuorumType, stateData.Validators.QuorumHash, protoProposal)
+			require.NoError(t, err)
+			proposal.Signature = protoProposal.Signature
+			peerID := types.NodeID("peer")
+			deliver := func(msg Message) {
+				t.Helper()
+				require.NoError(t, node.msgDispatcher.dispatch(ctx, &stateData,
+					msgInfo{Msg: msg, PeerID: peerID, ReceiveTime: tmtime.Now()}))
+			}
+			if tc.commitFirst {
+				deliver(&CommitMessage{Commit: commit})
+				require.NotNil(t, stateData.Commit)
+			}
+			deliver(&ProposalMessage{Proposal: proposal})
+			require.NotNil(t, stateData.Proposal, "the signed proposal must enter via its real handler")
+			for i := 0; i < int(parts.Total()); i++ {
+				deliver(&BlockPartMessage{Height: block.Height, Round: tc.localRound, Part: parts.GetPart(i)})
+			}
+			if !tc.commitFirst {
+				require.Nil(t, stateData.Proposal, "the completing part must drop the conflicting metadata")
+				require.True(t, stateData.ProposalBlockParts.IsComplete())
+				require.True(t, stateData.ProposalBlock.BlockID(stateData.ProposalBlockParts).Equals(block.BlockID(parts)))
+				if tc.invalidCommit != "" {
+					deliver(&CommitMessage{Commit: commit})
+					assert.Equal(t, block.Height, stateData.Height)
+					assert.Nil(t, stateData.Commit)
+					assert.True(t, stateData.ProposalBlockParts.IsComplete())
+					assert.True(t, stateData.ProposalBlockParts.HasHeader(parts.Header()))
+					return
+				}
+				deliver(&CommitMessage{Commit: commit})
+			}
+			assert.Equal(t, block.Height+1, stateData.Height,
+				"the valid committed block must be applied regardless of arrival order")
+			assert.True(t, stateData.state.LastBlockID.Equals(commit.BlockID))
+		})
+	}
+}

--- a/internal/consensus/state_data.go
+++ b/internal/consensus/state_data.go
@@ -463,6 +463,11 @@ func (s *StateData) verifyCommit(
 			return false, fmt.Errorf("error verifying commit: %w", err)
 		}
 
+		// A complete block can outlive its proposal; validate it before parking the commit.
+		if !ignoreProposalBlock && s.ProposalBlock != nil && s.ProposalBlockParts.IsComplete() {
+			return true, nil
+		}
+
 		if !s.ProposalBlockParts.HasHeader(commit.BlockID.PartSetHeader) {
 			s.logger.Debug("setting proposal block parts from commit", "partSetHeader", commit.BlockID.PartSetHeader)
 			s.ProposalBlockParts = types.NewPartSetFromHeader(commit.BlockID.PartSetHeader)

--- a/internal/consensus/state_data.go
+++ b/internal/consensus/state_data.go
@@ -463,8 +463,9 @@ func (s *StateData) verifyCommit(
 			return false, fmt.Errorf("error verifying commit: %w", err)
 		}
 
-		// A complete block can outlive its proposal; validate it before parking the commit.
-		if !ignoreProposalBlock && s.ProposalBlock != nil && s.ProposalBlockParts.IsComplete() {
+		// A retained block with matching parts can be validated without its proposal.
+		if !ignoreProposalBlock && s.ProposalBlock != nil && s.ProposalBlockParts.IsComplete() &&
+			s.ProposalBlockParts.HasHeader(commit.BlockID.PartSetHeader) {
 			return true, nil
 		}
 

--- a/internal/consensus/state_try_add_commit.go
+++ b/internal/consensus/state_try_add_commit.go
@@ -8,7 +8,6 @@ import (
 
 	abciclient "github.com/dashpay/tenderdash/abci/client"
 	"github.com/dashpay/tenderdash/dash"
-	cstypes "github.com/dashpay/tenderdash/internal/consensus/types"
 	"github.com/dashpay/tenderdash/libs/log"
 	"github.com/dashpay/tenderdash/types"
 )
@@ -86,11 +85,6 @@ func (cs *TryAddCommitAction) Execute(ctx context.Context, stateEvent StateEvent
 
 	stateData.Commit = commit
 
-	// We need to make sure we are past the Propose step
-	if stateData.Step <= cstypes.RoundStepPropose {
-		// In this case we need to apply the commit after the proposal block comes in
-		return nil
-	}
 	return stateEvent.Ctrl.Dispatch(ctx, &AddCommitEvent{Commit: commit}, stateData)
 }
 


### PR DESCRIPTION
A node now applies a confirmed block it has already downloaded when confirmation arrives after it discarded conflicting proposal metadata.

## User story
As a node operator, I want my node to continue processing confirmed blocks regardless of whether confirmation arrives before or after the block.

## Scenario
A node downloads a block, discards a proposal whose metadata disagrees with it, then receives valid confirmation. It currently stores that confirmation and waits for another block-completion event, even though the block is complete. It should validate and apply the available block immediately.

## Detailed discussion

## Issue being fixed or feature implemented
The release review of `1.7.1-dev.1` identified this recovery gap in the retained-block/dropped-proposal state exercised by #1439 (merged into `v1.7-dev` through #1437). Reproduction covers commits from the current and an earlier round, including arrival during the propose step. This is a local recovery defect; an unconditional network-wide halt has not been demonstrated.

## What was done?
- Let a complete block without proposal metadata proceed through existing commit/block verification after signature verification succeeds.
- Dispatch a fully verified commit immediately, including during the propose step.
- Keep signature, complete BlockID, application processing and block validation checks before application.
- Add dispatcher-level regression and rejection cases, and update the changelog.

## How Has This Been Tested?
- Regression cases failed against the base implementation and passed with the fix.
- Ten scenarios cover both message orders, current/earlier rounds, the propose step, conflicting proposal StateID/CoreChainLockedHeight, invalid signatures and mismatches in all three BlockID fields.
- Go 1.27.1 with native BLS: `go test -mod=readonly -count=1 -timeout=5m -race -p 1 ./internal/consensus/...`.
- Scoped golangci-lint v2.13.2: `run --timeout 10m --new-from-rev=origin/v1.7-dev ./internal/consensus/...` (0 issues).
- Matching Go formatter and `git diff --check`.

## Breaking Changes
None. No wire-format or public API changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
