### PR TITLE
test(consensus): freeze clocks in vote rate burst tests

### DIFF
--- a/internal/consensus/vote_rate_limit_test.go
+++ b/internal/consensus/vote_rate_limit_test.go
@@ -49,7 +49,7 @@ func TestAllowVoteChannelMessage_DropsFloodFromSinglePeer(t *testing.T) {
 	defer cancel()
 
 	const limit = 5.0
-	r := newRateLimitedReactor(ctx, limit)
+	r := newRateLimitedReactor(ctx, limit, client.WithRateLimitClock(clockwork.NewFakeClock()))
 
 	// More than the bucket can ever hold, so the flood must run into the limit
 	// whatever the peer sends.
@@ -64,7 +64,7 @@ func TestAllowVoteChannelMessage_DropsFloodFromSinglePeer(t *testing.T) {
 	}
 
 	assert.Positive(t, dropped, "a burst well above the budget must have messages dropped")
-	assert.LessOrEqual(t, allowed, voteRateBurst+1,
+	assert.Equal(t, voteRateBurst, allowed,
 		"allowed count is bounded by the burst, not the flood size")
 	assert.Equal(t, n, allowed+dropped)
 }
@@ -75,7 +75,7 @@ func TestAllowVoteChannelMessage_PerPeerIndependent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	r := newRateLimitedReactor(ctx, 5)
+	r := newRateLimitedReactor(ctx, 5, client.WithRateLimitClock(clockwork.NewFakeClock()))
 
 	// Exhaust the attacker's budget.
 	for i := 0; i < 2*voteRateBurst; i++ {
@@ -112,7 +112,8 @@ func TestAllowVoteChannelMessage_ChargesVerificationCost(t *testing.T) {
 	defer cancel()
 
 	admitted := func(env *p2p.Envelope) int {
-		r := newRateLimitedReactor(ctx, 600)
+		// Freeze time so the initial budget cannot refill while the loop runs.
+		r := newRateLimitedReactor(ctx, 600, client.WithRateLimitClock(clockwork.NewFakeClock()))
 		allowed := 0
 		for i := 0; i < 5000; i++ {
 			if r.allowVoteChannelMessage(ctx, env) {
@@ -130,7 +131,8 @@ func TestAllowVoteChannelMessage_ChargesVerificationCost(t *testing.T) {
 
 	// The bucket starts full, so an instantaneous flood admits at most
 	// burst/cost messages of that cost.
-	assert.LessOrEqual(t, precommits, voteRateBurst/maxPeerMessageCost+1,
+	assert.Equal(t, voteRateBurst, prevotes)
+	assert.Equal(t, voteRateBurst/maxPeerMessageCost, precommits,
 		"maximum-cost precommits admitted must be bounded by burst/cost")
 }
 
@@ -141,7 +143,7 @@ func TestAllowVoteChannelMessage_CostSharesOneBudget(t *testing.T) {
 	defer cancel()
 
 	const limit = 600.0
-	r := newRateLimitedReactor(ctx, limit)
+	r := newRateLimitedReactor(ctx, limit, client.WithRateLimitClock(clockwork.NewFakeClock()))
 
 	// Drain the bucket with maximum-cost precommits.
 	for i := 0; i < voteRateBurst/maxPeerMessageCost; i++ {


### PR DESCRIPTION
Fix intermittent CI failures caused by vote-rate tests refilling their budgets while they run.

## Issue being fixed or feature implemented
PR #1415 failed in [tests (01)](https://github.com/dashpay/tenderdash/actions/runs/34449409001/job/102781454634): `TestAllowVoteChannelMessage_ChargesVerificationCost` admitted 8 maximum-cost precommits against an upper bound of 7. The unchanged test also exists on `v1.8-dev`; none of the other open PRs fixes it.

## What was done?
Inject the existing fake clock into four tests that assume a fixed initial budget. Assert exact initial admission counts for prevotes and maximum-cost precommits. Production behavior is unchanged.

## How Has This Been Tested?
- Reproduced the failure with a temporary 200 ms pause in the admission loop: 9 precommits admitted against the old bound of 7.
- With the fake clock, the same delayed experiment passes. The diagnostic pause is not included in this PR.
- `go test -mod=readonly -race -cover ./internal/consensus -run '^(TestAllowVoteChannelMessage_|TestVoteRateBurst)' -count=100` passes (Go 1.27.1).
- golangci-lint v2.13.2 against the base revision, scoped to consensus: 0 issues.
- gofmt and git diff --check pass.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation (test-only change)

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
