### PR TITLE
fix(light/proxy)!: require configured WebSocket origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+- Require configured browser origins for light-proxy WebSockets via `rpc.cors-allowed-origins` (including same-host origins); an empty list rejects Origin-bearing requests, while clients without Origin remain supported.
 - Bound stalled block-response cleanup while allowing actively progressing transfers to continue.
 - Authenticate state-sync validator thresholds against locally stored genesis parameters.
 - Reject partially populated validator public-key shares in light blocks.

--- a/cmd/tenderdash/commands/light.go
+++ b/cmd/tenderdash/commands/light.go
@@ -180,6 +180,7 @@ for applications built w/ Cosmos SDK).
 			if err != nil {
 				return err
 			}
+			p.AllowedOrigins = conf.RPC.CORSAllowedOrigins
 
 			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 			defer cancel()

--- a/docs/nodes/configuration.md
+++ b/docs/nodes/configuration.md
@@ -135,6 +135,11 @@ laddr = "tcp://127.0.0.1:26657"
 # Use '["*"]' to allow any origin
 cors-allowed-origins = []
 
+# This list also permits browser WebSocket origins for `tenderdash light <chainID>`.
+# An empty list rejects all requests carrying Origin, including same-host requests.
+# Clients without Origin remain supported. Add explicit browser origins as needed;
+# wildcard matching follows RPC CORS rules, and ["*"] explicitly allows any origin.
+
 # A list of methods the client is allowed to use with cross-domain requests
 cors-allowed-methods = ["HEAD", "GET", "POST", ]
 

--- a/light/proxy/proxy.go
+++ b/light/proxy/proxy.go
@@ -22,6 +22,11 @@ type Proxy struct {
 	Client   *lrpc.Client
 	Logger   log.Logger
 	Listener net.Listener
+
+	// AllowedOrigins permits browser WebSocket origins using RPC CORS matching
+	// rules. Empty rejects every Origin-bearing request; Origin-less clients
+	// are accepted. Set before serving; a "*" entry explicitly allows all origins.
+	AllowedOrigins []string
 }
 
 // NewProxy creates the struct used to run an HTTP server for serving light
@@ -105,13 +110,7 @@ func (p *Proxy) listen(ctx context.Context) (net.Listener, *http.ServeMux, error
 		}),
 		rpcserver.ReadLimit(p.Config.MaxBodyBytes),
 	)
-	// Preserve the light proxy's historic permissive websocket origin policy:
-	// allow every origin. The proxy is configured via rpcserver.Config, which
-	// exposes no CORS allow-list knob, so the WebsocketManager default
-	// (same-host/Origin-less only) would silently reject browser clients that
-	// worked before. Operators that need origin restrictions are expected to
-	// enforce AuthN/AuthZ in front of the proxy.
-	wm.CheckOrigin = func(*http.Request) bool { return true }
+	wm.CheckOrigin = rpcserver.OriginAllowlistChecker(p.Logger, p.AllowedOrigins)
 
 	mux.HandleFunc("/websocket", wm.WebsocketHandler)
 

--- a/light/proxy/proxy_test.go
+++ b/light/proxy/proxy_test.go
@@ -1,0 +1,69 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dashpay/tenderdash/libs/log"
+	lrpc "github.com/dashpay/tenderdash/light/rpc"
+	"github.com/dashpay/tenderdash/rpc/client/mocks"
+	rpcserver "github.com/dashpay/tenderdash/rpc/jsonrpc/server"
+)
+
+func TestProxyWebsocketOrigins(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		origins []string
+		origin  string
+		allowed bool
+	}{
+		{name: "non-browser", allowed: true},
+		{name: "unconfigured browser", origin: "https://app.example"},
+		{name: "configured browser", origins: []string{"https://app.example"}, origin: "https://app.example", allowed: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			next := mocks.NewClient(t)
+			next.On("Start", mock.Anything).Return(nil).Once()
+			next.On("UnsubscribeAll", mock.Anything, mock.Anything).Return(nil).Maybe()
+			logger := log.NewNopLogger()
+			client := lrpc.NewClient(logger, next, nil)
+			p := &Proxy{
+				Addr: "tcp://127.0.0.1:0", Config: rpcserver.DefaultConfig(),
+				Client: client, Logger: logger, AllowedOrigins: tc.origins,
+			}
+			listener, mux, err := p.listen(ctx)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, listener.Close()) })
+			t.Cleanup(client.Stop)
+			server := httptest.NewServer(mux)
+			t.Cleanup(server.Close)
+			headers := http.Header{}
+			if tc.origin != "" {
+				headers.Set("Origin", tc.origin)
+			}
+			dialer := websocket.Dialer{HandshakeTimeout: time.Second}
+			conn, response, err := dialer.Dial("ws"+strings.TrimPrefix(server.URL, "http")+"/websocket", headers)
+			if response != nil {
+				t.Cleanup(func() { require.NoError(t, response.Body.Close()) })
+			}
+			if tc.allowed {
+				require.NoError(t, err)
+				require.NoError(t, conn.Close())
+			} else {
+				require.Error(t, err)
+				require.NotNil(t, response)
+				require.Equal(t, http.StatusForbidden, response.StatusCode)
+			}
+		})
+	}
+}

--- a/rpc/jsonrpc/server/origin_allowlist_test.go
+++ b/rpc/jsonrpc/server/origin_allowlist_test.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dashpay/tenderdash/libs/log"
+)
+
+func TestOriginAllowlistChecker(t *testing.T) {
+	tests := []struct {
+		name    string
+		origins []string
+		origin  string
+		allowed bool
+	}{
+		{name: "non-browser client", allowed: true},
+		{name: "empty list", origin: "https://app.example"},
+		{name: "same host requires configuration", origin: "http://proxy.example"},
+		{name: "configured origin", origins: []string{"https://app.example"}, origin: "https://app.example", allowed: true},
+		{name: "different origin", origins: []string{"https://app.example"}, origin: "https://other.example"},
+		{name: "different scheme", origins: []string{"https://app.example"}, origin: "http://app.example"},
+		{name: "configured pattern", origins: []string{"https://*.example"}, origin: "https://app.example", allowed: true},
+		{name: "explicit allow all", origins: []string{"*"}, origin: "https://app.example", allowed: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "http://proxy.example/websocket", nil)
+			if tc.origin != "" {
+				r.Header.Set("Origin", tc.origin)
+			}
+			require.Equal(t, tc.allowed, OriginAllowlistChecker(log.NewNopLogger(), tc.origins)(r))
+		})
+	}
+}

--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -62,6 +62,17 @@ func NewWebsocketManager(logger log.Logger, funcMap map[string]*RPCFunc, wsConnO
 // (e.g. "http://*.example.com"), mirroring the CORS allow-list semantics.
 // logger is used to warn about unusable allow-list entries at compile time.
 func OriginChecker(logger log.Logger, allowedOrigins []string) func(*http.Request) bool {
+	return originChecker(logger, allowedOrigins, true)
+}
+
+// OriginAllowlistChecker requires Origin-bearing requests to match allowedOrigins,
+// including same-host requests. Origin-less clients are accepted. Matching uses
+// the same case-insensitive exact and wildcard rules as OriginChecker.
+func OriginAllowlistChecker(logger log.Logger, allowedOrigins []string) func(*http.Request) bool {
+	return originChecker(logger, allowedOrigins, false)
+}
+
+func originChecker(logger log.Logger, allowedOrigins []string, allowSameHost bool) func(*http.Request) bool {
 	matchers := compileOriginMatchers(logger, allowedOrigins)
 	return func(r *http.Request) bool {
 		origin := r.Header.Get("Origin")
@@ -72,7 +83,7 @@ func OriginChecker(logger log.Logger, allowedOrigins []string) func(*http.Reques
 		if err != nil {
 			return false
 		}
-		if strings.EqualFold(u.Host, r.Host) {
+		if allowSameHost && strings.EqualFold(u.Host, r.Host) {
 			return true
 		}
 		origin = strings.ToLower(origin)


### PR DESCRIPTION
**TL;DR:** Browser connections to the light proxy now require an explicitly permitted origin. Non-browser clients remain supported.

## User story
As a node operator, I want to choose which websites can connect to my light proxy.

## Scenario
The light proxy currently accepts WebSocket connections from any website. After this change, browser origins must match the configured list, including same-host origins. Clients without an Origin header continue to work.

## Detailed discussion

## Issue being fixed or feature implemented
Extracts the useful WebSocket-origin restriction from closed PR #1382 into a standalone change based on current `v1.8-dev`. PR #1343 introduced the shared origin checker but deliberately retained allow-all behavior for the light proxy. No other open PR covering this fix was found.

## What was done?
- Added an allow-list-only variant of the shared origin checker, reusing existing case-insensitive exact and wildcard matching. The existing checker keeps its same-host behavior for other RPC consumers.
- Applied the strict variant to both light-proxy serving modes and wired `rpc.cors-allowed-origins` through the CLI.
- An empty list rejects Origin-bearing requests, including same-host origins. Origin-less clients remain supported; `*` is an explicit operator opt-in to allow all.
- Added policy tests and local WebSocket integration tests, plus configuration guidance and a 1.8.0 changelog entry.

This change does not provide authentication or authorization. It changes no light-client witness policy or consensus threshold behavior.

## How Has This Been Tested?
- `make test PACKAGES='./rpc/jsonrpc/server ./light/proxy ./cmd/tenderdash/commands'`: passed, with CGO and `-tags deadlock` as supplied by the Makefile.
- `make lint LINT_BASE=origin/v1.8-dev`: passed, zero issues.
- `gofmt` and `git diff --check`: passed.
- Local validation used existing native BLS libraries via `BLS_DIR=/home/ubuntu/git/tenderdash/third_party/bls-signatures` and a writable Go build cache. Full logs are retained locally.

## Breaking Changes
Browser WebSocket clients must configure their origin in `rpc.cors-allowed-origins`, including browsers served from the proxy host. Applications constructing `Proxy` directly can set `AllowedOrigins` before serving. An explicit `*` restores the previous allow-all policy but removes the origin restriction. Origin-less clients are unaffected.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
