### PR TITLE
test(consensus): deflake TestWALRoundsSkipper

### DIFF
--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1396,7 +1397,36 @@ func TestHandshakeInitialCoreLockHeight(t *testing.T) {
 	assert.Equal(t, InitialCoreHeight, state.LastCoreChainLockedBlockHeight)
 }
 
+// walRoundsSkipperProposeTimeout replaces the test genesis' 30ms propose
+// timeout on the node that generates the WAL for testWALRoundsSkipper. That
+// node is the only validator, so it proposes every round and its propose
+// timeout can only race its own proposal: there is no absent proposer to wait
+// out, and a round moves on as soon as the proposal is complete. At 30ms a
+// loaded machine lets the timeout win round maxRound, which heights 3 to
+// chainLen have to commit in. The override is node-local, not a consensus
+// parameter, so no block changes.
+const walRoundsSkipperProposeTimeout = 10 * time.Second
+
 func TestWALRoundsSkipper(t *testing.T) {
+	testWALRoundsSkipper(t, false)
+}
+
+// TestWALRoundsSkipperSlowProposer delays the node's own proposal at round
+// maxRound past the propose timeout the test genesis sets for that round, as a
+// loaded CI runner does. The WAL generator must still commit every height at
+// round maxRound.
+func TestWALRoundsSkipperSlowProposer(t *testing.T) {
+	testWALRoundsSkipper(t, true)
+}
+
+// testWALRoundsSkipper generates a WAL in which heights 3 to chainLen prevote
+// nil for rounds 0 to maxRound-1 and commit at round maxRound, then checks that
+// a node replaying it with WalSkipRoundsToLast carries on to the next height.
+// With slowProposer, the generating node's PrepareProposal at round maxRound
+// outlasts the test genesis' propose timeout.
+func testWALRoundsSkipper(t *testing.T, slowProposer bool) {
+	// first, so that it is muted only after every later cleanup has run
+	logger := newTeardownSafeLogger(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	const (
@@ -1405,7 +1435,7 @@ func TestWALRoundsSkipper(t *testing.T) {
 	)
 	cfg := getConfig(t)
 	cfg.Consensus.WalSkipRoundsToLast = true
-	logger := log.NewTestingLogger(t)
+	cfg.Consensus.UnsafeProposeTimeoutOverride = walRoundsSkipperProposeTimeout
 	ng := nodeGen{
 		cfg:    cfg,
 		logger: logger,
@@ -1413,6 +1443,9 @@ func TestWALRoundsSkipper(t *testing.T) {
 			stopConsensusAtHeight(chainLen+1, 0),
 			stopConsensusAtHeight(chainLen, maxRound+1),
 		)},
+	}
+	if slowProposer {
+		ng.app = newSlowProposerApp(t, cfg, maxRound)
 	}
 	node := ng.Generate(ctx, t)
 	withReplayPrevoter(node.csState)
@@ -1462,7 +1495,7 @@ func TestWALRoundsSkipper(t *testing.T) {
 	require.NoError(t, err)
 	ctx = dash.ContextWithProTxHash(ctx, proTxHash)
 
-	cs := newStateWithConfigAndBlockStore(ctx, t, log.NewTestingLogger(t), cfg, state, privVal, app, blockStore)
+	cs := newStateWithConfigAndBlockStore(ctx, t, logger, cfg, state, privVal, app, blockStore)
 
 	commit := blockStore.commits[len(blockStore.commits)-1]
 	require.Equal(t, int64(4), commit.Height)
@@ -1531,6 +1564,91 @@ func newBlockReplayer(
 		NewReplayBlockExecutor(proxyApp, stateStore, blockStore, eventBus),
 		ReplayerWithProTxHash(proTxHash),
 	)
+}
+
+// slowProposerApp is a kvstore application whose PrepareProposal takes delay
+// longer at round, so a node proposing at that round completes its proposal
+// only after delay has passed.
+type slowProposerApp struct {
+	*kvstore.Application
+	round int32
+	delay time.Duration
+}
+
+// newSlowProposerApp returns a slowProposerApp whose delay at round is three
+// times the propose timeout cfg's genesis sets for round, yet still well below
+// walRoundsSkipperProposeTimeout.
+func newSlowProposerApp(t *testing.T, cfg *config.Config, round int32) *slowProposerApp {
+	t.Helper()
+	genDoc, err := types.GenesisDocFromFile(cfg.GenesisFile())
+	require.NoError(t, err)
+	require.NotNil(t, genDoc.ConsensusParams, "test genesis sets no consensus params")
+	delay := 3 * genDoc.ConsensusParams.Timeout.TimeoutParamsOrDefaults().ProposeTimeout(round)
+	require.Less(t, delay, walRoundsSkipperProposeTimeout/10,
+		"the delay must stay far below the propose timeout override")
+
+	app, err := kvstore.NewMemoryApp()
+	require.NoError(t, err)
+	return &slowProposerApp{Application: app, round: round, delay: delay}
+}
+
+func (app *slowProposerApp) PrepareProposal(
+	ctx context.Context,
+	req *abci.RequestPrepareProposal,
+) (*abci.ResponsePrepareProposal, error) {
+	if req.Round == app.round {
+		select {
+		case <-time.After(app.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return app.Application.PrepareProposal(ctx, req)
+}
+
+// teardownSafeLogWriter writes to t's log until it is muted and discards
+// everything after. A consensus State outlives its test: Stop and Wait return
+// without waiting for its receiveRoutine, which exits only once it notices its
+// context is done, nor for the goroutines that stop its WAL and other services
+// on that context. Any of them logging after t has completed panics the whole
+// test binary.
+type teardownSafeLogWriter struct {
+	mtx   sync.Mutex // held across t.Log, so muting waits out a write in flight
+	t     testing.TB
+	muted bool
+}
+
+func (w *teardownSafeLogWriter) Write(p []byte) (int, error) {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+	if !w.muted {
+		w.t.Log(string(p))
+	}
+	return len(p), nil
+}
+
+func (w *teardownSafeLogWriter) mute() {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+	w.muted = true
+}
+
+// newTeardownSafeLogger returns a logger at NewTestingLogger's level that
+// writes through a teardownSafeLogWriter muted by a cleanup of t. Cleanups run
+// last-in first-out, so create it before anything else registers one: the
+// writer is then muted only after every other cleanup has run, and nothing is
+// logged once t has completed.
+func newTeardownSafeLogger(t *testing.T) log.Logger {
+	t.Helper()
+	w := &teardownSafeLogWriter{t: t}
+	t.Cleanup(w.mute)
+	level := log.LogLevelError
+	if testing.Verbose() {
+		level = log.LogLevelDebug
+	}
+	logger, err := log.NewLogger(level, w)
+	require.NoError(t, err)
+	return logger
 }
 
 type replayPrevoter struct {


### PR DESCRIPTION
## Issue being fixed or feature implemented

`TestWALRoundsSkipper` (`internal/consensus`) is a pre-existing timing flake, independent of any other in-flight change. It has caused unrelated CI failures on at least #1391, #1393 and #1410.

The WAL-generating node is the sole validator in this test, so it proposes every round, and `replayPrevoter` forces nil votes until round 10 — heights 3-5 can only commit at round 10. The test's genesis gives round 10 only a 30.5ms propose timeout. Under CPU contention (as on a shared CI runner, especially with `-race`), that timer can fire before the node finishes building its own proposal, so it prevotes nil and the round advances to 11:
- at height 5, `stopConsensusAtHeight(5, 11)` then halts consensus and the test times out after 60s waiting for 5 blocks — the exact signature seen in CI;
- at heights 3-4, the commit lands past `maxRound` and a replay-order assertion fails instead.

## What was done?

`internal/consensus/replay_test.go` only, test-only change, no production code touched:

1. **Propose-timeout override.** `UnsafeProposeTimeoutOverride = 10s` on the WAL generator node. This is a node-local setting (not a consensus parameter, not part of `ConsensusHash`), so it does not change blocks, the WAL, or replay behavior — it only removes the race between the timer and the node's own (single-proposer) proposal.
2. **A second, pre-existing flake this exposed.** Once the test reliably survives past round 10 under load, the replaying `State` and its WAL keep logging asynchronously (their context-cancellation watchers) slightly after the test itself returns, which used to panic the test binary (`panic: Log in goroutine after TestWALRoundsSkipper has completed`). Fixed with a small mutex-guarded logger wrapper that is muted by the test's first-registered cleanup (which runs last, LIFO), closing the check-then-log gap.
3. **New regression test**, `TestWALRoundsSkipperSlowProposer`: its app deliberately holds `PrepareProposal` at round 10 for 3x the genesis propose timeout, reproducing the CI failure mode on demand.

## How Has This Been Tested?

- Root cause reproduced locally with `-v`, matching CI's exact failure signature (same "prevoted for nil" sequence, same height/round).
- Confirmed not a regression from any other change: A/B between two branches under identical load gave statistically equal failure rates (e.g. 25/30 vs 27/30 failures at 1 CPU).
- `TestWALRoundsSkipperSlowProposer`: 12/12 FAIL (60s timeout) with the override reverted, 12/12 PASS with it in place.
- Harsh A/B of `TestWALRoundsSkipper` itself (10 runs/side, 1 CPU, 3 rounds) on the final code: 30/30 PASS with the fix, 4/30 PASS without.
- Full, unfiltered `go test -mod=readonly -timeout=5m -race ./internal/consensus/...` on this branch (based on `v1.8-dev`): `ok`, 102.8s, exit 0.
- `make lint`: 0 new issues vs `origin/v1.8-dev`. `gofmt` clean. `go vet` clean.

## Breaking Changes

None. Test-only change.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
